### PR TITLE
Fix compile error when lzcnt isn't enabled

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -14,8 +14,10 @@
 	#define JPH_PLATFORM_LINUX
 #endif
 
-// Turn off warnings
+// Determine compiler and turn off warnings
 #if defined(__clang__)
+	#define JPH_COMPILER_CLANG
+
 	#pragma clang diagnostic ignored "-Wc++98-compat"
 	#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
 	#pragma clang diagnostic ignored "-Wfloat-equal"
@@ -40,6 +42,8 @@
 		#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 	#endif
 #elif defined(_MSC_VER)
+	#define JPH_COMPILER_MSVC
+
 	#pragma warning (disable : 4514) // 'X' : unreferenced inline function has been removed
 	#pragma warning (disable : 4710) // 'X' : function not inlined
 	#pragma warning (disable : 4711) // function 'X' selected for automatic inline expansion

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -94,14 +94,18 @@ inline bool IsAligned(T inV, uint64 inAlignment)
 inline uint CountTrailingZeros(uint32 inValue)
 {
 #if defined(JPH_CPU_X64)
-	#ifdef JPH_USE_LZCNT
+	#if defined(JPH_USE_LZCNT)
 		return _tzcnt_u32(inValue);
-	#else
+	#elif defined(JPH_COMPILER_MSVC)
 		if (inValue == 0)
 			return 32;
 		unsigned long result;
 		_BitScanForward(&result, inValue);
 		return result;
+	#else
+		if (inValue == 0)
+			return 32;
+		return __builtin_clz(__builtin_bitreverse32(inValue));
 	#endif
 #elif defined(JPH_CPU_ARM64)
 	return __builtin_clz(__builtin_bitreverse32(inValue));
@@ -114,14 +118,18 @@ inline uint CountTrailingZeros(uint32 inValue)
 inline uint CountLeadingZeros(uint32 inValue)
 {
 #if defined(JPH_CPU_X64)
-	#ifdef JPH_USE_LZCNT
+	#if defined(JPH_USE_LZCNT)
 		return _lzcnt_u32(inValue);
-	#else
+	#elif defined(JPH_COMPILER_MSVC)
 		if (inValue == 0)
 			return 32;
 		unsigned long result;
 		_BitScanReverse(&result, inValue);
 		return 31 - result;
+	#else
+		if (inValue == 0)
+			return 32;
+		return __builtin_clz(inValue);
 	#endif
 #elif defined(JPH_CPU_ARM64)
 	return __builtin_clz(inValue);


### PR DESCRIPTION
It seems _BitScanForward and _BitScanReverse are available only in Visual Studio.