### PR TITLE
Broadphase fixes

### DIFF
--- a/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
@@ -47,7 +47,7 @@ public:
 	virtual	UpdateState	UpdatePrepare()														{ return UpdateState(); }
 
 	/// Finalizing the update will quickly apply the changes
-	virtual void		UpdateFinalize(UpdateState &inUpdateState)							{ /* Optionally overridden by implementation */ }
+	virtual void		UpdateFinalize(const UpdateState &inUpdateState)					{ /* Optionally overridden by implementation */ }
 
 	/// Must be called after UpdateFinalize to allow modifications to the broadphase
 	virtual void		UnlockModifications()												{ /* Optionally overridden by implementation */ }

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.cpp
@@ -125,13 +125,13 @@ BroadPhase::UpdateState BroadPhaseQuadTree::UpdatePrepare()
 	return update_state;
 }
 
-void BroadPhaseQuadTree::UpdateFinalize(UpdateState &inUpdateState)
+void BroadPhaseQuadTree::UpdateFinalize(const UpdateState &inUpdateState)
 {
 	// LockModifications should have been called
 	JPH_ASSERT(mUpdateMutex.is_locked());
 
 	// Test if a tree was updated
-	UpdateStateImpl *update_state_impl = reinterpret_cast<UpdateStateImpl *>(&inUpdateState);
+	const UpdateStateImpl *update_state_impl = reinterpret_cast<const UpdateStateImpl *>(&inUpdateState);
 	if (update_state_impl->mTree == nullptr)
 		return;
 

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.h
@@ -21,7 +21,7 @@ public:
 	virtual void			FrameSync() override;
 	virtual void			LockModifications() override;
 	virtual	UpdateState		UpdatePrepare() override;
-	virtual void			UpdateFinalize(UpdateState &inUpdateState) override;
+	virtual void			UpdateFinalize(const UpdateState &inUpdateState) override;
 	virtual void			UnlockModifications() override;
 	virtual AddState		AddBodiesPrepare(BodyID *ioBodies, int inNumber) override;
 	virtual void			AddBodiesFinalize(BodyID *ioBodies, int inNumber, AddState inAddState) override;

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -333,7 +333,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 	outUpdateState.mRootNodeID = root_node_id;
 }
 
