### PR TITLE
Add convex radius accessors for shape classes that lack them

### DIFF
--- a/Jolt/Physics/Collision/Shape/BoxShape.h
+++ b/Jolt/Physics/Collision/Shape/BoxShape.h
@@ -90,6 +90,9 @@ public:
 	// See Shape::GetVolume
 	virtual float			GetVolume() const override									{ return GetLocalBounds().GetVolume(); }
 
+	/// Get the convex radius of this box
+	float					GetConvexRadius() const										{ return mConvexRadius; }
+
 	// Register shape functions with the registry
 	static void				sRegister();
 

--- a/Jolt/Physics/Collision/Shape/CylinderShape.h
+++ b/Jolt/Physics/Collision/Shape/CylinderShape.h
@@ -97,6 +97,9 @@ public:
 	// See Shape::GetVolume
 	virtual float			GetVolume() const override												{ return 2.0f * JPH_PI * mHalfHeight * Square(mRadius); }
 
+	/// Get the convex radius of this cylinder
+	float					GetConvexRadius() const													{ return mConvexRadius; }
+
 	// See Shape::IsValidScale
 	virtual bool			IsValidScale(Vec3Arg inScale) const override;
 


### PR DESCRIPTION
A very minor contribution. Needed these for custom serialization, and found that they were missing.