### PR TITLE
Add TrackContactsForThisBodyPair to ValidateResult

### DIFF
--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -163,17 +163,17 @@ public:
 		return ValidateResult::AcceptAllContactsForThisBodyPair;
 	}
 
-	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override
+	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override
 	{
 		cout << "A contact was added" << endl;
 	}
 
-	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override
+	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override
 	{
 		cout << "A contact was persisted" << endl;
 	}
 
-	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair) override
+	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly) override
 	{ 
 		cout << "A contact was removed" << endl;
 	}

--- a/Jolt/Physics/Collision/ContactListener.h
+++ b/Jolt/Physics/Collision/ContactListener.h
@@ -45,7 +45,9 @@ enum class ValidateResult
 	AcceptAllContactsForThisBodyPair,							///< Accept this and any further contact points for this body pair
 	AcceptContact,												///< Accept this contact only (and continue calling this callback for every contact manifold for the same body pair)
 	RejectContact,												///< Reject this contact only (but process any other contact manifolds for the same body pair)
-	RejectAllContactsForThisBodyPair							///< Rejects this and any further contact points for this body pair
+	RejectAllContactsForThisBodyPair,							///< Rejects this and any further contact points for this body pair
+
+	TrackContactsForThisBodyPair,								///< Rejects all for this body pair, but tracks contacts and calls OnContactAdded. Essentially treats the pair as a 'sensor' interaction.
 };
 
 /// A listener class that receives collision contact events events.
@@ -74,18 +76,18 @@ public:
 	/// When contacts are added, the constraint solver has not run yet, so the collision impulse is unknown at that point.
 	/// The velocities of inBody1 and inBody2 are the velocities before the contact has been resolved, so you can use this to
 	/// estimate the collision impulse to e.g. determine the volume of the impact sound to play.
-	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) { /* Do nothing */ }
+	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) { /* Do nothing */ }
 
 	/// Called whenever a contact is detected that was also detected last update.
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
 	/// Body 1 and 2 will be sorted such that body 1 ID < body 2 ID, so body 1 may not be dynamic.
-	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) { /* Do nothing */ }
+	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) { /* Do nothing */ }
 
 	/// Called whenever a contact was detected last update but is not detected anymore.
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
 	/// Note that we're using BodyID's since the bodies may have been removed at the time of callback.
 	/// Body 1 and 2 will be sorted such that body 1 ID < body 2 ID, so body 1 may not be dynamic.
-	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair) { /* Do nothing */ }
+	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly) { /* Do nothing */ }
 };
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -133,7 +133,7 @@ public:
 	/// r1, r2 = contact point relative to center of mass of body 1 and body 2 (r1 = p1 - x1, r2 = p2 - x2).
 	/// v1, v2 = (linear velocity, angular velocity): 6 vectors containing linear and angular velocity for body 1 and 2.
 	/// M = mass matrix, a diagonal matrix of the mass and inertia with diagonal [m1, I1, m2, I2].
-	void						AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
+	void						AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, bool inTrackOnly);
 
 	/// Finalizes the contact cache, the contact cache that was generated during the calls to AddContactConstraint in this update
 	/// will be used from now on to read from.
@@ -220,7 +220,7 @@ public:
 	/// @param inBody2 The second body that is colliding
 	/// @param inManifold The manifold that describes the collision
 	/// @param outSettings The calculated contact settings (may be overridden by the contact listener)
-	void						OnCCDContactAdded(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &outSettings);
+	void						OnCCDContactAdded(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &outSettings, bool inTrackOnly);
 
 #ifdef JPH_DEBUG_RENDERER
 	// Drawing properties
@@ -283,7 +283,8 @@ private:
 		enum class EFlags : uint16
 		{
 			ContactPersisted	= 1,																///< If this cache entry was reused in the next simulation update
-			CCDContact			= 2																	///< This is a cached manifold reported by continuous collision detection and was only used to create a contact callback
+			CCDContact			= 2,																///< This is a cached manifold reported by continuous collision detection and was only used to create a contact callback
+			TrackOnly			= 4
 		};
 
 		/// @see EFlags
@@ -452,7 +453,7 @@ private:
 
 	/// Internal helper function to add a contact constraint. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, Mat44Arg inInvI1, Mat44Arg inInvI2);
+	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, Mat44Arg inInvI1, Mat44Arg inInvI2, bool inTrackOnly);
 
 	/// Internal helper function to warm start contact constraint. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>

--- a/Samples/Tests/General/ContactListenerTest.cpp
+++ b/Samples/Tests/General/ContactListenerTest.cpp
@@ -61,7 +61,7 @@ ValidateResult ContactListenerTest::OnContactValidate(const Body &inBody1, const
 	return ((&inBody1 == mBody[0] && &inBody2 == mBody[1]) || (&inBody1 == mBody[1] && &inBody2 == mBody[0]))? ValidateResult::RejectAllContactsForThisBodyPair : ValidateResult::AcceptAllContactsForThisBodyPair;
 }
 
-void ContactListenerTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void ContactListenerTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	// Make body 1 bounce only when a new contact point is added but not when it is persisted (its restitution is normally 0)
 	if (&inBody1 == mBody[0] || &inBody2 == mBody[0])

--- a/Samples/Tests/General/ContactListenerTest.h
+++ b/Samples/Tests/General/ContactListenerTest.h
@@ -20,7 +20,7 @@ public:
 
 	// See: ContactListener
 	virtual ValidateResult	OnContactValidate(const Body &inBody1, const Body &inBody2, const CollideShapeResult &inCollisionResult) override;
-	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
+	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
 
 private:
 	// The 4 bodies that we create

