### PR TITLE
Fixed tolerance issue in GetClosestPoint

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -2,7 +2,7 @@ name: Determinism Check
 
 env:
     CONVEX_VS_MESH_HASH: '0x485e1d8e739a3c9d'
-    RAGDOLL_HASH: '0xc29b4c0ea4cf1876'
+    RAGDOLL_HASH: '0x4aa4bf5368b6027'
 
 on:
   push:

--- a/Jolt/Geometry/ClosestPoint.h
+++ b/Jolt/Geometry/ClosestPoint.h
@@ -169,7 +169,7 @@ namespace ClosestPoint
 		float n_len_sq = n.LengthSq();
 
 		// Check degenerate
-		if (n_len_sq < Square(FLT_EPSILON))
+		if (n_len_sq < 1.0e-13f) // Square(FLT_EPSILON) was too small and caused numerical problems, see test case TestCollideParallelTriangleVsCapsule
 		{
 			// Degenerate, fallback to edges
 


### PR DESCRIPTION
Increased tolerance from FLT_EPSILON^2 -> 1.0e-13 because there was a case where this tolerance was too low and incorrectly caused the algorithm to return an interior hit for a degenerate triangle that was clearly not interior