### PR TITLE
Add a helper to manually invalidate contact cache

### DIFF
--- a/Jolt/Physics/Body/BodyInterface.cpp
+++ b/Jolt/Physics/Body/BodyInterface.cpp
@@ -811,4 +811,11 @@ const PhysicsMaterial *BodyInterface::GetMaterial(const BodyID &inBodyID, const 
 		return PhysicsMaterial::sDefault;
 }
 
+void BodyInterface::InvalidateContactCache(const BodyID &inBodyID)
+{
+	BodyLockWrite lock(*mBodyLockInterface, inBodyID);
+	if (lock.Succeeded())
+		mBodyManager->InvalidateContactCacheForBody(lock.GetBody());
+}
+
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Body/BodyInterface.h
+++ b/Jolt/Physics/Body/BodyInterface.h
@@ -186,6 +186,8 @@ public:
 	/// Get the material for a particular sub shape
 	const PhysicsMaterial *		GetMaterial(const BodyID &inBodyID, const SubShapeID &inSubShapeID) const;
 
+	void						InvalidateContactCache(const BodyID &inBodyID);
+
 private:
 	BodyLockInterface *			mBodyLockInterface = nullptr;
 	BodyManager *				mBodyManager = nullptr;


### PR DESCRIPTION
In our game, sometimes an object can be forced up against a wall by a force and then a hole is cut into the wall it is on, and it doesn't update as it still thinks its it's making contact, even when forcing an Activate, etc.

We know this ahead of time so we can manually invalidate the contact cache for the object that was touching.