### PR TITLE
Added ability to remove bodies from sim without deallocating them.

### DIFF
--- a/Jolt/Physics/Body/BodyInterface.cpp
+++ b/Jolt/Physics/Body/BodyInterface.cpp
@@ -52,6 +52,16 @@ bool BodyInterface::AssignBodyID(Body *ioBody, const BodyID &inBodyID)
 	return mBodyManager->AddBodyWithCustomID(ioBody, inBodyID);
 }
 
+void BodyInterface::RemoveBodyNoDeallocate(const BodyID &inBodyID)
+{
+	mBodyManager->RemoveBodies(&inBodyID, 1);
+}
+
+void BodyInterface::RemoveBodiesNoDeallocate(const BodyID *inBodyIDs, int inNumber)
+{
+	mBodyManager->RemoveBodies(inBodyIDs, inNumber);
+}
+
 void BodyInterface::DestroyBody(const BodyID &inBodyID)
 {
 	mBodyManager->DestroyBodies(&inBodyID, 1);

--- a/Jolt/Physics/Body/BodyInterface.h
+++ b/Jolt/Physics/Body/BodyInterface.h
@@ -51,6 +51,12 @@ public:
 	/// @return false if the body already has an ID or if the ID is not valid.
 	bool						AssignBodyID(Body *ioBody, const BodyID &inBodyID);
 
+	/// Remove a body without deallocating it
+	void						RemoveBodyNoDeallocate(const BodyID &inBodyID);
+
+	/// Removes multiple bodies without deallocating them
+	void						RemoveBodiesNoDeallocate(const BodyID *inBodyIDs, int inNumber);
+
 	/// Destroy a body
 	void						DestroyBody(const BodyID &inBodyID);
 	

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -63,7 +63,7 @@ public:
 	/// Create a body using creation settings. The returned body will not be part of the body manager yet.
 	Body *							AllocateBody(const BodyCreationSettings &inBodyCreationSettings) const;
 
-	/// Free a body that has not been added to the body manager yet (if it has, use DestroyBodies).
+	/// Free a body that is not currently added to the body manager (if it has been added and hasn't been removed, use DestroyBodies).
 	void							FreeBody(Body *inBody) const;
 
 	/// Add a body to the body manager, assigning it the next available ID. Returns false if no more IDs are available.
@@ -71,6 +71,9 @@ public:
 
 	/// Add a body to the body manager, assigning it a custom ID. Returns false if the ID is not valid.
 	bool							AddBodyWithCustomID(Body *ioBody, const BodyID &inBodyID);
+
+	/// Remove a set of bodies from the body manager without destroying / freeing them.
+	void                            RemoveBodies(const BodyID *inBodyIDs, int inNumber);
 
 	/// Remove a set of bodies from the body manager and destroy them.
 	void							DestroyBodies(const BodyID *inBodyIDs, int inNumber);


### PR DESCRIPTION
This allows a quick, serial, and deterministic removal on a single thread without having to pay the cost of memory deallocation immediately.

Deallocations can be done opportunistically and / or on background thread, to prevent frame time spikes.