### PR TITLE
Added Visual Studio Code workspace settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.vscode
 .DS_Store
 /profile_list_*.html
 /profile_chart_*.html


### PR DESCRIPTION
This adds the `.vscode` folder to `.gitignore`, which houses things like the workspace-specific settings and launch configurations for Visual Studio Code. This allows for having Jolt-specific settings, such as disabling the trimming of trailing whitespaces, without having these files litter Git's list of untracked files.