### PR TITLE
Fixed MSVC warning about overriding /GR

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -53,7 +53,13 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
 	endif()
 
 	# Set general compiler flags
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /GR- /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 /Zc:__cplusplus /Gm- /Wall /WX /MP /nologo /diagnostics:classic /FC /fp:except- /Zc:inline /Zi")
+
+	# Remove any existing compiler flag that enables RTTI
+	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+	# Set compiler flag for disabling RTTI
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 
 	# Set compiler flags for various configurations
 	set(CMAKE_CXX_FLAGS_DEBUG "/GS /Od /Ob0 /RTC1")


### PR DESCRIPTION
Since #319 was merged a lot of warnings are popping up saying `warning D9025 : overriding '/GR' with '/GR-'` when compiling with MSVC and using non-Visual Studio generators like `"Ninja"` or `"Ninja Multi-Config"`.

This is because CMake ([up until version 3.20](https://cmake.org/cmake/help/latest/policy/CMP0117.html)) by default adds `/GR` to all MSVC builds.

This doesn't seem to be an issue with regular Visual Studio builds, which I can only assume is because Visual Studio resolves the conflicting flags somehow. When invoking `cl.exe` (through Ninja in this case) it throws a warning instead.

If you're interested in trying out the Ninja generators you can do so by using Visual Studio's [built-in CMake support](https://learn.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio), where Ninja is the default generator. Alternatively you can also run this from a Visual Studio developer command prompt, assuming you have Ninja installed:

```
cmake -S Build -B Build/Ninja_CL -G "Ninja Multi-Config" -DCMAKE_CXX_COMPILER=cl
cmake --build Build/Ninja_CL --config Distribution
```

Anyway, I figured you probably don't want to bump the minimum CMake version, so I opted to solve this using `string(REPLACE ...)`. However, instead of replacing `/GR` with `/GR-` in one go, I do the removal of the flag first, so that if/when you do decide to bump the CMake version past 3.20 then this shouldn't silently break for you.