-void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[maybe_unused]] TrackingVector &ioTracking, const UpdateState &inUpdateState)
+void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[maybe_unused]] const TrackingVector &inTracking, const UpdateState &inUpdateState)
 {
 	// Tree building is complete, now we switch the old with the new tree
 	uint32 new_root_idx = mRootNodeIndex ^ 1;
@@ -350,7 +350,7 @@ void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[may
 	mRootNodeIndex = new_root_idx;
 
 #ifdef _DEBUG
-	ValidateTree(inBodies, ioTracking, new_root_node.mIndex, mNumBodies);
+	ValidateTree(inBodies, inTracking, new_root_node.mIndex, mNumBodies);
 #endif
 }
 

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -238,8 +238,8 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 #endif
 
 	// Create space for all body ID's
-	outUpdateState.mAllNodeIDs = new NodeID [mNumBodies];
-	NodeID *cur_node_id = outUpdateState.mAllNodeIDs;
+	NodeID *node_ids = new NodeID [mNumBodies];
+	NodeID *cur_node_id = node_ids;
 
 	// Collect all bodies
 	NodeID node_stack[cStackSize];
@@ -297,7 +297,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 	while (top >= 0);
 
 	// Check that our book keeping matches
-	uint32 num_node_ids = uint32(cur_node_id - outUpdateState.mAllNodeIDs);
+	uint32 num_node_ids = uint32(cur_node_id - node_ids);
 	JPH_ASSERT(num_node_ids <= mNumBodies);
 
 	// This will be the new root node id
@@ -307,7 +307,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 	{
 		// Build new tree
 		AABox root_bounds;
-		root_node_id = BuildTree(inBodies, ioTracking, outUpdateState.mAllNodeIDs, num_node_ids, root_bounds);
+		root_node_id = BuildTree(inBodies, ioTracking, node_ids, num_node_ids, root_bounds);
 
 		if (root_node_id.IsBody())
 		{
@@ -327,6 +327,9 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 		root_node_id = NodeID::sFromNodeIndex(root_idx);
 	}
 
+	// Delete temporary data
+	delete [] node_ids;
+
 	outUpdateState.mRootNodeID = root_node_id;
 }
 
@@ -345,9 +348,6 @@ void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[may
 
 	// All queries that start from now on will use this new tree
 	mRootNodeIndex = new_root_idx;
-
-	// Delete temporary data
-	delete [] inUpdateState.mAllNodeIDs;
 
 #ifdef _DEBUG
 	ValidateTree(inBodies, ioTracking, new_root_node.mIndex, mNumBodies);

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -307,7 +307,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 	{
 		// Build new tree
 		AABox root_bounds;
-		root_node_id = BuildTree(inBodies, ioTracking, outUpdateState.mAllNodeIDs, num_node_ids, cInvalidNodeIndex, root_bounds);
+		root_node_id = BuildTree(inBodies, ioTracking, outUpdateState.mAllNodeIDs, num_node_ids, root_bounds);
 
 		if (root_node_id.IsBody())
 		{
@@ -454,7 +454,7 @@ AABox QuadTree::GetNodeOrBodyBounds(const BodyVector &inBodies, NodeID inNodeID)
 	}
 }
 
-QuadTree::NodeID QuadTree::BuildTree(const BodyVector &inBodies, TrackingVector &ioTracking, NodeID *ioNodeIDs, int inNumber, uint32 inParentNodeIndex, AABox &outBounds)
+QuadTree::NodeID QuadTree::BuildTree(const BodyVector &inBodies, TrackingVector &ioTracking, NodeID *ioNodeIDs, int inNumber, AABox &outBounds)
 {
 	// Trivial case: No bodies in tree
 	if (inNumber == 0)
@@ -764,7 +764,7 @@ void QuadTree::AddBodiesPrepare(const BodyVector &inBodies, TrackingVector &ioTr
 #endif
 
 	// Build subtree for the new bodies
-	outState.mLeafID = BuildTree(inBodies, ioTracking, (NodeID *)ioBodyIDs, inNumber, cInvalidNodeIndex, outState.mLeafBounds);
+	outState.mLeafID = BuildTree(inBodies, ioTracking, (NodeID *)ioBodyIDs, inNumber, outState.mLeafBounds);
 
 #ifdef _DEBUG
 	if (outState.mLeafID.IsNode())

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -333,7 +333,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 	outUpdateState.mRootNodeID = root_node_id;
 }
 
-void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[maybe_unused]] TrackingVector &ioTracking, UpdateState &inUpdateState)
+void QuadTree::UpdateFinalize([[maybe_unused]] const BodyVector &inBodies, [[maybe_unused]] TrackingVector &ioTracking, const UpdateState &inUpdateState)
 {
 	// Tree building is complete, now we switch the old with the new tree
 	uint32 new_root_idx = mRootNodeIndex ^ 1;

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.h
@@ -196,7 +196,7 @@ public:
 	/// Update the broadphase, needs to be called regularly to achieve a tight fit of the tree when bodies have been modified.
 	/// UpdatePrepare() will build the tree, UpdateFinalize() will lock the root of the tree shortly and swap the trees and afterwards clean up temporary data structures.
 	void						UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTracking, UpdateState &outUpdateState);
-	void						UpdateFinalize(const BodyVector &inBodies, TrackingVector &ioTracking, const UpdateState &inUpdateState);
+	void						UpdateFinalize(const BodyVector &inBodies, const TrackingVector &inTracking, const UpdateState &inUpdateState);
 
 	/// Temporary data structure to pass information between AddBodiesPrepare and AddBodiesFinalize/Abort
 	struct AddState

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.h
@@ -187,7 +187,6 @@ public:
 
 	struct UpdateState
 	{
-		NodeID *				mAllNodeIDs;						///< Temporary storage for all leaf node ID's in the tree that must be grouped into a new tree
 		NodeID					mRootNodeID;						///< This will be the new root node id
 	};
 

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.h
@@ -196,7 +196,7 @@ public:
 	/// Update the broadphase, needs to be called regularly to achieve a tight fit of the tree when bodies have been modified.
 	/// UpdatePrepare() will build the tree, UpdateFinalize() will lock the root of the tree shortly and swap the trees and afterwards clean up temporary data structures.
 	void						UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTracking, UpdateState &outUpdateState);
