### PR TITLE
Failed attempt at fixing the validation function.

### DIFF
--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -2373,8 +2373,6 @@ void PhysicsSystem::SaveState(StateRecorder &inStream, EStateRecorderState inSta
 {
 	JPH_PROFILE_FUNCTION();
 
-	inStream.Write(inState);
-
 	if (uint8(inState) & uint8(EStateRecorderState::Global))
 	{
 		inStream.Write(mPreviousStepDeltaTime);
@@ -2391,32 +2389,29 @@ void PhysicsSystem::SaveState(StateRecorder &inStream, EStateRecorderState inSta
 		mConstraintManager.SaveState(inStream, inFilter);
 }
 
-bool PhysicsSystem::RestoreState(StateRecorder &inStream)
+bool PhysicsSystem::RestoreState(StateRecorder &inStream, EStateRecorderState inState)
 {
 	JPH_PROFILE_FUNCTION();
 
-	EStateRecorderState state = EStateRecorderState::None;
-	inStream.Read(state);
-
-	if (uint8(state) & uint8(EStateRecorderState::Global))
+	if (uint8(inState) & uint8(EStateRecorderState::Global))
 	{
 		inStream.Read(mPreviousStepDeltaTime);
 		inStream.Read(mGravity);
 	}
 
-	if (uint8(state) & uint8(EStateRecorderState::Bodies))
+	if (uint8(inState) & uint8(EStateRecorderState::Bodies))
 	{
 		if (!mBodyManager.RestoreState(inStream))
 			return false;
 	}
 
-	if (uint8(state) & uint8(EStateRecorderState::Contacts))
+	if (uint8(inState) & uint8(EStateRecorderState::Contacts))
 	{
 		if (!mContactManager.RestoreState(inStream))
 			return false;
 	}
 
-	if (uint8(state) & uint8(EStateRecorderState::Constraints))
+	if (uint8(inState) & uint8(EStateRecorderState::Constraints))
 	{
 		if (!mConstraintManager.RestoreState(inStream))
 			return false;

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -112,7 +112,7 @@ public:
 	void						SaveState(StateRecorder &inStream, EStateRecorderState inState = EStateRecorderState::All, const StateRecorderFilter *inFilter = nullptr) const;
 
 	/// Restoring state for replay. Returns false if failed.
-	bool						RestoreState(StateRecorder &inStream);
+	bool						RestoreState(StateRecorder &inStream, EStateRecorderState inState = EStateRecorderState::All);
 
 #ifdef JPH_DEBUG_RENDERER
 	// Drawing properties

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -1523,6 +1523,16 @@ TEST_SUITE("PhysicsTests")
 			StateRecorderImpl absolute_initial_state;
 			c.GetSystem()->SaveState(absolute_initial_state);
 
+			// Validate the state.
+			{
+				absolute_initial_state.Rewind();
+				absolute_initial_state.SetValidating(true);
+				c.GetSystem()->RestoreState(absolute_initial_state);
+				CHECK(!absolute_initial_state.IsFailed());
+				absolute_initial_state.SetValidating(false);
+				absolute_initial_state.Rewind();
+			}
+
 			EStateRecorderState state_to_save = EStateRecorderState::All;
 			MyFilter filter;
 			if (mode == 1)
@@ -1546,6 +1556,16 @@ TEST_SUITE("PhysicsTests")
 			StateRecorderImpl initial_state;
 			c.GetSystem()->SaveState(initial_state, state_to_save, &filter);
 
+			// Validate the state.
+			{
+				initial_state.Rewind();
+				initial_state.SetValidating(true);
+				c.GetSystem()->RestoreState(initial_state, state_to_save);
+				CHECK(!initial_state.IsFailed());
+				initial_state.SetValidating(false);
+				initial_state.Rewind();
+			}
+
 			// Simulate for 2 seconds
 			c.Simulate(2.0f);
 
@@ -1567,11 +1587,21 @@ TEST_SUITE("PhysicsTests")
 			StateRecorderImpl intermediate_state;
 			c.GetSystem()->SaveState(intermediate_state, state_to_save, &filter);
 
+			// Validate the state.
+			{
+				intermediate_state.Rewind();
+				intermediate_state.SetValidating(true);
+				c.GetSystem()->RestoreState(intermediate_state, state_to_save);
+				CHECK(!intermediate_state.IsFailed());
+				intermediate_state.SetValidating(false);
+				intermediate_state.Rewind();
+			}
+
 			// Change the gravity.
 			c.GetSystem()->SetGravity(upside_down_gravity);
 
 			// Restore the initial state.
-			c.GetSystem()->RestoreState(initial_state);
+			c.GetSystem()->RestoreState(initial_state, state_to_save);
 
 			// Make sure the state is properly set back to the initial state.
 			CHECK(box1.GetWorldTransform() == initial_box1_transform);
@@ -1634,6 +1664,16 @@ TEST_SUITE("PhysicsTests")
 			// Save the final state
 			StateRecorderImpl final_state;
 			c.GetSystem()->SaveState(final_state, state_to_save, &filter);
+
+			// Validate the state.
+			{
+				final_state.Rewind();
+				final_state.SetValidating(true);
+				c.GetSystem()->RestoreState(final_state, state_to_save);
+				CHECK(!final_state.IsFailed());
+				final_state.SetValidating(false);
+				final_state.Rewind();
+			}
 
 			// Compare the states to make sure they are the same
 			CHECK(final_state.IsEqual(intermediate_state));


### PR DESCRIPTION
The `RestoreState` validation feature is not working properly, I fix what I thought was causing the issue, but after adding some unit tests I found that there is something else. @jrouwe Do you have any clue by reading the below?

---- 

The `SaveState` function is storing the user-provided `EStateRecorderState` into the stream:
```cpp
void PhysicsSystem::SaveState(StateRecorder &inStream, EStateRecorderState inState, const StateRecorderFilter *inFilter) const
{
	inStream.Write(inState);
```

While the `RestoreState` is reading from the stream, and it's providing an hardcoded `EStateRecorderState::None` as initial recorder state:
```cpp
bool PhysicsSystem::RestoreState(StateRecorder &inStream)
{
	EStateRecorderState state = EStateRecorderState::None;
	inStream.Read(state);
```

The issue is that by doing so, the validation is going to always fail as the hardcoded `EStateRecorderState::None` is always going to be different to what's into the stream.

As metioned above, I've tried to fix it by removing it from the stream, but the UnitTests is highlighting that there is still some reading misalignment somewhere.

```
/UnitTests/Physics/PhysicsTests.cpp:1482:
TEST SUITE: PhysicsTests
TEST CASE:  TestSelectiveStateSaveAndRestore

/UnitTests/UnitTestFramework.cpp:49: MESSAGE: Mismatch reading 8 bytes
/UnitTests/UnitTestFramework.cpp:49: MESSAGE: Offset 0: 05 -> 02

Trace/breakpoint trap (core dumped)
```