### PR TITLE
Added CMake multi-config support for GCC

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -32,7 +32,7 @@ include(CMakeDependentOption)
 # Windows Store only supports the DLL version
 cmake_dependent_option(USE_STATIC_MSVC_RUNTIME_LIBRARY "Use the static MSVC runtime library" ON "MSVC;NOT WINDOWS_STORE" OFF)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Distribution")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	set(CMAKE_CONFIGURATION_TYPES "Debug;Release;ReleaseASAN;ReleaseUBSAN;ReleaseCoverage;Distribution")


### PR DESCRIPTION
When compiling with `g++` and using a multi-config generator like `"Ninja Multi-Config"` you currently run into CMake errors such as:

```
ninja: error: loading 'build-Distribution.ninja': No such file or directory
```

Here's how to reproduce it (you'll need the [`ninja-build`](https://packages.ubuntu.com/jammy/ninja-build) package):

```
cmake -S Build -B Build/Ninja_GCC -G "Ninja Multi-Config" -DCMAKE_CXX_COMPILER=g++
cmake --build Build/Ninja_GCC --config Distribution
```

This seems to stem from `CMAKE_CONFIGURATION_TYPES` not being set for anything but MSVC and Clang currently.

This PR sets that to be `Debug;Release;Distribution` for GCC as well.

GCC does seem to have support for ASan and UBSan, but not for code coverage, so I kept it simple and left all of them out.