### PR TITLE
Add GetCenterOfMassTransform to BodyInterface

### DIFF
--- a/Jolt/Physics/Body/BodyInterface.cpp
+++ b/Jolt/Physics/Body/BodyInterface.cpp
@@ -405,6 +405,15 @@ Mat44 BodyInterface::GetWorldTransform(const BodyID &inBodyID) const
 		return Mat44::sIdentity();
 }
 
+Mat44 BodyInterface::GetCenterOfMassTransform(const BodyID &inBodyID) const
+{
+	BodyLockRead lock(*mBodyLockInterface, inBodyID);
+	if (lock.Succeeded())
+		return lock.GetBody().GetCenterOfMassTransform();
+	else
+		return Mat44::sIdentity();
+}
+
 void BodyInterface::MoveKinematic(const BodyID &inBodyID, Vec3Arg inTargetPosition, QuatArg inTargetRotation, float inDeltaTime)
 {
 	BodyLockWrite lock(*mBodyLockInterface, inBodyID);

--- a/Jolt/Physics/Body/BodyInterface.h
+++ b/Jolt/Physics/Body/BodyInterface.h
@@ -116,6 +116,7 @@ public:
 	void						SetRotation(const BodyID &inBodyID, QuatArg inRotation, EActivation inActivationMode);
 	Quat						GetRotation(const BodyID &inBodyID) const;
 	Mat44						GetWorldTransform(const BodyID &inBodyID) const;
+	Mat44						GetCenterOfMassTransform(const BodyID &inBodyID) const;
 	///@}
 
 	/// Set velocity of body such that it will be positioned at inTargetPosition/Rotation in inDeltaTime seconds (will activate body if needed)


### PR DESCRIPTION
This is useful for avoiding having to do the the rotation * pShape->GetCenterOfMass() on the other side, which is just inverting work GetWorldTransform is doing as it calls GetPosition and doesn't use mPosition directly.