### PR TITLE
Fix deprecated implicit copy constructor

### DIFF
--- a/Jolt/Core/Color.h
+++ b/Jolt/Core/Color.h
@@ -17,6 +17,7 @@ public:
 	/// Constructors
 							Color() = default; ///< Intentionally not initialized for performance reasons
 							Color(const Color &inRHS) = default;
+	Color &					operator=(const Color &inRHS) = default;
 	explicit constexpr		Color(uint32 inColor)													: mU32(inColor) { }
 	constexpr				Color(uint8 inRed, uint8 inGreen, uint8 inBlue, uint8 inAlpha = 255)	: r(inRed), g(inGreen), b(inBlue), a(inAlpha) { }
 	constexpr				Color(ColorArg inRHS, uint8 inAlpha)									: r(inRHS.r), g(inRHS.g), b(inRHS.b), a(inAlpha) { }

--- a/Jolt/Math/Float2.h
+++ b/Jolt/Math/Float2.h
@@ -14,6 +14,7 @@ public:
 						Float2() = default; ///< Intentionally not initialized for performance reasons
 						Float2(const Float2 &inRHS) = default;
 						Float2(float inX, float inY)					: x(inX), y(inY) { }
+	Float2 &			operator=(const Float2 &inRHS) = default;
 
 	bool				operator == (const Float2 &inRHS) const			{ return x == inRHS.x && y == inRHS.y; }
 	bool				operator != (const Float2 &inRHS) const			{ return x != inRHS.x || y != inRHS.y; }

--- a/Jolt/Math/Float3.h
+++ b/Jolt/Math/Float3.h
@@ -15,6 +15,7 @@ public:
 
 				Float3() = default; ///< Intentionally not initialized for performance reasons
 				Float3(const Float3 &inRHS) = default;
+	Float3 &	operator=(const Float3 &inRHS) = default;
 				Float3(float inX, float inY, float inZ) : x(inX), y(inY), z(inZ) { }
 
 	float		operator [] (int inCoordinate) const	

--- a/Jolt/Math/Quat.h
+++ b/Jolt/Math/Quat.h
@@ -37,6 +37,7 @@ public:
 	///@{
 	inline						Quat() = default; ///< Intentionally not initialized for performance reasons
 								Quat(const Quat &inRHS) = default;
+	Quat &						operator=(const Quat &inRHS) = default;
 	inline						Quat(float inX, float inY, float inZ, float inW)				: mValue(inX, inY, inZ, inW) { }
 	inline explicit				Quat(Vec4Arg inV)												: mValue(inV) { }
 	///@}

--- a/Jolt/Math/UVec4.h
+++ b/Jolt/Math/UVec4.h
@@ -24,6 +24,7 @@ public:
 	/// Constructor
 								UVec4() = default; ///< Intentionally not initialized for performance reasons
 								UVec4(const UVec4 &inRHS) = default;
+	UVec4 &						operator=(const UVec4 &inRHS) = default;
 	JPH_INLINE					UVec4(Type inRHS) : mValue(inRHS)					{ }
 
 	/// Create a vector from 4 integer components

--- a/Jolt/Math/Vec3.h
+++ b/Jolt/Math/Vec3.h
@@ -28,6 +28,7 @@ public:
 	/// Constructor
 								Vec3() = default; ///< Intentionally not initialized for performance reasons
 								Vec3(const Vec3 &inRHS) = default;
+	Vec3 &						operator=(const Vec3 &inRHS) = default;
 	explicit JPH_INLINE			Vec3(Vec4Arg inRHS);
 	JPH_INLINE					Vec3(Type inRHS) : mValue(inRHS)				{ CheckW(); }
 

--- a/Jolt/Math/Vec4.h
+++ b/Jolt/Math/Vec4.h
@@ -26,6 +26,7 @@ public:
 	/// Constructor
 								Vec4() = default; ///< Intentionally not initialized for performance reasons
 								Vec4(const Vec4 &inRHS) = default;
+	Vec4 &						operator=(const Vec4 &inRHS) = default;
 	explicit JPH_INLINE			Vec4(Vec3Arg inRHS);							///< WARNING: W component undefined!
 	JPH_INLINE					Vec4(Vec3Arg inRHS, float inW);
 	JPH_INLINE					Vec4(Type inRHS) : mValue(inRHS)				{ }

--- a/Jolt/Physics/Collision/Shape/SubShapeIDPair.h
+++ b/Jolt/Physics/Collision/Shape/SubShapeIDPair.h
@@ -19,6 +19,7 @@ public:
 							SubShapeIDPair() = default;
 							SubShapeIDPair(const BodyID &inBody1ID, const SubShapeID &inSubShapeID1, const BodyID &inBody2ID, const SubShapeID &inSubShapeID2) : mBody1ID(inBody1ID), mSubShapeID1(inSubShapeID1), mBody2ID(inBody2ID), mSubShapeID2(inSubShapeID2) { }
 							SubShapeIDPair(const SubShapeIDPair &) = default;
+	SubShapeIDPair &		operator=(const SubShapeIDPair &) = default;
 
 	/// Equality operator
 	inline bool				operator == (const SubShapeIDPair &inRHS) const		

--- a/Jolt/Physics/Constraints/MotorSettings.h
+++ b/Jolt/Physics/Constraints/MotorSettings.h
@@ -28,6 +28,7 @@ public:
 	/// Constructor
 							MotorSettings() = default;
 							MotorSettings(const MotorSettings &inRHS) = default;
+	MotorSettings &			operator=(const MotorSettings &inRHS) = default;
 							MotorSettings(float inFrequency, float inDamping) : mFrequency(inFrequency), mDamping(inDamping) { JPH_ASSERT(IsValid()); }
 							MotorSettings(float inFrequency, float inDamping, float inForceLimit, float inTorqueLimit) : mFrequency(inFrequency), mDamping(inDamping), mMinForceLimit(-inForceLimit), mMaxForceLimit(inForceLimit), mMinTorqueLimit(-inTorqueLimit), mMaxTorqueLimit(inTorqueLimit) { JPH_ASSERT(IsValid()); }
 


### PR DESCRIPTION
At least Clang 15.0.2 with `-Wextra` / `-Wdeprecated-copy` complains 'definition of implicit copy constructor is deprecated'.