### PR TITLE
fix 'unused parameter' compiler warnings (got under GCC 11, linux)

### DIFF
--- a/Jolt/Core/Memory.h
+++ b/Jolt/Core/Memory.h
@@ -32,9 +32,9 @@ JPH_EXPORT void RegisterDefaultAllocator();
 	JPH_INLINE void *operator new[] (size_t inCount)											{ return JPH::Allocate(inCount); } \
 	JPH_INLINE void operator delete[] (void *inPointer) noexcept								{ JPH::Free(inPointer); } \
 	JPH_INLINE void *operator new (size_t inCount, std::align_val_t inAlignment)				{ return JPH::AlignedAllocate(inCount, static_cast<size_t>(inAlignment)); } \
-	JPH_INLINE void operator delete (void *inPointer, std::align_val_t inAlignment) noexcept	{ JPH::AlignedFree(inPointer); } \
+	JPH_INLINE void operator delete (void *inPointer, [[maybe_unused]] std::align_val_t inAlignment) noexcept	{ JPH::AlignedFree(inPointer); } \
 	JPH_INLINE void *operator new[] (size_t inCount, std::align_val_t inAlignment)				{ return JPH::AlignedAllocate(inCount, static_cast<size_t>(inAlignment)); } \
-	JPH_INLINE void operator delete[] (void *inPointer, std::align_val_t inAlignment) noexcept	{ JPH::AlignedFree(inPointer); }
+	JPH_INLINE void operator delete[] (void *inPointer, [[maybe_unused]] std::align_val_t inAlignment) noexcept	{ JPH::AlignedFree(inPointer); }
 
 #else
 

--- a/Jolt/Core/RTTI.h
+++ b/Jolt/Core/RTTI.h
@@ -192,7 +192,7 @@ protected:
 public:																												\
 	JPH_OVERRIDE_NEW_DELETE																							\
 	friend linkage RTTI *		GetRTTIOfType(class_name *);														\
-	friend inline const RTTI *	GetRTTI(const class_name *inObject) { return GetRTTIOfType((class_name *)nullptr); }\
+	friend inline const RTTI *	GetRTTI([[maybe_unused]] const class_name *inObject) { return GetRTTIOfType((class_name *)nullptr); }\
 	static void					sCreateRTTI(RTTI &inRTTI);															\
 
 // JPH_IMPLEMENT_RTTI_NON_VIRTUAL

--- a/Jolt/Core/TempAllocator.h
+++ b/Jolt/Core/TempAllocator.h
@@ -106,7 +106,7 @@ public:
 	}
 
 	// See: TempAllocator
-	virtual void					Free(void *inAddress, uint inSize) override
+	virtual void					Free(void *inAddress, [[maybe_unused]] uint inSize) override
 	{
 		AlignedFree(inAddress);
 	}

--- a/Jolt/Physics/Body/BodyFilter.h
+++ b/Jolt/Physics/Body/BodyFilter.h
@@ -19,13 +19,13 @@ public:
 	virtual					~BodyFilter() = default;
 
 	/// Filter function. Returns true if we should collide with inBodyID
-	virtual bool			ShouldCollide(const BodyID &inBodyID) const
+	virtual bool			ShouldCollide([[maybe_unused]] const BodyID &inBodyID) const
 	{
 		return true;
 	}
 
 	/// Filter function. Returns true if we should collide with inBody (this is called after the body is locked and makes it possible to filter based on body members)
-	virtual bool			ShouldCollideLocked(const Body &inBody) const
+	virtual bool			ShouldCollideLocked([[maybe_unused]] const Body &inBody) const
 	{
 		return true;
 	}
@@ -92,7 +92,7 @@ public:
 	virtual					~BodyDrawFilter() = default;
 
 	/// Filter function. Returns true if inBody should be rendered
-	virtual bool			ShouldDraw(const Body& inBody) const
+	virtual bool			ShouldDraw([[maybe_unused]] const Body& inBody) const
 	{
 		return true;
 	}

