### PR TITLE
CMake FetchContent Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(Jolt)
+set(PHYSICS_REPO_ROOT ${PROJECT_SOURCE_DIR})
+set(CMAKE_CXX_STANDARD 17)
+include(Jolt/Jolt.cmake)


### PR DESCRIPTION
This adds a minimal CMake `CMakeLists.txt` so that Jolt Physics can be used nicely with CMake FetchContent.

Here is an example how one would use CMake FetchContent:

```
include(FetchContent)
FetchContent_Declare(
    JoltPhysics
    GIT_REPOSITORY  https://github.com/jrouwe/JoltPhysics.git
    GIT_TAG         master
    GIT_SHALLOW     TRUE
    GIT_PROGRESS    TRUE
)
FetchContent_MakeAvailable(JoltPhysics)
```