### PR TITLE
Removed setting of MSVC runtime library when using DLL runtime

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -61,8 +61,6 @@ if (("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows" OR "${CMAKE_SYSTEM_NAME}" STREQUA
 	# Set runtime library
 	if (USE_STATIC_MSVC_RUNTIME_LIBRARY)
 		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-	else()
-		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 	endif()
 
 	# Set general compiler flags


### PR DESCRIPTION
This removes the redundant setting of `CMAKE_MSVC_RUNTIME_LIBRARY` when using the dynamically linked MSVC runtime, which allows the consuming project to set it instead, like when mixing debug and release runtimes.

Related to #494.