--- a/Jolt/Physics/Body/BodyLockInterface.h
+++ b/Jolt/Physics/Body/BodyLockInterface.h
@@ -60,17 +60,17 @@ public:
 	using BodyLockInterface::BodyLockInterface;
 
 	///@name Locking functions
-	virtual SharedMutex *		LockRead(const BodyID &inBodyID) const override		{ return nullptr; }
-	virtual void				UnlockRead(SharedMutex *inMutex) const override		{ /* Nothing to do */ }
-	virtual SharedMutex *		LockWrite(const BodyID &inBodyID) const override	{ return nullptr; }
-	virtual void				UnlockWrite(SharedMutex *inMutex) const override	{ /* Nothing to do */ }
+	virtual SharedMutex *		LockRead([[maybe_unused]] const BodyID &inBodyID) const override		{ return nullptr; }
+	virtual void				UnlockRead([[maybe_unused]] SharedMutex *inMutex) const override		{ /* Nothing to do */ }
+	virtual SharedMutex *		LockWrite([[maybe_unused]] const BodyID &inBodyID) const override	{ return nullptr; }
+	virtual void				UnlockWrite([[maybe_unused]] SharedMutex *inMutex) const override	{ /* Nothing to do */ }
 
 	///@name Batch locking functions
-	virtual MutexMask			GetMutexMask(const BodyID *inBodies, int inNumber) const override { return 0; }
-	virtual void				LockRead(MutexMask inMutexMask) const override		{ /* Nothing to do */ }
-	virtual void				UnlockRead(MutexMask inMutexMask) const override	{ /* Nothing to do */ }
-	virtual void				LockWrite(MutexMask inMutexMask) const override		{ /* Nothing to do */ }
-	virtual void				UnlockWrite(MutexMask inMutexMask) const override	{ /* Nothing to do */ }
+	virtual MutexMask			GetMutexMask([[maybe_unused]] const BodyID *inBodies, [[maybe_unused]] int inNumber) const override { return 0; }
+	virtual void				LockRead([[maybe_unused]] MutexMask inMutexMask) const override		{ /* Nothing to do */ }
+	virtual void				UnlockRead([[maybe_unused]] MutexMask inMutexMask) const override	{ /* Nothing to do */ }
+	virtual void				LockWrite([[maybe_unused]] MutexMask inMutexMask) const override		{ /* Nothing to do */ }
+	virtual void				UnlockWrite([[maybe_unused]] MutexMask inMutexMask) const override	{ /* Nothing to do */ }
 };
 
 /// Implementation that uses the body manager to lock the correct mutex for a body

--- a/Jolt/Physics/Body/BodyLockInterface.h
+++ b/Jolt/Physics/Body/BodyLockInterface.h
@@ -60,8 +60,8 @@ public:
 	using BodyLockInterface::BodyLockInterface;
 
 	///@name Locking functions
-	virtual SharedMutex *		LockRead([[maybe_unused]] const BodyID &inBodyID) const override		{ return nullptr; }
-	virtual void				UnlockRead([[maybe_unused]] SharedMutex *inMutex) const override		{ /* Nothing to do */ }
+	virtual SharedMutex *		LockRead([[maybe_unused]] const BodyID &inBodyID) const override	{ return nullptr; }
+	virtual void				UnlockRead([[maybe_unused]] SharedMutex *inMutex) const override	{ /* Nothing to do */ }
 	virtual SharedMutex *		LockWrite([[maybe_unused]] const BodyID &inBodyID) const override	{ return nullptr; }
 	virtual void				UnlockWrite([[maybe_unused]] SharedMutex *inMutex) const override	{ /* Nothing to do */ }
 
@@ -69,7 +69,7 @@ public:
 	virtual MutexMask			GetMutexMask([[maybe_unused]] const BodyID *inBodies, [[maybe_unused]] int inNumber) const override { return 0; }
 	virtual void				LockRead([[maybe_unused]] MutexMask inMutexMask) const override		{ /* Nothing to do */ }
 	virtual void				UnlockRead([[maybe_unused]] MutexMask inMutexMask) const override	{ /* Nothing to do */ }
