### PR TITLE
Allowed sensors to collide with one another

### DIFF
--- a/Jolt/Physics/Body/Body.inl
+++ b/Jolt/Physics/Body/Body.inl
@@ -31,11 +31,9 @@ inline bool Body::sFindCollidingPairsCanCollide(const Body &inBody1, const Body 
 	// One of these conditions must be true
 	// - One of the bodies must be dynamic to collide
 	// - A kinematic object can collide with a sensor
-	bool body1_sensor = inBody1.IsSensor();
-	bool body2_sensor = inBody2.IsSensor();
 	if ((!inBody1.IsDynamic() && !inBody2.IsDynamic()) 
-		&& !(inBody1.IsKinematic() && body2_sensor)
-		&& !(inBody2.IsKinematic() && body1_sensor))
+		&& !(inBody1.IsKinematic() && inBody2.IsSensor())
+		&& !(inBody2.IsKinematic() && inBody1.IsSensor()))
 		return false;
 
 	// Check that body 1 is active

--- a/Jolt/Physics/Body/Body.inl
+++ b/Jolt/Physics/Body/Body.inl
@@ -38,10 +38,6 @@ inline bool Body::sFindCollidingPairsCanCollide(const Body &inBody1, const Body 
 		&& !(inBody2.IsKinematic() && body1_sensor))
 		return false;
 
-	// If both bodies are sensors, there's no collision
-	if (body1_sensor && body2_sensor)
-		return false;
-
 	// Check that body 1 is active
 	uint32 body1_index_in_active_bodies = inBody1.GetIndexInActiveBodiesInternal();
 	JPH_ASSERT(!inBody1.IsStatic() && body1_index_in_active_bodies != Body::cInactiveIndex, "This function assumes that Body 1 is active");

--- a/UnitTests/Layers.h
+++ b/UnitTests/Layers.h
@@ -18,7 +18,8 @@ namespace Layers
 	static constexpr uint8 MOVING = 6;
 	static constexpr uint8 HQ_DEBRIS = 7; // High quality debris collides with MOVING and NON_MOVING but not with any debris
 	static constexpr uint8 LQ_DEBRIS = 8; // Low quality debris only collides with NON_MOVING
-	static constexpr uint8 NUM_LAYERS = 9;
+	static constexpr uint8 SENSOR = 9; // Sensors only collide with MOVING objects
+	static constexpr uint8 NUM_LAYERS = 10;
 };
 
 /// Class that determines if two object layers can collide
@@ -38,11 +39,13 @@ public:
 		case Layers::NON_MOVING:
 			return inObject2 == Layers::MOVING || inObject2 == Layers::HQ_DEBRIS || inObject2 == Layers::LQ_DEBRIS;
 		case Layers::MOVING:
-			return inObject2 == Layers::NON_MOVING || inObject2 == Layers::MOVING || inObject2 == Layers::HQ_DEBRIS;
+			return inObject2 == Layers::NON_MOVING || inObject2 == Layers::MOVING || inObject2 == Layers::HQ_DEBRIS || inObject2 == Layers::SENSOR;
 		case Layers::HQ_DEBRIS:
 			return inObject2 == Layers::NON_MOVING || inObject2 == Layers::MOVING;
 		case Layers::LQ_DEBRIS:
 			return inObject2 == Layers::NON_MOVING;
+		case Layers::SENSOR:
+			return inObject2 == Layers::MOVING;
 		default:
 			JPH_ASSERT(false);
 			return false;
@@ -57,7 +60,8 @@ namespace BroadPhaseLayers
 	static constexpr BroadPhaseLayer MOVING(1); 
 	static constexpr BroadPhaseLayer LQ_DEBRIS(2);
 	static constexpr BroadPhaseLayer UNUSED(3);
-	static constexpr uint NUM_LAYERS(4);
+	static constexpr BroadPhaseLayer SENSOR(4);
+	static constexpr uint NUM_LAYERS(5);
 };
 
 /// BroadPhaseLayerInterface implementation
@@ -76,6 +80,7 @@ public:
 		mObjectToBroadPhase[Layers::MOVING] = BroadPhaseLayers::MOVING;
 		mObjectToBroadPhase[Layers::HQ_DEBRIS] = BroadPhaseLayers::MOVING; // HQ_DEBRIS is also in the MOVING layer as an example on how to map multiple layers onto the same broadphase layer
 		mObjectToBroadPhase[Layers::LQ_DEBRIS] = BroadPhaseLayers::LQ_DEBRIS;
+		mObjectToBroadPhase[Layers::SENSOR] = BroadPhaseLayers::SENSOR;
 	}
 
 	virtual uint					GetNumBroadPhaseLayers() const override
@@ -98,6 +103,7 @@ public:
 		case (BroadPhaseLayer::Type)BroadPhaseLayers::MOVING:		return "MOVING";
 		case (BroadPhaseLayer::Type)BroadPhaseLayers::LQ_DEBRIS:	return "LQ_DEBRIS";
 		case (BroadPhaseLayer::Type)BroadPhaseLayers::UNUSED:		return "UNUSED";
+		case (BroadPhaseLayer::Type)BroadPhaseLayers::SENSOR:		return "SENSOR";
 		default:													JPH_ASSERT(false); return "INVALID";
 		}
 	}
@@ -119,15 +125,17 @@ public:
 			return inLayer2 == BroadPhaseLayers::MOVING;
 		case Layers::MOVING:
 		case Layers::HQ_DEBRIS:
-			return inLayer2 == BroadPhaseLayers::NON_MOVING || inLayer2 == BroadPhaseLayers::MOVING;
+			return inLayer2 == BroadPhaseLayers::NON_MOVING || inLayer2 == BroadPhaseLayers::MOVING || inLayer2 == BroadPhaseLayers::SENSOR;
 		case Layers::LQ_DEBRIS:
 			return inLayer2 == BroadPhaseLayers::NON_MOVING;
+		case Layers::SENSOR:
+			return inLayer2 == BroadPhaseLayers::MOVING;
 		case Layers::UNUSED1:
 		case Layers::UNUSED2:
 		case Layers::UNUSED3:
 		case Layers::UNUSED4:
 		case Layers::UNUSED5:
-			return false;			
+			return false;
 		default:
 			JPH_ASSERT(false);
 			return false;


### PR DESCRIPTION
I figured I could ask this question in the form of a PR. :)

I noticed that sensors are unable to detect other sensors overlapping with them. I realize this is probably an unusual thing to want to have, but it is none the less something that Godot offers, so I must try to implement it.

I dug through the code a bit and found the lines that I've removed in this PR. Removing them seems to unlock the ability to receive sensor-to-sensor contact reports.

Is there a particular reason why this should be there, considering that the existing filtering mechanisms, like `ObjectLayerPairFilter`, have the opportunity to filter out those collisions already?

Feel free to push back on this if it seems too niche of a use-case. It's a small enough change that I'd be happy to maintain it on my own fork, assuming it even makes sense to begin with.