### PR TITLE
Bugfix in speculative contact handling

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -1,8 +1,8 @@
 name: Determinism Check
 
 env:
-    CONVEX_VS_MESH_HASH: '0x3c55fb5709fda28c'
-    RAGDOLL_HASH: '0x5f3b8e4a9e166453'
+    CONVEX_VS_MESH_HASH: '0x219df2ceee6baff2'
+    RAGDOLL_HASH: '0x9bace3bd537e6759'
 
 on:
   push:

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -96,7 +96,9 @@ JPH_INLINE void ContactConstraintManager::WorldContactPoint::CalculateFrictionAn
 		if (normal_velocity < -speculative_contact_velocity_bias)
 			normal_velocity_bias = inCombinedRestitution * normal_velocity;
 		else
-			normal_velocity_bias = 0.0f;
+			// In this case we have predicted that we don't hit the other object, but if we do (due to other constraints changing velocities)
+			// the speculative contact will prevent penetration but will not apply restitution leading to another artifact.
+			normal_velocity_bias = speculative_contact_velocity_bias;
 	}
 	else
 	{


### PR DESCRIPTION
When an object wasn't moving fast enough to trigger restitution for a speculative contact, the contact was enforced at the current position rather than at the distance of the speculative contact

Should help fix godot-jolt/godot-jolt#374