-	virtual void				LockWrite([[maybe_unused]] MutexMask inMutexMask) const override		{ /* Nothing to do */ }
+	virtual void				LockWrite([[maybe_unused]] MutexMask inMutexMask) const override	{ /* Nothing to do */ }
 	virtual void				UnlockWrite([[maybe_unused]] MutexMask inMutexMask) const override	{ /* Nothing to do */ }
 };
 

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
@@ -48,7 +48,7 @@ public:
 	virtual	UpdateState	UpdatePrepare()														{ return UpdateState(); }
 
 	/// Finalizing the update will quickly apply the changes
-	virtual void		UpdateFinalize([[maybe_unused]] const UpdateState &inUpdateState)					{ /* Optionally overridden by implementation */ }
+	virtual void		UpdateFinalize([[maybe_unused]] const UpdateState &inUpdateState)	{ /* Optionally overridden by implementation */ }
 
 	/// Must be called after UpdateFinalize to allow modifications to the broadphase
 	virtual void		UnlockModifications()												{ /* Optionally overridden by implementation */ }
@@ -59,7 +59,7 @@ public:
 	/// Prepare adding inNumber bodies at ioBodies to the broadphase, returns a handle that should be used in AddBodiesFinalize/Abort.
 	/// This can be done on a background thread without influencing the broadphase.
 	/// ioBodies may be shuffled around by this function and should be kept that way until AddBodiesFinalize/Abort is called.
-	virtual AddState	AddBodiesPrepare([[maybe_unused]] BodyID *ioBodies, [[maybe_unused]] int inNumber)					{ return nullptr; } // By default the broadphase doesn't support this
+	virtual AddState	AddBodiesPrepare([[maybe_unused]] BodyID *ioBodies, [[maybe_unused]] int inNumber) { return nullptr; } // By default the broadphase doesn't support this
 
 	/// Finalize adding bodies to the broadphase, supply the return value of AddBodiesPrepare in inAddState.
 	/// Please ensure that the ioBodies array passed to AddBodiesPrepare is unmodified and passed again to this function.

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhase.h
@@ -48,7 +48,7 @@ public:
 	virtual	UpdateState	UpdatePrepare()														{ return UpdateState(); }
 
 	/// Finalizing the update will quickly apply the changes
-	virtual void		UpdateFinalize(const UpdateState &inUpdateState)					{ /* Optionally overridden by implementation */ }
+	virtual void		UpdateFinalize([[maybe_unused]] const UpdateState &inUpdateState)					{ /* Optionally overridden by implementation */ }
 
 	/// Must be called after UpdateFinalize to allow modifications to the broadphase
 	virtual void		UnlockModifications()												{ /* Optionally overridden by implementation */ }
@@ -59,7 +59,7 @@ public:
 	/// Prepare adding inNumber bodies at ioBodies to the broadphase, returns a handle that should be used in AddBodiesFinalize/Abort.
 	/// This can be done on a background thread without influencing the broadphase.
 	/// ioBodies may be shuffled around by this function and should be kept that way until AddBodiesFinalize/Abort is called.
-	virtual AddState	AddBodiesPrepare(BodyID *ioBodies, int inNumber)					{ return nullptr; } // By default the broadphase doesn't support this
+	virtual AddState	AddBodiesPrepare([[maybe_unused]] BodyID *ioBodies, [[maybe_unused]] int inNumber)					{ return nullptr; } // By default the broadphase doesn't support this
 
 	/// Finalize adding bodies to the broadphase, supply the return value of AddBodiesPrepare in inAddState.
 	/// Please ensure that the ioBodies array passed to AddBodiesPrepare is unmodified and passed again to this function.
@@ -68,7 +68,7 @@ public:
 	/// Abort adding bodies to the broadphase, supply the return value of AddBodiesPrepare in inAddState.
 	/// This can be done on a background thread without influencing the broadphase.
 	/// Please ensure that the ioBodies array passed to AddBodiesPrepare is unmodified and passed again to this function.
