### PR TITLE
Exposes BroadPhase and BodyManager

### DIFF
--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -863,6 +863,16 @@ bool BodyManager::RestoreState(StateRecorder &inStream)
 	return true;
 }
 
+void BodyManager::UnsafeAddBodyToActiveBodies(Body &ioBody)
+{
+	AddBodyToActiveBodies(ioBody);
+}
+
+void BodyManager::UnsafeRemoveBodyFromActiveBodies(Body &ioBody)
+{
+	RemoveBodyFromActiveBodies(ioBody);
+}
+
 #ifdef JPH_DEBUG_RENDERER
 void BodyManager::Draw(const DrawSettings &inDrawSettings, const PhysicsSettings &inPhysicsSettings, DebugRenderer *inRenderer, const BodyDrawFilter *inBodyFilter)
 {

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -197,6 +197,12 @@ public:
 	/// Restoring state for replay. Returns false if failed.
 	bool							RestoreState(StateRecorder &inStream);
 
+	/// Add a single body to mActiveBodies, note doesn't lock the active body mutex!
+	void							UnsafeAddBodyToActiveBodies(Body &ioBody);
+
+	/// Remove a single body from mActiveBodies, note doesn't lock the active body mutex!
+	void							UnsafeRemoveBodyFromActiveBodies(Body &ioBody);
+	
 	enum class EShapeColor
 	{
 		InstanceColor,				///< Random color per instance

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -135,6 +135,18 @@ public:
 	void						SetGravity(Vec3Arg inGravity)								{ mGravity = inGravity; }
 	Vec3		 				GetGravity() const											{ return mGravity; }
 
+	/// Returns the raw BodyManager without locking it, use `GetBodyLockInterface` instead.
+	inline const BodyManager&	UnsafeGetBodyManager() const								{ return mBodyManager; }
+
+	/// Returns the raw BodyManager without locking it, use `GetBodyLockInterface` instead.
+	inline BodyManager&			UnsafeGetBodyManager()										{ return mBodyManager; }
+
+	/// Returns the raw BroadPhase.
+	inline const BroadPhase*	UnsafeGetBroadPhase() const									{ return mBroadPhase; }
+
+	/// Returns the raw BroadPhase.
+	inline BroadPhase*			UnsafeGetBroadPhase()										{ return mBroadPhase; }
+
 	/// Returns a locking interface that won't actually lock the body. Use with great care!
 	inline const BodyLockInterfaceNoLock &	GetBodyLockInterfaceNoLock() const				{ return mBodyLockInterfaceNoLock; }
 


### PR DESCRIPTION
This commit exposes the internal BodyManager and BroadPhase classes, so it's possible to customize the Physics Engine behaviour.

---- 

This change was needed to implement a custom `SaveState` and `RestoreState`, so that:
- I can avoid using the `BodyManager` to restore the state, as it crashes if the body doesn't exist.
- Allows me to skip networking a Body which state didn't change from the last update.
- Allows me not to network the unnecessary BodyID.

The code I'm using to "Save" an "Restore" is the following one:
```cpp
void JBody3D::jolt_set_state(const Vector<uint8_t> &p_data) {
	if (!body) {
		// The body doesn't exists, so we can just skip it. Eventually the
		// server will make sure to create it.
		return;
	}

	jolt_state.set_data(p_data);
	jolt_state.BeginRead();

	bool is_active;
	jolt_state.ReadBytes(&is_active, 1);

	body->RestoreState(jolt_state);

	if (is_active != body->IsActive()) {
		if (is_active) {
			Jolt::singleton()->body_manager_activate_body(*body);
		} else {
			Jolt::singleton()->body_manager_deactivate_body(*body);
		}
	}

	// Update the Godot transform.
	const Transform3D t(Quaternion(convert(body->GetRotation())), convert_r(body->GetPosition()));
	set_global_transform(t);
}
```

```cpp
Vector<uint8_t> JBody3D::jolt_get_state() {
	if (!body) {
		return Vector<uint8_t>();
	}

	jolt_state.Clear();
	const bool is_active = body->IsActive();
	jolt_state.WriteBytes(&is_active, 1);
	body->SaveState(jolt_state);
	return Vector<uint8_t>(jolt_state.get_data());
}
```

```cpp
void Jolt::body_manager_activate_body(JPH::Body &p_body) {
	JPH::PhysicsSystem *physics_system = worlds[0];
	JPH::BodyManager &bm = physics_system->UnsafeGetBodyManager();
	bm.UnsafeAddBodyToActiveBodies(p_body);
}

void Jolt::body_manager_deactivate_body(JPH::Body &p_body) {
	JPH::PhysicsSystem *physics_system = worlds[0];
	JPH::BodyManager &bm = physics_system->UnsafeGetBodyManager();
	bm.UnsafeRemoveBodyFromActiveBodies(p_body);
}
```

This function is being called when all the bodies states got restored. 
```cpp
void Jolt::world_update_broadphase_aabb(uint32_t p_world_id) {
	JPH::PhysicsSystem *physics_system = worlds[p_world_id];
	JPH::BodyManager &bm = physics_system->UnsafeGetBodyManager();

	// Update bounding boxes for all bodies in the broadphase
	JPH::Array<JPH::BodyID> bodies;
	for (const JPH::Body *b : bm.GetBodies()) {
		if (JPH::BodyManager::sIsValidBodyPointer(b) && b->IsInBroadPhase()) {
			bodies.push_back(b->GetID());
		}
	}

	if (!bodies.empty()) {
		JPH::BroadPhase *bp = physics_system->UnsafeGetBroadPhase();
		bp->NotifyBodiesAABBChanged(&bodies[0], (int)bodies.size());
	}
}
```