### PR TITLE
Detect JPH_COMPILER_MINGW for llvm-mingw

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -37,13 +37,14 @@
 // Determine compiler
 #if defined(__clang__)
 	#define JPH_COMPILER_CLANG
-#elif defined(__MINGW64__) || defined (__MINGW32__)
-	#define JPH_COMPILER_GCC
-	#define JPH_COMPILER_MINGW
 #elif defined(__GNUC__)
 	#define JPH_COMPILER_GCC
 #elif defined(_MSC_VER)
 	#define JPH_COMPILER_MSVC
+#endif
+
+#if defined(__MINGW64__) || defined (__MINGW32__)
+	#define JPH_COMPILER_MINGW
 #endif
 
 // Detect CPU architecture


### PR DESCRIPTION
Hello!

This PR fixes the following compile error when building with [llvm-mingw](https://github.com/mstorsjo/llvm-mingw):

```cpp
JoltPhysics/Jolt/Core/JobSystemThreadPool.cpp:509:2: error: use of undeclared identifier '__try'
        __try
        ^
1 error generated.
```

This happens because `JPH_COMPILER_MINGW` is not defined during compiler detection in `Jolt/Core/Core.h`.
To fix this I've moved the `#if defined(__MINGW(32/64)__)` check into a separate `#if`. As for MSYS2 MinGW-w64, `JPH_COMPILER_GCC`  stays defined because of the `__GNUC__` check.

List of llvm-mingw `#defines` for reference:
```cpp
#define __GNUC__ 4
#define __clang__ 1
#define __MINGW32__ 1
#define __MINGW64__ 1
```


By the way, thank you for this amazing library!