### PR TITLE
Changed IndexedTriangle::IsDegenerate to include slivers

### DIFF
--- a/Jolt/Geometry/IndexedTriangle.h
+++ b/Jolt/Geometry/IndexedTriangle.h
@@ -41,9 +41,13 @@ public:
 	}
 
 	/// Check if triangle is degenerate
-	bool			IsDegenerate() const
+	bool			IsDegenerate(const VertexList &inVertices) const
 	{
-		return mIdx[0] == mIdx[1] || mIdx[1] == mIdx[2] || mIdx[2] == mIdx[0];
+		Vec3 v0(inVertices[mIdx[0]]);
+		Vec3 v1(inVertices[mIdx[1]]);
+		Vec3 v2(inVertices[mIdx[2]]);
+
+		return (v1 - v0).Cross(v2 - v0).IsNearZero();
 	}
 
 	/// Rotate the vertices so that the second vertex becomes first etc. This does not change the represented triangle.

--- a/Jolt/Geometry/Indexify.cpp
+++ b/Jolt/Geometry/Indexify.cpp
@@ -56,7 +56,7 @@ void Indexify(const TriangleList &inTriangles, VertexList &outVertices, IndexedT
 		it.mMaterialIndex = t.mMaterialIndex;
 		for (int j = 0; j < 3; ++j)
 			it.mIdx[j] = vertex_map[t.mV[j]];
-		if (!it.IsDegenerate())
+		if (!it.IsDegenerate(outVertices))
 			outTriangles.push_back(it);
 	}
 }

--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -96,13 +96,7 @@ void MeshShapeSettings::Sanitize()
 	{
 		const IndexedTriangle &tri = mIndexedTriangles[t];
 
-		// Get vertices
-		Vec3 v0(mTriangleVertices[tri.mIdx[0]]);
-		Vec3 v1(mTriangleVertices[tri.mIdx[1]]);
-		Vec3 v2(mTriangleVertices[tri.mIdx[2]]);
-
-		if (tri.IsDegenerate()										// Degenerate triangle
-			|| (v1 - v0).Cross(v2 - v0).IsNearZero()				// Sliver
+		if (tri.IsDegenerate(mTriangleVertices)						// Degenerate triangle
 			|| !triangles.insert(tri.GetLowestIndexFirst()).second) // Duplicate triangle
 		{
 			// The order of triangles doesn't matter (gets reordered while building the tree), so we can just swap the last triangle into this slot
@@ -133,7 +127,7 @@ MeshShape::MeshShape(const MeshShapeSettings &inSettings, ShapeResult &outResult
 	for (int t = (int)inSettings.mIndexedTriangles.size() - 1; t >= 0; --t)
 	{
 		const IndexedTriangle &triangle = inSettings.mIndexedTriangles[t];
-		if (triangle.IsDegenerate())
+		if (triangle.IsDegenerate(inSettings.mTriangleVertices))
 		{
 			outResult.SetError(StringFormat("Triangle %d is degenerate!", t));
 			return;


### PR DESCRIPTION
This doesn't have any bearing on godot-jolt/godot-jolt#485, but I was looking through the code and saw an opportunity to maybe simplify things a bit.

I figured the previous `IsDegenerate` check was made more or less redundant by this new cross-product check, so I replaced one with the other. This has the added benefit of also checking for slivers during the sanity checks in `MeshShape::MeshShape` as well as in `Indexify`.