### PR TITLE
Fixed tolerance issue in GetClosestPoint

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -1,8 +1,8 @@
 name: Determinism Check
 
 env:
-    CONVEX_VS_MESH_HASH: '0x485e1d8e739a3c9d'
-    RAGDOLL_HASH: '0xc29b4c0ea4cf1876'
+    CONVEX_VS_MESH_HASH: '0xffa5a3695dec1ccd'
+    RAGDOLL_HASH: '0x91352c8200917359'
 
 on:
   push:

--- a/Jolt/Physics/Collision/GroupFilter.cpp
+++ b/Jolt/Physics/Collision/GroupFilter.cpp
@@ -48,6 +48,11 @@ GroupFilter::GroupFilterResult GroupFilter::sRestoreFromBinaryState(StreamIn &in
 
 	// Construct and read the data of the group filter
 	Ref<GroupFilter> group_filter = reinterpret_cast<GroupFilter *>(rtti->CreateObject());
+	if (group_filter == nullptr)
+	{
+		result.SetError("Failed to create instance of group filter");
+		return result;
+	}
 	group_filter->RestoreBinaryState(inStream);
 	if (inStream.IsEOF() || inStream.IsFailed())
 	{


### PR DESCRIPTION
- Increased tolerance from FLT_EPSILON^2 -> 1.0e-12 because there was a case where this tolerance was too low and incorrectly caused the algorithm to return an interior hit for a degenerate triangle that was clearly not interior
- Fixed crash when restoring a group filter that tries to instantiate an abstract class