### PR TITLE
Add missing standard include

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -296,6 +296,7 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <sstream>
 #include <functional>
 #include <algorithm>
+#include <cstdint>
 JPH_SUPPRESS_WARNINGS_STD_END
 #include <limits.h>
 #include <float.h>


### PR DESCRIPTION
Jolt uses `std::uintX_t` types, which are defined in the [cstdint](https://en.cppreference.com/w/cpp/header/cstdint) header without including it.

This works on most platforms because this header is included by other standard includes (but we have no guarantee on that), and Jolt compilation recently failed on Linux Fedora because of a compiler update. (see https://github.com/SirLynix/xmake-repo/actions/runs/4817052207/jobs/8577304087 )

This commits fixes it (tested [here](https://github.com/SirLynix/xmake-repo/actions/runs/4817136733/jobs/8577484264) by [applying this commit as a patch](https://github.com/SirLynix/xmake-repo/pull/9/files#diff-df1ba7aad51e5146e071f1b2d7d74c0fc9f2a65cd972fa72d8c25277b976cd16R11)).

On a side note, I'm wondering about these includes:
```cpp
#include <limits.h>
#include <float.h>
#include <string.h>
```

is there a reason Jolt doesn't include the corresponding C++ headers?
```cpp
#include <climits>
#include <cfloat>
#include <cstring>
```