### PR TITLE
Fix stdout 

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -263,7 +263,7 @@
 	JPH_CLANG_SUPPRESS_WARNING("-Wgnu-zero-variadic-macro-arguments")							\
 	JPH_CLANG_SUPPRESS_WARNING("-Wdocumentation-unknown-command")								\
 	JPH_CLANG_SUPPRESS_WARNING("-Wctad-maybe-unsupported")										\
-	JPH_CLANG_SUPPRESS_WARNING("-Wdeprecated-copy")												\
+	JPH_IF_NOT_ANDROID(JPH_CLANG_SUPPRESS_WARNING("-Wdeprecated-copy"))					\
 	JPH_CLANG_13_PLUS_SUPPRESS_WARNING("-Wdeprecated-copy-with-dtor")							\
 	JPH_IF_NOT_ANDROID(JPH_CLANG_SUPPRESS_WARNING("-Wimplicit-int-float-conversion"))			\
 																								\


### PR DESCRIPTION
I get warning spew in my build output for Quest 2 if I leave this line enabled. Maybe the quest uses an older clang version?

Lastly I messed up the macro alignment with my change, the \ at the end of the line :(

An example of the output I was getting:

```
/var/lib/jenkins/workspace/KTFN_dev_2/build_quest/_deps/joltphysics-src/Jolt/Core/StringTools.h:7:1: warning: unknown warning group '-Wdeprecated-copy', ignored [-Wunknown-warning-option]
JPH_NAMESPACE_BEGIN
^
/var/lib/jenkins/workspace/KTFN_dev_2/build_quest/_deps/joltphysics-src/Jolt/Core/Core.h:326:2: note: expanded from macro 'JPH_NAMESPACE_BEGIN'
        JPH_SUPPRESS_WARNINGS                                                                                                                                           \
        ^
/var/lib/jenkins/workspace/KTFN_dev_2/build_quest/_deps/joltphysics-src/Jolt/Core/Core.h:266:2: note: expanded from macro 'JPH_SUPPRESS_WARNINGS'
        JPH_CLANG_SUPPRESS_WARNING("-Wdeprecated-copy")                                                                                         \
        ^
/var/lib/jenkins/workspace/KTFN_dev_2/build_quest/_deps/joltphysics-src/Jolt/Core/Core.h:212:39: note: expanded from macro 'JPH_CLANG_SUPPRESS_WARNING'
#define JPH_CLANG_SUPPRESS_WARNING(w)   JPH_PRAGMA(clang diagnostic ignored w)
                                        ^
/var/lib/jenkins/workspace/KTFN_dev_2/build_quest/_deps/joltphysics-src/Jolt/Core/Core.h:209:27: note: expanded from macro 'JPH_PRAGMA'
#define JPH_PRAGMA(x)                                   _Pragma(#x)
                                                        ^
<scratch space>:24:27: note: expanded from here
 clang diagnostic ignored "-Wdeprecated-copy"
                          ^
``` 