-	virtual void		AddBodiesAbort(BodyID *ioBodies, int inNumber, AddState inAddState)	{ /* By default nothing needs to be done */ }
+	virtual void		AddBodiesAbort([[maybe_unused]] BodyID *ioBodies, [[maybe_unused]] int inNumber, [[maybe_unused]] AddState inAddState)	{ /* By default nothing needs to be done */ }
 
 	/// Remove inNumber bodies in ioBodies from the broadphase.
 	/// ioBodies may be shuffled around by this function.

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h
@@ -78,7 +78,7 @@ public:
 	virtual							~ObjectVsBroadPhaseLayerFilter() = default;
 
 	/// Returns true if an object layer should collide with a broadphase layer
-	virtual bool					ShouldCollide(ObjectLayer inLayer1, BroadPhaseLayer inLayer2) const
+	virtual bool					ShouldCollide([[maybe_unused]] ObjectLayer inLayer1, [[maybe_unused]] BroadPhaseLayer inLayer2) const
 	{
 		return true;
 	}
@@ -92,7 +92,7 @@ public:
 	virtual							~BroadPhaseLayerFilter() = default;
 
 	/// Function to filter out broadphase layers when doing collision query test (return true to allow testing against objects with this layer)
-	virtual bool					ShouldCollide(BroadPhaseLayer inLayer) const
+	virtual bool					ShouldCollide([[maybe_unused]] BroadPhaseLayer inLayer) const
 	{
 		return true;
 	}

--- a/Jolt/Physics/Collision/CollisionCollector.h
+++ b/Jolt/Physics/Collision/CollisionCollector.h
@@ -63,7 +63,7 @@ public:
 	/// When running a query through the NarrowPhaseQuery class, this will be called for every body that is potentially colliding.
 	/// It allows collecting additional information needed by the collision collector implementation from the body under lock protection 
 	/// before AddHit is called (e.g. the user data pointer or the velocity of the body).
-	virtual void			OnBody(const Body &inBody)						{ /* Collects nothing by default */ }
+	virtual void			OnBody([[maybe_unused]] const Body &inBody)						{ /* Collects nothing by default */ }
 
 	/// Set by the collision detection functions to the current TransformedShape that we're colliding against before calling the AddHit function
 	void					SetContext(const TransformedShape *inContext)	{ mContext = inContext; }

--- a/Jolt/Physics/Collision/CollisionCollector.h
+++ b/Jolt/Physics/Collision/CollisionCollector.h
@@ -63,7 +63,7 @@ public:
 	/// When running a query through the NarrowPhaseQuery class, this will be called for every body that is potentially colliding.
 	/// It allows collecting additional information needed by the collision collector implementation from the body under lock protection 
 	/// before AddHit is called (e.g. the user data pointer or the velocity of the body).
-	virtual void			OnBody([[maybe_unused]] const Body &inBody)						{ /* Collects nothing by default */ }
+	virtual void			OnBody([[maybe_unused]] const Body &inBody)		{ /* Collects nothing by default */ }
 
 	/// Set by the collision detection functions to the current TransformedShape that we're colliding against before calling the AddHit function
 	void					SetContext(const TransformedShape *inContext)	{ mContext = inContext; }

--- a/Jolt/Physics/Collision/ContactListener.h
+++ b/Jolt/Physics/Collision/ContactListener.h
@@ -78,7 +78,7 @@ public:
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
 	/// The order of body 1 and 2 is undefined, but when one of the two bodies is dynamic it will be body 1.
 	/// The collision result (inCollisionResult) is reported relative to inBaseOffset.
