### PR TITLE
Fixes Linux compilation, by removing range loop variable construction.

### DIFF
--- a/Jolt/Physics/Constraints/ConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ConstraintManager.cpp
@@ -245,7 +245,7 @@ void ConstraintManager::SaveState(StateRecorder &inStream) const
 		// Save them
 		size_t num_constraints = constraints.size();
 		inStream.Write(num_constraints);
-		for (const Ref<Constraint> &c : constraints)
+		for (const Constraint *c : constraints)
 		{
 			inStream.Write(c->mConstraintIndex);
 			c->SaveState(inStream);


### PR DESCRIPTION
Fixes the following compilation error:

```
error: loop variable 'c' of type 'const JPH::Ref<JPH::Constraint>&' binds to a temporary constructed from type 'JPH::Constraint*' [-Werror=range-loop-construct]
```