### PR TITLE
Added missing va_end to va_list usages

### DIFF
--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -39,6 +39,7 @@ static void TraceImpl(const char *inFMT, ...)
 	va_start(list, inFMT);
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 
 	// Print to the TTY
 	cout << buffer << endl;

--- a/Jolt/Core/StringTools.cpp
+++ b/Jolt/Core/StringTools.cpp
@@ -19,6 +19,7 @@ String StringFormat(const char *inFMT, ...)
 	va_list list;
 	va_start(list, inFMT);
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 
 	return String(buffer);
 }

--- a/PerformanceTest/PerformanceTest.cpp
+++ b/PerformanceTest/PerformanceTest.cpp
@@ -44,6 +44,7 @@ static void TraceImpl(const char *inFMT, ...)
 	va_start(list, inFMT);
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 
 	// Print to the TTY
 	cout << buffer << endl;

--- a/TestFramework/Utils/Log.cpp
+++ b/TestFramework/Utils/Log.cpp
@@ -13,6 +13,7 @@ void TraceImpl(const char *inFMT, ...)
 	va_start(list, inFMT);
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 	strcat_s(buffer, "\n");
 
 	// Log to the output window

--- a/UnitTests/UnitTestFramework.cpp
+++ b/UnitTests/UnitTestFramework.cpp
@@ -37,6 +37,7 @@ static void TraceImpl(const char *inFMT, ...)
 	va_start(list, inFMT);
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 
 	// Forward to doctest
 	MESSAGE(buffer);


### PR DESCRIPTION
As mentioned on [cppreference.com](https://en.cppreference.com/w/c/io/vfprintf#Notes) regarding `vsnprintf`:

> These functions do not invoke `va_end`, and it must be done by the caller.

It seems to just null out the `va_list` pointer on MSVC, so no leaks or anything, but I haven't checked other platforms.