-	virtual ValidateResult	OnContactValidate(const Body &inBody1, const Body &inBody2, RVec3Arg inBaseOffset, const CollideShapeResult &inCollisionResult) { return ValidateResult::AcceptAllContactsForThisBodyPair; }
+	virtual ValidateResult	OnContactValidate([[maybe_unused]] const Body &inBody1, [[maybe_unused]] const Body &inBody2, [[maybe_unused]] RVec3Arg inBaseOffset, [[maybe_unused]] const CollideShapeResult &inCollisionResult) { return ValidateResult::AcceptAllContactsForThisBodyPair; }
 
 	/// Called whenever a new contact point is detected.
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
@@ -88,7 +88,7 @@ public:
 	/// When contacts are added, the constraint solver has not run yet, so the collision impulse is unknown at that point.
 	/// The velocities of inBody1 and inBody2 are the velocities before the contact has been resolved, so you can use this to
 	/// estimate the collision impulse to e.g. determine the volume of the impact sound to play (see: EstimateCollisionResponse).
-	virtual void			OnContactAdded(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) { /* Do nothing */ }
+	virtual void			OnContactAdded([[maybe_unused]] const Body &inBody1, [[maybe_unused]] const Body &inBody2, [[maybe_unused]] const ContactManifold &inManifold, [[maybe_unused]] ContactSettings &ioSettings) { /* Do nothing */ }
 
 	/// Called whenever a contact is detected that was also detected last update.
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
@@ -98,7 +98,7 @@ public:
 	/// system cannot detect this, so may send a 'contact persisted' callback even though the contact is now on a different child shape. You can
 	/// detect this by keeping the old shape (before adding/removing a part) around until the next PhysicsSystem::Update (when the OnContactPersisted
 	/// callbacks are triggered) and resolving the sub shape ID against both the old and new shape to see if they still refer to the same child shape.
-	virtual void			OnContactPersisted(const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &ioSettings) { /* Do nothing */ }
+	virtual void			OnContactPersisted([[maybe_unused]] const Body &inBody1, [[maybe_unused]] const Body &inBody2, [[maybe_unused]] const ContactManifold &inManifold, [[maybe_unused]] ContactSettings &ioSettings) { /* Do nothing */ }
 
 	/// Called whenever a contact was detected last update but is not detected anymore.
 	/// Note that this callback is called when all bodies are locked, so don't use any locking functions!
@@ -107,7 +107,7 @@ public:
 	/// The sub shape ID were created in the previous simulation step too, so if the structure of a shape changes (e.g. by adding/removing a child shape of a compound shape),
 	/// the sub shape ID may not be valid / may not point to the same sub shape anymore.
 	/// If you want to know if this is the last contact between the two bodies, use PhysicsSystem::WereBodiesInContact.
-	virtual void			OnContactRemoved(const SubShapeIDPair &inSubShapePair) { /* Do nothing */ }
+	virtual void			OnContactRemoved([[maybe_unused]] const SubShapeIDPair &inSubShapePair) { /* Do nothing */ }
 };
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Collision/ObjectLayer.h
+++ b/Jolt/Physics/Collision/ObjectLayer.h
@@ -31,7 +31,7 @@ public:
 	virtual					~ObjectLayerFilter() = default;
 
 	/// Function to filter out object layers when doing collision query test (return true to allow testing against objects with this layer)
-	virtual bool			ShouldCollide(ObjectLayer inLayer) const
+	virtual bool			ShouldCollide([[maybe_unused]] ObjectLayer inLayer) const
 	{
 		return true;
 	}
@@ -53,7 +53,7 @@ public:
 	virtual					~ObjectLayerPairFilter() = default;
 
 	/// Returns true if two layers can collide
-	virtual bool			ShouldCollide(ObjectLayer inLayer1, ObjectLayer inLayer2) const
+	virtual bool			ShouldCollide([[maybe_unused]] ObjectLayer inLayer1, [[maybe_unused]] ObjectLayer inLayer2) const
 	{
 		return true;
 	}

--- a/Jolt/Physics/Collision/Shape/Shape.h
+++ b/Jolt/Physics/Collision/Shape/Shape.h
@@ -241,10 +241,10 @@ public:
 	/// @param inCenterOfMassTransform Transform to transform outVertices with
 	/// @param inScale Scale of this shape
 	/// @param outVertices Resulting face. The returned face can be empty if the shape doesn't have polygons to return (e.g. because it's a sphere). The face will be returned in world space.
