### PR TITLE
Added tolerance to contact velocity check.

### DIFF
--- a/Jolt/Physics/Character/CharacterVirtual.cpp
+++ b/Jolt/Physics/Character/CharacterVirtual.cpp
@@ -679,7 +679,7 @@ void CharacterVirtual::UpdateSupportingContact(bool inSkipContactVelocityCheck, 
 		if (!c.mWasDiscarded
 			&& !c.mHadCollision
 			&& c.mDistance < mCollisionTolerance
-			&& (inSkipContactVelocityCheck || c.mSurfaceNormal.Dot(mLinearVelocity - c.mLinearVelocity) <= 0.0f))
+			&& (inSkipContactVelocityCheck || c.mSurfaceNormal.Dot(mLinearVelocity - c.mLinearVelocity) <= 1.0e-4f))
 		{
 			if (ValidateContact(c))
 				c.mHadCollision = true;


### PR DESCRIPTION
Sometimes the character was reporting InAir due to floating point accuracy issues.