### PR TITLE
CharacterVirtual: Added missing delta time term in DetermineConstraints

### DIFF
--- a/Jolt/Physics/Character/CharacterVirtual.cpp
+++ b/Jolt/Physics/Character/CharacterVirtual.cpp
@@ -377,7 +377,7 @@ bool CharacterVirtual::GetFirstContactForSweep(RVec3Arg inPosition, Vec3Arg inDi
 	return true;
 }
 
-void CharacterVirtual::DetermineConstraints(TempContactList &inContacts, ConstraintList &outConstraints) const
+void CharacterVirtual::DetermineConstraints(TempContactList &inContacts, float inDeltaTime, ConstraintList &outConstraints) const
 {
 	for (Contact &c : inContacts)
 	{
@@ -385,7 +385,7 @@ void CharacterVirtual::DetermineConstraints(TempContactList &inContacts, Constra
 
 		// Penetrating contact: Add a contact velocity that pushes the character out at the desired speed
 		if (c.mDistance < 0.0f)
-			contact_velocity -= c.mContactNormal * c.mDistance * mPenetrationRecoverySpeed;
+			contact_velocity -= c.mContactNormal * c.mDistance * mPenetrationRecoverySpeed / inDeltaTime;
 
 		// Convert to a constraint
 		outConstraints.emplace_back();
@@ -869,7 +869,7 @@ void CharacterVirtual::UpdateSupportingContact(bool inSkipContactVelocityCheck, 
 		TempContactList contacts(mActiveContacts.begin(), mActiveContacts.end(), inAllocator);
 		ConstraintList constraints(inAllocator);
 		constraints.reserve(contacts.size() * 2);
-		DetermineConstraints(contacts, constraints);
+		DetermineConstraints(contacts, mLastDeltaTime, constraints);
 
 		// Solve the displacement using these constraints, this is used to check if we didn't move at all because we are supported
 		Vec3 displacement;
@@ -923,7 +923,7 @@ void CharacterVirtual::MoveShape(RVec3 &ioPosition, Vec3Arg inVelocity, float in
 		// Convert contacts into constraints
 		ConstraintList constraints(inAllocator);
 		constraints.reserve(contacts.size() * 2);
-		DetermineConstraints(contacts, constraints);
+		DetermineConstraints(contacts, inDeltaTime, constraints);
 
 #ifdef JPH_DEBUG_RENDERER
 		bool draw_constraints = inDrawConstraints && iteration == 0;

--- a/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Jolt/Physics/Character/CharacterVirtual.h
@@ -393,7 +393,7 @@ private:
 	void								RemoveConflictingContacts(TempContactList &ioContacts, IgnoredContactList &outIgnoredContacts) const;
 
 	// Convert contacts into constraints. The character is assumed to start at the origin and the constraints are planes around the origin that confine the movement of the character.
-	void								DetermineConstraints(TempContactList &inContacts, ConstraintList &outConstraints) const;
+	void								DetermineConstraints(TempContactList &inContacts, float inDeltaTime, ConstraintList &outConstraints) const;
 
 	// Use the constraints to solve the displacement of the character. This will slide the character on the planes around the origin for as far as possible.
 	void								SolveConstraints(Vec3Arg inVelocity, float inDeltaTime, float inTimeRemaining, ConstraintList &ioConstraints, IgnoredContactList &ioIgnoredContacts, float &outTimeSimulated, Vec3 &outDisplacement, TempAllocator &inAllocator

--- a/Samples/Tests/Character/CharacterBaseTest.cpp
+++ b/Samples/Tests/Character/CharacterBaseTest.cpp
@@ -30,6 +30,7 @@ const char *CharacterBaseTest::sScenes[] =
 	"PerlinMesh",
 	"PerlinHeightField",
 	"ObstacleCourse",
+	"InitiallyIntersecting",
 	"Terrain1",
 	"Terrain2",
 };
@@ -91,6 +92,21 @@ void CharacterBaseTest::Initialize()
 	{
 		// Default terrain
 		CreateHeightFieldTerrain();
+	}
+	else if (strcmp(sSceneName, "InitiallyIntersecting") == 0)
+	{
+		CreateFloor();
+
+		// Create a grid of boxes that are initially intersecting with the character
+		RefConst<Shape> box = new BoxShape(Vec3(0.1f, 0.1f, 0.1f));
+		BodyCreationSettings settings(box, RVec3(0, 0.5f, 0), Quat::sIdentity(), EMotionType::Static, Layers::NON_MOVING);
+		for (int x = 0; x < 4; ++x)
+			for (int y = 0; y <= 10; ++y)
+				for (int z = 0; z <= 10; ++z)
+				{
+					settings.mPosition = RVec3(-0.5f + 0.1f * x, 0.1f + 0.1f * y, -0.5f + 0.1f * z);
+					mBodyInterface->CreateAndAddBody(settings, EActivation::DontActivate);
+				}
 	}
 	else if (strcmp(sSceneName, "ObstacleCourse") == 0)
 	{

--- a/Samples/Tests/Character/CharacterBaseTest.cpp
+++ b/Samples/Tests/Character/CharacterBaseTest.cpp
@@ -586,6 +586,7 @@ void CharacterBaseTest::CreateSettingsMenu(DebugUI *inUI, UIElement *inSubMenu)
 		inUI->CreateCheckBox(movement_settings, "Control Movement During Jump", sControlMovementDuringJump, [](UICheckBox::EState inState) { sControlMovementDuringJump = inState == UICheckBox::STATE_CHECKED; });
 		inUI->CreateSlider(movement_settings, "Character Speed", sCharacterSpeed, 0.1f, 10.0f, 0.1f, [](float inValue) { sCharacterSpeed = inValue; });
 		inUI->CreateSlider(movement_settings, "Character Jump Speed", sJumpSpeed, 0.1f, 10.0f, 0.1f, [](float inValue) { sJumpSpeed = inValue; });
+		AddCharacterMovementSettings(inUI, movement_settings);
 		inUI->ShowMenu(movement_settings);
 	});
 

--- a/Samples/Tests/Character/CharacterBaseTest.h
+++ b/Samples/Tests/Character/CharacterBaseTest.h
@@ -99,6 +99,8 @@ private:
 	BodyID					mRotatingBody;
 	BodyID					mRotatingWallBody;
 	BodyID					mRotatingAndTranslatingBody;
-	BodyID					mVerticallyMovingBody;
+	BodyID					mSmoothVerticallyMovingBody;
+	BodyID					mReversingVerticallyMovingBody;
+	float					mReversingVerticallyMovingVelocity = 1.0f;
 	BodyID					mHorizontallyMovingBody;
 };

--- a/Samples/Tests/Character/CharacterBaseTest.h
+++ b/Samples/Tests/Character/CharacterBaseTest.h
@@ -46,6 +46,9 @@ protected:
 	// Draw the character state
 	void					DrawCharacterState(const CharacterBase *inCharacter, RMat44Arg inCharacterTransform, Vec3Arg inCharacterVelocity);
 
+	// Add character movement settings
+	virtual void			AddCharacterMovementSettings(DebugUI* inUI, UIElement* inSubMenu) { /* Nothing by default */ }
+
 	// Add test configuration settings
 	virtual void			AddConfigurationSettings(DebugUI *inUI, UIElement *inSubMenu) { /* Nothing by default */ }
 

--- a/Samples/Tests/Character/CharacterVirtualTest.cpp
+++ b/Samples/Tests/Character/CharacterVirtualTest.cpp
@@ -53,6 +53,16 @@ void CharacterVirtualTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 			mDebugRenderer->DrawCapsule(com, 0.5f * cCharacterHeightCrouching, cCharacterRadiusCrouching + mCharacter->GetCharacterPadding(), Color::sGrey, DebugRenderer::ECastShadow::Off, DebugRenderer::EDrawMode::Wireframe);
 	}
 
+	// Draw state of character
+	DrawCharacterState(mCharacter, mCharacter->GetWorldTransform(), mCharacterVelocity);
+
+	// Draw labels on ramp blocks
+	for (size_t i = 0; i < mRampBlocks.size(); ++i)
+		mDebugRenderer->DrawText3D(mBodyInterface->GetPosition(mRampBlocks[i]), StringFormat("PushesPlayer: %s\nPushable: %s", (i & 1) != 0? "True" : "False", (i & 2) != 0? "True" : "False"), Color::sWhite, 0.25f);
+}
+
+void CharacterVirtualTest::PostPhysicsUpdate(float inDeltaTime)
+{
 	// Remember old position
 	RVec3 old_position = mCharacter->GetPosition();
 
@@ -68,7 +78,7 @@ void CharacterVirtualTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 		update_settings.mWalkStairsStepUp = mCharacter->GetUp() * update_settings.mWalkStairsStepUp.Length();
 
 	// Update the character position
-	mCharacter->ExtendedUpdate(inParams.mDeltaTime,
+	mCharacter->ExtendedUpdate(inDeltaTime,
 		-mCharacter->GetUp() * mPhysicsSystem->GetGravity().Length(),
 		update_settings,
 		mPhysicsSystem->GetDefaultBroadPhaseLayerFilter(Layers::MOVING),
@@ -79,14 +89,7 @@ void CharacterVirtualTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 
 	// Calculate effective velocity
 	RVec3 new_position = mCharacter->GetPosition();
-	Vec3 velocity = Vec3(new_position - old_position) / inParams.mDeltaTime;
-
-	// Draw state of character
-	DrawCharacterState(mCharacter, mCharacter->GetWorldTransform(), velocity);
-
-	// Draw labels on ramp blocks
-	for (size_t i = 0; i < mRampBlocks.size(); ++i)
-		mDebugRenderer->DrawText3D(mBodyInterface->GetPosition(mRampBlocks[i]), StringFormat("PushesPlayer: %s\nPushable: %s", (i & 1) != 0? "True" : "False", (i & 2) != 0? "True" : "False"), Color::sWhite, 0.25f);
+	mCharacterVelocity = Vec3(new_position - old_position) / inDeltaTime;
 }
 
 void CharacterVirtualTest::HandleInput(Vec3Arg inMovementDirection, bool inJump, bool inSwitchStance, float inDeltaTime)

--- a/Samples/Tests/Character/CharacterVirtualTest.cpp
+++ b/Samples/Tests/Character/CharacterVirtualTest.cpp
@@ -121,8 +121,10 @@ void CharacterVirtualTest::HandleInput(Vec3Arg inMovementDirection, bool inJump,
 	Vec3 ground_velocity = mCharacter->GetGroundVelocity();
 	Vec3 new_velocity;
 	bool moving_towards_ground = (current_vertical_velocity.GetY() - ground_velocity.GetY()) < 0.1f;
-	if (mCharacter->GetGroundState() == CharacterVirtual::EGroundState::OnGround // If on ground
-		&& (!sEnableCharacterInertia || moving_towards_ground)) // And not moving away from ground
+	if (mCharacter->GetGroundState() == CharacterVirtual::EGroundState::OnGround	// If on ground
+		&& (sEnableCharacterInertia?
+			moving_towards_ground													// Inertia enabled: And not moving away from ground
+			: !mCharacter->IsSlopeTooSteep(mCharacter->GetGroundNormal())))			// Inertia disabled: And not on a slope that is too steep
 	{
 		// Assume velocity of ground when on ground
 		new_velocity = ground_velocity;

--- a/Samples/Tests/Character/CharacterVirtualTest.h
+++ b/Samples/Tests/Character/CharacterVirtualTest.h
@@ -19,6 +19,9 @@ public:
 	// Update the test, called before the physics update
 	virtual void			PrePhysicsUpdate(const PreUpdateParams &inParams) override;
 
+	// Update the test, called after the physics update
+	virtual void			PostPhysicsUpdate(float inDeltaTime) override;
+
 	// Saving / restoring state for replay
 	virtual void			SaveState(StateRecorder &inStream) const override;
 	virtual void			RestoreState(StateRecorder &inStream) override;
@@ -63,4 +66,7 @@ private:
 
 	// True when the player is pressing movement controls
 	bool					mAllowSliding = false;
+
+	// Measured character velocity
+	Vec3					mCharacterVelocity = Vec3::sZero();
 };

--- a/Samples/Tests/Character/CharacterVirtualTest.h
+++ b/Samples/Tests/Character/CharacterVirtualTest.h
@@ -19,9 +19,6 @@ public:
 	// Update the test, called before the physics update
 	virtual void			PrePhysicsUpdate(const PreUpdateParams &inParams) override;
 
-	// Update the test, called after the physics update
-	virtual void			PostPhysicsUpdate(float inDeltaTime) override;
-
 	// Saving / restoring state for replay
 	virtual void			SaveState(StateRecorder &inStream) const override;
 	virtual void			RestoreState(StateRecorder &inStream) override;
@@ -72,7 +69,4 @@ private:
 
 	// True when the player is pressing movement controls
 	bool					mAllowSliding = false;
-
-	// Measured character velocity
-	Vec3					mCharacterVelocity = Vec3::sZero();
 };

--- a/Samples/Tests/Character/CharacterVirtualTest.h
+++ b/Samples/Tests/Character/CharacterVirtualTest.h
@@ -42,11 +42,17 @@ protected:
 	// Handle user input to the character
 	virtual void			HandleInput(Vec3Arg inMovementDirection, bool inJump, bool inSwitchStance, float inDeltaTime) override;
 
+	// Add character movement settings
+	virtual void			AddCharacterMovementSettings(DebugUI* inUI, UIElement* inSubMenu) override;
+
 	// Add test configuration settings
 	virtual void			AddConfigurationSettings(DebugUI *inUI, UIElement *inSubMenu) override;
 
 private:
-	// Test settings
+	// Character movement settings
+	static inline bool		sEnableCharacterInertia = true;
+
+	// Test configuration settings
 	static inline EBackFaceMode sBackFaceMode = EBackFaceMode::CollideWithBackFaces;
 	static inline float		sUpRotationX = 0;
 	static inline float		sUpRotationZ = 0;	

--- a/UnitTests/Physics/CharacterVirtualTests.cpp
+++ b/UnitTests/Physics/CharacterVirtualTests.cpp
@@ -198,7 +198,7 @@ TEST_SUITE("CharacterVirtualTests")
 			// After 1 step we should be on the slope
 			character.Step();
 			CHECK(character.mCharacter->GetGroundState() == expected_ground_state);
-			CHECK_APPROX_EQUAL(character.mCharacter->GetPosition(), position_after_1_step);
+			CHECK_APPROX_EQUAL(character.mCharacter->GetPosition(), position_after_1_step, 2.0e-6f);
 
 			// Cancel any velocity to make the calculation below easier (otherwise we have to take gravity for 1 time step into account)
 			character.mCharacter->SetLinearVelocity(Vec3::sZero());
@@ -366,7 +366,7 @@ TEST_SUITE("CharacterVirtualTests")
 			// We should have gotten stuck at the start of the stairs (can't move up)
 			CHECK(character.mCharacter->GetGroundState() == CharacterBase::EGroundState::OnGround);
 			float radius_and_padding = character.mRadiusStanding + character.mCharacterSettings.mCharacterPadding;
-			CHECK_APPROX_EQUAL(character.mCharacter->GetPosition(), RVec3(0, 0, -radius_and_padding), 1.0e-2f);
+			CHECK_APPROX_EQUAL(character.mCharacter->GetPosition(), RVec3(0, 0, -radius_and_padding), 1.1e-2f);
 
 			// Enable stair walking
 			character.mUpdateSettings.mWalkStairsStepUp = Vec3(0, 0.4f, 0);


### PR DESCRIPTION
This was causing moving objects to push out characters at a lower speed than required. 

Should fix #530. 