-	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const { /* Nothing */ }
+	virtual void					GetSupportingFace([[maybe_unused]] const SubShapeID &inSubShapeID, [[maybe_unused]] Vec3Arg inDirection, [[maybe_unused]] Vec3Arg inScale, [[maybe_unused]] Mat44Arg inCenterOfMassTransform, [[maybe_unused]] SupportingFace &outVertices) const { /* Nothing */ }
 
 	/// Get the user data of a particular sub shape ID
-	virtual uint64					GetSubShapeUserData(const SubShapeID &inSubShapeID) const			{ return mUserData; }
+	virtual uint64					GetSubShapeUserData([[maybe_unused]] const SubShapeID &inSubShapeID) const			{ return mUserData; }
 
 	/// Get the direct child sub shape and its transform for a sub shape ID.
 	/// @param inSubShapeID Sub shape ID that indicates the path to the leaf shape
@@ -276,10 +276,10 @@ public:
 	virtual void					Draw(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, Vec3Arg inScale, ColorArg inColor, bool inUseMaterialColors, bool inDrawWireframe) const = 0;
 
 	/// Draw the results of the GetSupportFunction with the convex radius added back on to show any errors introduced by this process (only relevant for convex shapes)
-	virtual void					DrawGetSupportFunction(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, Vec3Arg inScale, ColorArg inColor, bool inDrawSupportDirection) const { /* Only implemented for convex shapes */ }
+	virtual void					DrawGetSupportFunction([[maybe_unused]] DebugRenderer *inRenderer, [[maybe_unused]] RMat44Arg inCenterOfMassTransform, [[maybe_unused]] Vec3Arg inScale, [[maybe_unused]] ColorArg inColor, [[maybe_unused]] bool inDrawSupportDirection) const { /* Only implemented for convex shapes */ }
 
 	/// Draw the results of the GetSupportingFace function to show any errors introduced by this process (only relevant for convex shapes)
-	virtual void					DrawGetSupportingFace(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, Vec3Arg inScale) const { /* Only implemented for convex shapes */ }
+	virtual void					DrawGetSupportingFace([[maybe_unused]] DebugRenderer *inRenderer, [[maybe_unused]] RMat44Arg inCenterOfMassTransform, [[maybe_unused]] Vec3Arg inScale) const { /* Only implemented for convex shapes */ }
 #endif // JPH_DEBUG_RENDERER
 
 	/// Cast a ray against this shape, returns true if it finds a hit closer than ioHit.mFraction and updates that fraction. Otherwise ioHit is left untouched and the function returns false.
@@ -348,16 +348,16 @@ public:
 	static ShapeResult				sRestoreFromBinaryState(StreamIn &inStream);
 
 	/// Outputs the material references that this shape has to outMaterials.
-	virtual void					SaveMaterialState(PhysicsMaterialList &outMaterials) const			{ /* By default do nothing */ }
+	virtual void					SaveMaterialState([[maybe_unused]] PhysicsMaterialList &outMaterials) const			{ /* By default do nothing */ }
 
 	/// Restore the material references after calling sRestoreFromBinaryState. Note that the exact same materials need to be provided in the same order as returned by SaveMaterialState.
-	virtual void					RestoreMaterialState(const PhysicsMaterialRefC *inMaterials, uint inNumMaterials) { JPH_ASSERT(inNumMaterials == 0); }
+	virtual void					RestoreMaterialState([[maybe_unused]] const PhysicsMaterialRefC *inMaterials, uint inNumMaterials) { JPH_ASSERT(inNumMaterials == 0); }
 
 	/// Outputs the shape references that this shape has to outSubShapes.
-	virtual void					SaveSubShapeState(ShapeList &outSubShapes) const					{ /* By default do nothing */ }
+	virtual void					SaveSubShapeState([[maybe_unused]] ShapeList &outSubShapes) const					{ /* By default do nothing */ }
 
 	/// Restore the shape references after calling sRestoreFromBinaryState. Note that the exact same shapes need to be provided in the same order as returned by SaveSubShapeState.
