### PR TITLE
Made detection of instruction sets a little bit less brittle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ on:
 
 jobs:
   linux-clang:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Linux Clang
     strategy:
         fail-fast: false
         matrix:
             build_type: [Debug, Release, Distribution, ReleaseASAN, ReleaseUBSAN]
-            clang_version: [clang++-10, clang++-12]
+            clang_version: [clang++-12, clang++-14]
 
     steps:
     - name: Checkout Code
@@ -34,7 +34,7 @@ jobs:
       run: ctest --output-on-failure
 
   linux-gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Linux GCC
     strategy:
         fail-fast: false
@@ -163,7 +163,7 @@ jobs:
       run: ctest --output-on-failure
 
   android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Android
     strategy:
         fail-fast: false

--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Linux Determinism Check
 
     steps:

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -73,13 +73,13 @@
 	#if (defined(__SSE4_1__) || defined(JPH_USE_SSE4_2)) && !defined(JPH_USE_SSE4_1)
 		#define JPH_USE_SSE4_1
 	#endif
-	#if (defined(__F16C__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_F16C)
+	#if (defined(__F16C__) || defined(JPH_USE_AVX2)) && !defined(JPH_USE_F16C)
 		#define JPH_USE_F16C
 	#endif
-	#if (defined(__LZCNT__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_LZCNT)
+	#if (defined(__LZCNT__) || defined(JPH_USE_AVX2)) && !defined(JPH_USE_LZCNT)
 		#define JPH_USE_LZCNT
 	#endif
-	#if (defined(__BMI__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_TZCNT)
+	#if (defined(__BMI__) || defined(JPH_USE_AVX2)) && !defined(JPH_USE_TZCNT)
 		#define JPH_USE_TZCNT
 	#endif
 	#ifndef JPH_CROSS_PLATFORM_DETERMINISTIC // FMA is not compatible with cross platform determinism

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -58,29 +58,29 @@
 	#define JPH_USE_SSE
 
 	// Detect enabled instruction sets
-	#if (defined(__F16C__) || defined(__AVX2__)) && !defined(JPH_USE_F16C)
-		#define JPH_USE_F16C
-	#endif
-	#if (defined(__LZCNT__) || defined(__AVX2__)) && !defined(JPH_USE_LZCNT)
-		#define JPH_USE_LZCNT
-	#endif
-	#if (defined(__BMI__) || defined(__AVX2__)) && !defined(JPH_USE_TZCNT)
-		#define JPH_USE_TZCNT
-	#endif
-	#if (defined(__SSE4_1__) || defined(__AVX__)) && !defined(JPH_USE_SSE4_1)
-		#define JPH_USE_SSE4_1
-	#endif
-	#if (defined(__SSE4_2__) || defined(__AVX__)) && !defined(JPH_USE_SSE4_2)
-		#define JPH_USE_SSE4_2
-	#endif
-	#if defined(__AVX__) && !defined(JPH_USE_AVX)
-		#define JPH_USE_AVX
-	#endif
-	#if defined(__AVX2__) && !defined(JPH_USE_AVX2)
-		#define JPH_USE_AVX2
-	#endif
 	#if defined(__AVX512F__) && defined(__AVX512VL__) && defined(__AVX512DQ__) && !defined(JPH_USE_AVX512)
 		#define JPH_USE_AVX512
+	#endif
+	#if (defined(__AVX2__) || defined(JPH_USE_AVX512)) && !defined(JPH_USE_AVX2)
+		#define JPH_USE_AVX2
+	#endif
+	#if (defined(__AVX__) || defined(JPH_USE_AVX2)) && !defined(JPH_USE_AVX)
+		#define JPH_USE_AVX
+	#endif
+	#if (defined(__SSE4_2__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_SSE4_2)
+		#define JPH_USE_SSE4_2
+	#endif
+	#if (defined(__SSE4_1__) || defined(JPH_USE_SSE4_2)) && !defined(JPH_USE_SSE4_1)
+		#define JPH_USE_SSE4_1
+	#endif
+	#if (defined(__F16C__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_F16C)
+		#define JPH_USE_F16C
+	#endif
+	#if (defined(__LZCNT__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_LZCNT)
+		#define JPH_USE_LZCNT
+	#endif
+	#if (defined(__BMI__) || defined(JPH_USE_AVX)) && !defined(JPH_USE_TZCNT)
+		#define JPH_USE_TZCNT
 	#endif
 	#ifndef JPH_CROSS_PLATFORM_DETERMINISTIC // FMA is not compatible with cross platform determinism
 		#if defined(JPH_COMPILER_CLANG) || defined(JPH_COMPILER_GCC)

--- a/Jolt/Geometry/GJKClosestPoint.h
+++ b/Jolt/Geometry/GJKClosestPoint.h
@@ -111,6 +111,10 @@ private:
 		mNumPoints = num_points;
 	}
 
+	// GCC 11.3 thinks the assignments to mP, mQ and mY below may use uninitialized variables
+	JPH_SUPPRESS_WARNING_PUSH
+	JPH_GCC_SUPPRESS_WARNING("-Wmaybe-uninitialized")
+
 	// Remove points that are not in the set, only updates mP
 	void		UpdatePointSetP(uint32 inSet)
 	{
@@ -152,6 +156,8 @@ private:
 			}
 		mNumPoints = num_points;
 	}
+
+	JPH_SUPPRESS_WARNING_POP
 
 	// Calculate closest points on A and B
 	void		CalculatePointAAndB(Vec3 &outPointA, Vec3 &outPointB) const

--- a/UnitTests/UnitTestFramework.cpp
+++ b/UnitTests/UnitTestFramework.cpp
@@ -174,6 +174,46 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine,
 // Generic entry point
 int main(int argc, char** argv)
 {
+	// Show used instruction sets
+	std::cout << JPH_CPU_ADDRESS_BITS << "-bit build with instructions: ";
+#ifdef JPH_USE_NEON
+	std::cout << "NEON ";
+#endif
+#ifdef JPH_USE_SSE
+	std::cout << "SSE2 ";
+#endif
+#ifdef JPH_USE_SSE4_1
+	std::cout << "SSE4.1 ";
+#endif
+#ifdef JPH_USE_SSE4_2
+	std::cout << "SSE4.2 ";
+#endif
+#ifdef JPH_USE_AVX
+	std::cout << "AVX ";
+#endif
+#ifdef JPH_USE_AVX2
+	std::cout << "AVX2 ";
+#endif
+#ifdef JPH_USE_AVX512
+	std::cout << "AVX512 ";
+#endif
+#ifdef JPH_USE_F16C
+	std::cout << "F16C ";
+#endif
+#ifdef JPH_USE_LZCNT
+	std::cout << "LZCNT ";
+#endif
+#ifdef JPH_USE_TZCNT
+	std::cout << "TZCNT ";
+#endif
+#ifdef JPH_USE_FMADD
+	std::cout << "FMADD ";
+#endif
+#ifdef JPH_CROSS_PLATFORM_DETERMINISTIC
+	std::cout << "(Cross Platform Deterministic)";
+#endif
+	std::cout << std::endl;
+
 	// Register allocation hook
 	RegisterDefaultAllocator();
 


### PR DESCRIPTION
Before e.g. defining JPH_USE_SSE4_2 did not imply JPH_USE_SSE4_1, now it does Also updated github build scripts to run on ubuntu 22.04