--- a/Samples/Tests/General/FrictionPerTriangleTest.cpp
+++ b/Samples/Tests/General/FrictionPerTriangleTest.cpp
@@ -83,12 +83,12 @@ void FrictionPerTriangleTest::sOverrideContactSettings(const Body &inBody1, cons
 	ioSettings.mCombinedRestitution = max(restitution1, restitution2);
 }
 
-void FrictionPerTriangleTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void FrictionPerTriangleTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	sOverrideContactSettings(inBody1, inBody2, inManifold, ioSettings);
 }
 
-void FrictionPerTriangleTest::OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void FrictionPerTriangleTest::OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	sOverrideContactSettings(inBody1, inBody2, inManifold, ioSettings);
 }

--- a/Samples/Tests/General/FrictionPerTriangleTest.h
+++ b/Samples/Tests/General/FrictionPerTriangleTest.h
@@ -40,6 +40,6 @@ public:
 	virtual ContactListener *GetContactListener() override		{ return this; }
 
 	// See: ContactListener
-	virtual void	OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
-	virtual void	OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
+	virtual void	OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
+	virtual void	OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
 };

--- a/Samples/Tests/General/SensorTest.cpp
+++ b/Samples/Tests/General/SensorTest.cpp
@@ -139,7 +139,7 @@ void SensorTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 	}
 }
 
-void SensorTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void SensorTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	for (int sensor = 0; sensor < NumSensors; ++sensor)
 	{
@@ -170,7 +170,7 @@ void SensorTest::OnContactAdded(const Body &inBody1, const Body &inBody2, const 
 	}
 }
 
-void SensorTest::OnContactRemoved(const SubShapeIDPair &inSubShapePair)
+void SensorTest::OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly)
 {
 	for (int sensor = 0; sensor < NumSensors; ++sensor)
 	{

--- a/Samples/Tests/General/SensorTest.h
+++ b/Samples/Tests/General/SensorTest.h
@@ -25,8 +25,8 @@ public:
 	virtual ContactListener *GetContactListener() override	{ return this; }
 
 	// See: ContactListener
-	virtual void		OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
-	virtual void		OnContactRemoved(const SubShapeIDPair &inSubShapePair) override;
+	virtual void		OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
+	virtual void		OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly) override;
 	
 	// Saving / restoring state for replay
 	virtual void		SaveState(StateRecorder &inStream) const override;

--- a/Samples/Utils/ContactListenerImpl.cpp
+++ b/Samples/Utils/ContactListenerImpl.cpp
@@ -24,7 +24,7 @@ ValidateResult ContactListenerImpl::OnContactValidate(const Body &inBody1, const
 	return result;
 }
 
-void ContactListenerImpl::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void ContactListenerImpl::OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	// Expect bodies to be sorted
 	if (!(inBody1.GetID() < inBody2.GetID()))
@@ -46,10 +46,10 @@ void ContactListenerImpl::OnContactAdded(const Body &inBody1, const Body &inBody
 	}
 
 	if (mNext != nullptr)
-		mNext->OnContactAdded(inBody1, inBody2, inManifold, ioSettings);
+		mNext->OnContactAdded(inBody1, inBody2, inManifold, ioSettings, inTrackOnly);
 }
 
-void ContactListenerImpl::OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings)
+void ContactListenerImpl::OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly)
 {
 	// Expect bodies to be sorted
 	if (!(inBody1.GetID() < inBody2.GetID()))
@@ -73,10 +73,10 @@ void ContactListenerImpl::OnContactPersisted(const Body &inBody1, const Body &in
 	}
 
 	if (mNext != nullptr)
-		mNext->OnContactPersisted(inBody1, inBody2, inManifold, ioSettings);
+		mNext->OnContactPersisted(inBody1, inBody2, inManifold, ioSettings, inTrackOnly);
 }
 
-void ContactListenerImpl::OnContactRemoved(const SubShapeIDPair &inSubShapePair)
+void ContactListenerImpl::OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly)
 {
 	// Expect bodies to be sorted
 	if (!(inSubShapePair.GetBody1ID() < inSubShapePair.GetBody2ID()))
@@ -95,7 +95,7 @@ void ContactListenerImpl::OnContactRemoved(const SubShapeIDPair &inSubShapePair)
 	}
 
 	if (mNext != nullptr)
-		mNext->OnContactRemoved(inSubShapePair);
+		mNext->OnContactRemoved(inSubShapePair, inTrackOnly);
 }
 
 void ContactListenerImpl::SaveState(StateRecorder &inStream) const

--- a/Samples/Utils/ContactListenerImpl.h
+++ b/Samples/Utils/ContactListenerImpl.h
@@ -14,9 +14,9 @@ class ContactListenerImpl : public ContactListener
 public:
 	// See: ContactListener
 	virtual ValidateResult	OnContactValidate(const Body &inBody1, const Body &inBody2, const CollideShapeResult &inCollisionResult) override;
-	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
-	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) override;
-	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair) override;
+	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
+	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings, bool inTrackOnly) override;
+	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair, bool inTrackOnly) override;
 
 	// Saving / restoring state for replay
 	void					SaveState(StateRecorder &inStream) const;


### PR DESCRIPTION
Adds a new validate result, in which the object's collision can be tracked for contact, without actually performing any constraints, etc on the object.

This essentially makes it work like a sensor, following the validation step, which can be useful if the body only wants to act as a sensor to some objects and not others.

It's also useful if your game/engine expects to get Start/EndTouch callbacks even when collision is disabled from an object from testing if two narrow-phase bodies should collide.