-	virtual void					RestoreSubShapeState(const ShapeRefC *inSubShapes, uint inNumShapes) { JPH_ASSERT(inNumShapes == 0); }
+	virtual void					RestoreSubShapeState([[maybe_unused]] const ShapeRefC *inSubShapes, uint inNumShapes) { JPH_ASSERT(inNumShapes == 0); }
 
 	using ShapeToIDMap = UnorderedMap<const Shape *, uint32>;
 	using MaterialToIDMap = UnorderedMap<const PhysicsMaterial *, uint32>;

--- a/Jolt/Physics/Collision/Shape/SphereShape.h
+++ b/Jolt/Physics/Collision/Shape/SphereShape.h
@@ -60,7 +60,7 @@ public:
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
 	// See Shape::GetSupportingFace
-	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override { /* Hit is always a single point, no point in returning anything */ }
+	virtual void			GetSupportingFace([[maybe_unused]] const SubShapeID &inSubShapeID, [[maybe_unused]] Vec3Arg inDirection, [[maybe_unused]] Vec3Arg inScale, [[maybe_unused]] Mat44Arg inCenterOfMassTransform, [[maybe_unused]] SupportingFace &outVertices) const override { /* Hit is always a single point, no point in returning anything */ }
 
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;

--- a/Jolt/Physics/Collision/ShapeFilter.h
+++ b/Jolt/Physics/Collision/ShapeFilter.h
@@ -23,7 +23,7 @@ public:
 	/// This overload is called when the query doesn't have a source shape (e.g. ray cast / collide point)
 	/// @param inShape2 Shape we're colliding against
 	/// @param inSubShapeIDOfShape2 The sub shape ID that will lead from the root shape to inShape2 (i.e. the shape of mBodyID2)
-	virtual bool			ShouldCollide(const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const
+	virtual bool			ShouldCollide([[maybe_unused]] const Shape *inShape2, [[maybe_unused]] const SubShapeID &inSubShapeIDOfShape2) const
 	{
 		return true;
 	}
@@ -36,7 +36,7 @@ public:
 	/// @param inSubShapeIDOfShape1 The sub shape ID that will lead from the root shape to inShape1 (i.e. the shape that is used to collide or cast against shape 2)
 	/// @param inShape2 2nd shape that is colliding
 	/// @param inSubShapeIDOfShape2 The sub shape ID that will lead from the root shape to inShape2 (i.e. the shape of mBodyID2)
-	virtual bool			ShouldCollide(const Shape *inShape1, const SubShapeID &inSubShapeIDOfShape1, const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const
+	virtual bool			ShouldCollide([[maybe_unused]] const Shape *inShape1, [[maybe_unused]] const SubShapeID &inSubShapeIDOfShape1, [[maybe_unused]] const Shape *inShape2, [[maybe_unused]] const SubShapeID &inSubShapeIDOfShape2) const
 	{
 		return true;
 	}

--- a/Jolt/Physics/Constraints/Constraint.h
+++ b/Jolt/Physics/Constraints/Constraint.h
@@ -166,8 +166,8 @@ public:
 #ifdef JPH_DEBUG_RENDERER
 	// Drawing interface
 	virtual void				DrawConstraint(DebugRenderer *inRenderer) const = 0;
-	virtual void				DrawConstraintLimits(DebugRenderer *inRenderer) const { }
-	virtual void				DrawConstraintReferenceFrame(DebugRenderer *inRenderer) const { }
+	virtual void				DrawConstraintLimits([[maybe_unused]] DebugRenderer *inRenderer) const { }
+	virtual void				DrawConstraintReferenceFrame([[maybe_unused]] DebugRenderer *inRenderer) const { }
 
 	/// Size of constraint when drawing it through the debug renderer
 	float						GetDrawConstraintSize() const				{ return mDrawConstraintSize; }


### PR DESCRIPTION
now using C++17 [[maybe_unused]]