-	void						UpdateFinalize(const BodyVector &inBodies, TrackingVector &ioTracking, UpdateState &inUpdateState);
+	void						UpdateFinalize(const BodyVector &inBodies, TrackingVector &ioTracking, const UpdateState &inUpdateState);
 
 	/// Temporary data structure to pass information between AddBodiesPrepare and AddBodiesFinalize/Abort
 	struct AddState

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.h
@@ -295,7 +295,7 @@ private:
 	inline bool					TryCreateNewRoot(TrackingVector &ioTracking, atomic<uint32> &ioRootNodeIndex, NodeID inLeafID, const AABox &inLeafBounds, int inLeafNumBodies);
 
 	/// Build a tree for ioBodyIDs, returns the NodeID of the root (which will be the ID of a single body if inNumber = 1)
-	NodeID						BuildTree(const BodyVector &inBodies, TrackingVector &ioTracking, NodeID *ioNodeIDs, int inNumber, uint32 inParentNodeIndex, AABox &outBounds);
+	NodeID						BuildTree(const BodyVector &inBodies, TrackingVector &ioTracking, NodeID *ioNodeIDs, int inNumber, AABox &outBounds);
 
 	/// Sorts ioNodeIDs spatially into 2 groups. Second groups starts at ioNodeIDs + outMidPoint.
 	/// After the function returns ioNodeIDs and ioNodeCenters will be shuffled

--- a/Jolt/Physics/Collision/Shape/ConvexShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ConvexShape.cpp
@@ -67,7 +67,13 @@ void ConvexShape::sCollideConvexVsConvex(const Shape *inShape1, const Shape *inS
 	// Note: As we don't remember the penetration axis from the last iteration, and it is likely that shape2 is pushed out of
 	// collision relative to shape1 by comparing their COM's, we use that as an initial penetration axis: shape2.com - shape1.com
 	// This has been seen to improve performance by approx. 1% over using a fixed axis like (1, 0, 0).
-	Vec3 penetration_axis = transform_2_to_1.GetTranslation(), point1, point2;
+	Vec3 penetration_axis = transform_2_to_1.GetTranslation();
+
+	// Ensure that we do not pass in a near zero penetration axis
+	if (penetration_axis.IsNearZero())
+		penetration_axis = Vec3::sAxisX();
+
+	Vec3 point1, point2;
 	EPAPenetrationDepth pen_depth;
 	EPAPenetrationDepth::EStatus status;
 

--- a/Samples/Utils/ContactListenerImpl.cpp
+++ b/Samples/Utils/ContactListenerImpl.cpp
@@ -9,8 +9,8 @@
 
 ValidateResult ContactListenerImpl::OnContactValidate(const Body &inBody1, const Body &inBody2, const CollideShapeResult &inCollisionResult)
 {
-	// Expect body 1 to be dynamic
-	if (!inBody1.IsDynamic())
+	// Expect body 1 to be dynamic (or one of the bodies must be a sensor)
+	if (!inBody1.IsDynamic() && !inBody1.IsSensor() && !inBody2.IsSensor())
 		JPH_BREAKPOINT;
 
 	ValidateResult result;


### PR DESCRIPTION
- Changed 'is locked' flag to 'is changed' flag
- Fixed bug where TryInsertLeaf would never find a leaf
- Fixed race condition where bounds of root could be too small after TryCreateNewRoot
- Reduced lifetime of temporary allocation

Other fixes:
- Fixed issue where penetration axis passed to GJK could be zero
- Fixed issue in a contact listener that would cause a breakpoint for a valid situation