### PR TITLE
Add convex hull point accessor

### DIFF
--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
@@ -1186,6 +1186,12 @@ Shape::Stats ConvexHullShape::GetStats() const
 		triangle_count);
 }
 
+Vec3 ConvexHullShape::GetPoint(size_t index) const
+{
+	JPH_ASSERT(index >= 0 && index < mPoints.size(), "Point index out of bounds");
+	return mPoints[index].mPosition;
+}
+
 void ConvexHullShape::sRegister()
 {
 	ShapeFunctions &f = ShapeFunctions::sGet(EShapeSubType::ConvexHull);

--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
@@ -1186,12 +1186,6 @@ Shape::Stats ConvexHullShape::GetStats() const
 		triangle_count);
 }
 
-Vec3 ConvexHullShape::GetPoint(size_t index) const
-{
-	JPH_ASSERT(index >= 0 && index < mPoints.size(), "Point index out of bounds");
-	return mPoints[index].mPosition;
-}
-
 void ConvexHullShape::sRegister()
 {
 	ShapeFunctions &f = ShapeFunctions::sGet(EShapeSubType::ConvexHull);

--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.h
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.h
@@ -110,10 +110,10 @@ public:
 	const Array<Plane> &	GetPlanes() const													{ return mPlanes; }
 
 	/// Get the number of vertices in this convex hull
-	size_t					GetNumPoints() const												{ return mPoints.size(); }
+	inline uint				GetNumPoints() const												{ return (uint)mPoints.size(); }
 
 	/// Get a vertex of this convex hull relative to the center of mass
-	Vec3					GetPoint(size_t index) const;
+	inline Vec3				GetPoint(uint inIndex) const										{ return mPoints[inIndex].mPosition; }
 
 	// Register shape functions with the registry
 	static void				sRegister();

--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.h
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.h
@@ -109,6 +109,12 @@ public:
 	/// Get the planes of this convex hull
 	const Array<Plane> &	GetPlanes() const													{ return mPlanes; }
 
+	/// Get the number of vertices in this convex hull
+	size_t					GetNumPoints() const												{ return mPoints.size(); }
+
+	/// Get a vertex of this convex hull relative to the center of mass
+	Vec3					GetPoint(size_t index) const;
+
 	// Register shape functions with the registry
 	static void				sRegister();
 


### PR DESCRIPTION
Similar to my last PR. 

Another approach would have been to add a getter for an `Array<Point>`, which would have been more symmetrical with `GetPlanes()`. However, I didn't want to expose more internal state than necessary. I also considered adding a getter for an iterable, read-only view of the points as `Vec3`s, but this would have meant adding too much code for a minor feature.
