### PR TITLE
Separated body allocation / init from insertion.

### DIFF
--- a/Jolt/Physics/Body/BodyInterface.cpp
+++ b/Jolt/Physics/Body/BodyInterface.cpp
@@ -25,6 +25,16 @@ Body *BodyInterface::CreateBodyWithID(const BodyID &inBodyID, const BodyCreation
 	return mBodyManager->CreateBodyWithID(inBodyID, inSettings);
 }
 
+Body *BodyInterface::AllocateBody(const BodyCreationSettings &inSettings)
+{
+	return mBodyManager->AllocateBody(inSettings);
+}
+
+bool BodyInterface::InsertBody(Body *inBody, const BodyID &inBodyID)
+{
+	return mBodyManager->InsertBody(inBody, inBodyID);
+}
+
 void BodyInterface::DestroyBody(const BodyID &inBodyID)
 {
 	mBodyManager->DestroyBodies(&inBodyID, 1);

--- a/Jolt/Physics/Body/BodyInterface.h
+++ b/Jolt/Physics/Body/BodyInterface.h
@@ -40,6 +40,15 @@ public:
 	/// @return Created body or null when the body ID is invalid or a body of the same ID already exists.
 	Body *						CreateBodyWithID(const BodyID &inBodyID, const BodyCreationSettings &inSettings);
 
+	/// Allocates and initializes a body, without adding it.
+	/// @return Created body or null when allocation fails.
+	Body *						AllocateBody(const BodyCreationSettings &inSettings);
+
+	/// Insert a preallocated body at a specified ID. This function can be used if a simulation is to run in sync between clients or if a simulation needs to be restored exactly.
+	/// The ID created on the server can be replicated to the client and used to create a deterministic simulation.
+	/// @return true on success, false on failure.
+	bool                        InsertBody(Body *inBody, const BodyID &inBodyID);
+
 	/// Destroy a body
 	void						DestroyBody(const BodyID &inBodyID);
 	

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -68,6 +68,14 @@ public:
 	/// This is a thread safe function. Can return null if there are no more bodies available or when the body ID is already in use.
 	Body *							CreateBodyWithID(const BodyID &inBodyID, const BodyCreationSettings &inBodyCreationSettings);
 
+	/// Helper function to allocate and initialize a body without modifying other state and without holding locks.
+	/// This is a thread safe function. Can return null if allocation fails.
+	Body *							AllocateBody(const BodyCreationSettings &inBodyCreationSettings);
+
+	/// Helper function to insert a preallocated body at a specified body ID.
+	/// This is a thread safe function. Can return false if the body ID is already in use.
+	bool                            InsertBody(Body *inBody, const BodyID &inBodyID);
+
 	/// Mark a list of bodies for destruction and remove it from this manager.
 	/// This is a thread safe function since the body is not deleted until the next PhysicsSystem::Update() (which will take all locks)
 	void							DestroyBodies(const BodyID *inBodyIDs, int inNumber);


### PR DESCRIPTION
With the new CreateBodyAtID() API the save / restore problem is solved, but new issues and performance bottlenecks popped up during streaming: to guarantee deterministic IDs when streaming in a new chunk of the world, the ID allocation step needs to be serialized - but the existing API bundled memory allocation & initialization with body insertion, forcing serialization.

With this new API new objects can have their expensive allocations made in parallel on many threads, while the ID assignment can happen on a single thread in a deterministic order. This enables better use of multi-core systems during streaming while guaranteeing deterministic BodyIDs despite the unordered parallel nature of the body allocation process.