### PR TITLE
Added more bitwise operators and an invalid value to EAllowedDOFs

### DIFF
--- a/Jolt/Physics/Body/AllowedDOFs.h
+++ b/Jolt/Physics/Body/AllowedDOFs.h
@@ -45,21 +45,21 @@ constexpr EAllowedDOFs operator ~ (EAllowedDOFs inAllowedDOFs)
 }
 
 /// Bitwise OR assignment operator for EAllowedDOFs
-constexpr EAllowedDOFs operator |= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+constexpr EAllowedDOFs & operator |= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
 {
 	ioLHS = ioLHS | inRHS;
 	return ioLHS;
 }
 
 /// Bitwise AND assignment operator for EAllowedDOFs
-constexpr EAllowedDOFs operator &= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+constexpr EAllowedDOFs & operator &= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
 {
 	ioLHS = ioLHS & inRHS;
 	return ioLHS;
 }
 
 /// Bitwise XOR assignment operator for EAllowedDOFs
-constexpr EAllowedDOFs operator ^= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+constexpr EAllowedDOFs & operator ^= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
 {
 	ioLHS = ioLHS ^ inRHS;
 	return ioLHS;

--- a/Jolt/Physics/Body/AllowedDOFs.h
+++ b/Jolt/Physics/Body/AllowedDOFs.h
@@ -9,6 +9,7 @@ JPH_NAMESPACE_BEGIN
 /// Enum used in BodyCreationSettings and MotionProperties to indicate which degrees of freedom a body has
 enum class EAllowedDOFs : uint8
 {
+	None				= 0b000000,									///< No degrees of freedom are allowed. Note that this is not valid and will crash. Use a static body instead.
 	All					= 0b111111,									///< All degrees of freedom are allowed
 	TranslationX		= 0b000001,									///< Body cannot move in world space X axis
 	TranslationY		= 0b000010,									///< Body cannot move in world space Y axis
@@ -20,15 +21,48 @@ enum class EAllowedDOFs : uint8
 };
 
 /// Bitwise OR operator for EAllowedDOFs
-inline EAllowedDOFs operator | (EAllowedDOFs inLHS, EAllowedDOFs inRHS)
+constexpr EAllowedDOFs operator | (EAllowedDOFs inLHS, EAllowedDOFs inRHS)
 {
 	return EAllowedDOFs(uint8(inLHS) | uint8(inRHS));
 }
 
 /// Bitwise AND operator for EAllowedDOFs
-inline EAllowedDOFs operator & (EAllowedDOFs inLHS, EAllowedDOFs inRHS)
+constexpr EAllowedDOFs operator & (EAllowedDOFs inLHS, EAllowedDOFs inRHS)
 {
 	return EAllowedDOFs(uint8(inLHS) & uint8(inRHS));
+}
+
+/// Bitwise XOR operator for EAllowedDOFs
+constexpr EAllowedDOFs operator ^ (EAllowedDOFs inLHS, EAllowedDOFs inRHS)
+{
+	return EAllowedDOFs(uint8(inLHS) ^ uint8(inRHS));
+}
+
+/// Bitwise NOT operator for EAllowedDOFs
+constexpr EAllowedDOFs operator ~ (EAllowedDOFs inAllowedDOFs)
+{
+	return EAllowedDOFs(~uint8(inAllowedDOFs));
+}
+
+/// Bitwise OR assignment operator for EAllowedDOFs
+constexpr EAllowedDOFs operator |= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+{
+	ioLHS = ioLHS | inRHS;
+	return ioLHS;
+}
+
+/// Bitwise AND assignment operator for EAllowedDOFs
+constexpr EAllowedDOFs operator &= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+{
+	ioLHS = ioLHS & inRHS;
+	return ioLHS;
+}
+
+/// Bitwise XOR assignment operator for EAllowedDOFs
+constexpr EAllowedDOFs operator ^= (EAllowedDOFs &ioLHS, EAllowedDOFs inRHS)
+{
+	ioLHS = ioLHS ^ inRHS;
+	return ioLHS;
 }
 
 JPH_NAMESPACE_END


### PR DESCRIPTION
This adds XOR and NOT bitwise operators to `EAllowedDOFs`, as well as assignment operators for all the bitwise operations. It also changes the operators to be `constexpr` (which implies `inline`) to allow them to be used in `constexpr` expressions.

I also added a `None` value to the enum, to make certain bitwise operations cleaner. I'm not sure how you feel about this one, since it does technically make it a little bit easier to shoot yourself in the foot by locking all the translation axes, but seeing as how I managed to shoot myself in the foot in this exact manner from just thinking that you might have left this out by mistake then maybe it's better to have it be there with an appropriate comment instead.