### PR TITLE
add override for constructor (Werror breaks clang visual studio 2019 …

### DIFF
--- a/Jolt/Physics/Collision/Shape/MutableCompoundShape.h
+++ b/Jolt/Physics/Collision/Shape/MutableCompoundShape.h
@@ -32,7 +32,7 @@ public:
 	/// Constructor
 									MutableCompoundShape() : CompoundShape(EShapeSubType::MutableCompound) { }
 									MutableCompoundShape(const MutableCompoundShapeSettings &inSettings, ShapeResult &outResult);
-	virtual							~MutableCompoundShape();
+	virtual							~MutableCompoundShape() override;
 		
 	// See Shape::CastRay
 	virtual bool					CastRay(const RayCast &inRay, const SubShapeIDCreator &inSubShapeIDCreator, RayCastResult &ioHit) const override;


### PR DESCRIPTION
…build)

thanks for sharing JoltPhysics, well engineered!