### PR TITLE
Fixed warnings emitted by MSVC 14.36

### DIFF
--- a/Jolt/Core/Reference.h
+++ b/Jolt/Core/Reference.h
@@ -113,12 +113,10 @@ public:
 	inline Ref<T> &			operator = (Ref<T> &&inRHS) noexcept			{ if (mPtr != inRHS.mPtr) { Release(); mPtr = inRHS.mPtr; inRHS.mPtr = nullptr; } return *this; }
 						
 	/// Casting operators
-	inline					operator T * const () const						{ return mPtr; }
-	inline					operator T *()									{ return mPtr; }
+	inline					operator T *() const							{ return mPtr; }
 						
 	/// Access like a normal pointer
-	inline T * const 		operator -> () const							{ return mPtr; }
-	inline T *				operator -> ()									{ return mPtr; }
+	inline T * 				operator -> () const							{ return mPtr; }
 	inline T &				operator * () const								{ return *mPtr; }
 
 	/// Comparison
@@ -129,7 +127,6 @@ public:
 
 	/// Get pointer
 	inline T * 				GetPtr() const									{ return mPtr; }
-	inline T *				GetPtr()										{ return mPtr; }
 
 	/// INTERNAL HELPER FUNCTION USED BY SERIALIZATION
 	void **					InternalGetPointer()							{ return reinterpret_cast<void **>(&mPtr); }


### PR DESCRIPTION
Visual Studio 17.6 was released yesterday and brought with it the MSVC 14.36 toolchain, which seems to trigger a new warning in Jolt.

Specifically it complains about `'const' qualifier on return type has no effect` for `operator T * const () const` and `T * const operator -> () const` in `Ref<T>`, which seems reasonable considering those `const` qualifiers only make the pointer `const` but not its pointee.

I couldn't quite grasp what the actual intent was with these operators. If the intent was to only allow `const` access to the pointee when using a `const Ref<T>` then fixing this would result in a breaking change.

I opted instead to remove the redundant non-`const` operators, since you can just as well return a non-`const` pointer member from a `const` method. This happens to also line up nicely with `RefConst<T>`.