### PR TITLE
Added CMake option for link-time optimizations

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -21,6 +21,9 @@ option(CROSS_PLATFORM_DETERMINISTIC "Cross platform deterministic" OFF)
 # When turning this option on, the library will be compiled for ARM (aarch64-linux-gnu), requires compiling with clang
 option(CROSS_COMPILE_ARM "Cross compile to aarch64-linux-gnu" OFF)
 
+# When turning this option on, the library will be compiled with interprocedural optimizations enabled, also known as link-time optimizations or link-time code generation
+option(INTERPROCEDURAL_OPTIMIZATION "Enable interprocedural optimizations" ON)
+
 # Select X86 processor features to use (if everything is off it will be SSE2 compatible)
 option(USE_SSE4_1 "Enable SSE4.1" ON)
 option(USE_SSE4_2 "Enable SSE4.2" ON)
@@ -91,12 +94,6 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
 	set(CMAKE_CXX_FLAGS_RELEASEUBSAN "-fsanitize=undefined,implicit-conversion,float-divide-by-zero,local-bounds -fno-sanitize-recover=all")
 	set(CMAKE_CXX_FLAGS_RELEASECOVERAGE "-fprofile-instr-generate -fcoverage-mapping")
 
-	if (NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM64") AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM"))
-		# On ARM, whole program optimization triggers an internal compiler error during code gen, so we don't turn it on
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL")
-		set(CMAKE_CXX_FLAGS_DISTRIBUTION "${CMAKE_CXX_FLAGS_DISTRIBUTION} /GL")
-	endif()
-
 	# Set linker flags
 	set(CMAKE_EXE_LINKER_FLAGS "/SUBSYSTEM:WINDOWS /ignore:4221 /DEBUG:FASTLINK")
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -134,8 +131,6 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
 		endif()
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /DJPH_FLOATING_POINT_EXCEPTIONS_ENABLED") # Clang turns Float2 into a vector sometimes causing floating point exceptions
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /DJPH_FLOATING_POINT_EXCEPTIONS_ENABLED")
-		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO /LTCG:incremental /OPT:ICF /OPT:REF")
-		set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "/LTCG")
 	elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /showFilenames")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments") # Clang emits warnings about unused arguments such as /MP and /GL
@@ -236,6 +231,22 @@ endif()
 # Setting to attempt cross platform determinism
 if (CROSS_PLATFORM_DETERMINISTIC)
 	add_compile_definitions(JPH_CROSS_PLATFORM_DETERMINISTIC)
+endif()
+
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DISTRIBUTION OFF)
+
+# On ARM, whole program optimization triggers an internal compiler error during code gen, so we don't turn it on
+if (INTERPROCEDURAL_OPTIMIZATION AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM64") AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM"))
+	include(CheckIPOSupported)
+	check_ipo_supported(RESULT IS_IPO_SUPPORTED OUTPUT IPO_CHECK_OUTPUT)
+
+	if (IS_IPO_SUPPORTED)
+		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DISTRIBUTION ON)
+	else()
+		message(WARNING "Interprocedural optimizations are not supported: ${IPO_CHECK_OUTPUT}")
+	endif()
 endif()
 
 # Set linker flags

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -174,8 +174,9 @@ elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQU
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		# Somehow -Wcomment doesn't want to be turned off from code and we need this because Doxygen MathJax uses it
+		# Also disable -Wstringop-overflow or it will generate false positives that can't be disabled from code when link-time optimizations are enabled
 		# Also turn off automatic fused multiply add contractions, there doesn't seem to be a way to do this selectively through the macro JPH_PRECISE_MATH_OFF
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-comment -ffp-contract=off")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-comment -Wno-stringop-overflow -ffp-contract=off")
 	else()
 		# Do not use -ffast-math or -ffp-contract=on since it cannot be turned off in a single compilation unit under clang, see Core.h
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-model=precise -ffp-contract=off")

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -242,9 +242,7 @@
 	JPH_MSVC_SUPPRESS_WARNING(4820)																\
 	JPH_MSVC_SUPPRESS_WARNING(4514)																\
 	JPH_MSVC_SUPPRESS_WARNING(5262)																\
-	JPH_MSVC_SUPPRESS_WARNING(5264)																\
-																								\
-	JPH_GCC_SUPPRESS_WARNING("-Wstringop-overflow=")
+	JPH_MSVC_SUPPRESS_WARNING(5264)
 
 #define JPH_SUPPRESS_WARNINGS_STD_END															\
 	JPH_SUPPRESS_WARNING_POP

--- a/UnitTests/Core/FPFlushDenormalsTest.cpp
+++ b/UnitTests/Core/FPFlushDenormalsTest.cpp
@@ -32,5 +32,8 @@ TEST_SUITE("FlushDenormalsTests")
 			float value = TestFltMin * 0.1f;
 			CHECK(value > 0.0f);
 		}
+
+		// Update TestFltMin to prevent the compiler from optimizing away TestFltMin and replace all calculations above with 0
+		TestFltMin = 1.0f;
 	}
 }


### PR DESCRIPTION
I'm currently unable to disable link-time code generation (`/LTCG`) on MSVC builds due to Jolt unconditionally using `/GL` for the `Release` and `Distribution` configurations. Microsoft's linker forcefully switches over to `/LTCG` mode whenever it finds an object file or static library with `/GL` enabled.

I figured instead of hiding the current use of `/GL` behind an `option` I would solve this using CMake's built-in support for adding these types of flags, which CMake calls [`INTERPROCEDURAL_OPTIMIZATION`](https://cmake.org/cmake/help/v3.16/variable/CMAKE_INTERPROCEDURAL_OPTIMIZATION.html#variable:CMAKE_INTERPROCEDURAL_OPTIMIZATION).

This has the added benefit of also adding the appropriate flags for GCC and Clang, where the equivalent of `/GL` is `-flto` and `-flto=thin` respectively.

I also made use of CMake's suggested [`check_ipo_supported`](https://cmake.org/cmake/help/v3.16/module/CheckIPOSupported.html) helper function, which does a `try_compile` with IPO enabled to see if the current platform/compiler supports it. Sadly this does not seem to catch the internal compiler error that happens when using IPO on Windows ARM/ARM64, so I'm not sure how much value it really provides.

Along with removing the explicit `/LTCG` I also removed the explicit `/INCREMENTAL:NO`, `/OPT:ICF` and `/OPT:REF`, all of which seem to be the default values of those flags when `/DEBUG` isn't specified.

It might also be worth mentioning that when using a Visual Studio generator, CMake simply emits `<WholeProgramOptimization>` in the project files, which Visual Studio then translates into `/GL` and `/LTCG:INCREMENTAL`, meaning you don't get the regular `/LTCG`. This only affects Jolt's executables and shared libraries though, which were already using the default `/LTCG:INCREMENTAL` previously.