### PR TITLE
Fix error in doctest.h under MSVC 2022

### DIFF
--- a/UnitTests/doctest.h
+++ b/UnitTests/doctest.h
@@ -3206,7 +3206,7 @@ typedef timer_large_integer::type ticks_t;
     ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
     ticks_t getCurrentTicks() {
-        static LARGE_INTEGER hz = {0}, hzo = {0};
+        static LARGE_INTEGER hz{}, hzo{};
         if(!hz.QuadPart) {
             QueryPerformanceFrequency(&hz);
             QueryPerformanceCounter(&hzo);


### PR DESCRIPTION
Warns about not having additional inner braces for unions, however, it is easier to just {} and avoid it.