### PR TITLE
Allowed for moving triangle data into MeshShapeSettings

### DIFF
--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -70,7 +70,15 @@ static JPH_INLINE const TriangleCodec::TriangleHeader *sGetTriangleHeader(const 
 	return inTree.Get<TriangleCodec::TriangleHeader>(NodeCodec::HeaderSize);
 }
 
-MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials) :
+MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
+	mMaterials(inMaterials)
+{
+	Indexify(inTriangles, mTriangleVertices, mIndexedTriangles);
+
+	Sanitize();
+}
+
+MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList &&inMaterials) :
 	mMaterials(std::move(inMaterials))
 {
 	Indexify(inTriangles, mTriangleVertices, mIndexedTriangles);
@@ -78,7 +86,15 @@ MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMat
 	Sanitize();
 }
 
-MeshShapeSettings::MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials) :
+MeshShapeSettings::MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
+	mTriangleVertices(inVertices),
+	mIndexedTriangles(inTriangles),
+	mMaterials(inMaterials)
+{
+	Sanitize();
+}
+
+MeshShapeSettings::MeshShapeSettings(VertexList &&inVertices, IndexedTriangleList &&inTriangles, PhysicsMaterialList &&inMaterials) :
 	mTriangleVertices(std::move(inVertices)),
 	mIndexedTriangles(std::move(inTriangles)),
 	mMaterials(std::move(inMaterials))

--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -70,15 +70,7 @@ static JPH_INLINE const TriangleCodec::TriangleHeader *sGetTriangleHeader(const 
 	return inTree.Get<TriangleCodec::TriangleHeader>(NodeCodec::HeaderSize);
 }
 
-MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
-	mMaterials(inMaterials)
-{
-	Indexify(inTriangles, mTriangleVertices, mIndexedTriangles);
-
-	Sanitize();
-}
-
-MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList &&inMaterials) :
+MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials) :
 	mMaterials(std::move(inMaterials))
 {
 	Indexify(inTriangles, mTriangleVertices, mIndexedTriangles);
@@ -86,15 +78,7 @@ MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMat
 	Sanitize();
 }
 
-MeshShapeSettings::MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
-	mTriangleVertices(inVertices),
-	mIndexedTriangles(inTriangles),
-	mMaterials(inMaterials)
-{
-	Sanitize();
-}
-
-MeshShapeSettings::MeshShapeSettings(VertexList &&inVertices, IndexedTriangleList &&inTriangles, PhysicsMaterialList &&inMaterials) :
+MeshShapeSettings::MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials) :
 	mTriangleVertices(std::move(inVertices)),
 	mIndexedTriangles(std::move(inTriangles)),
 	mMaterials(std::move(inMaterials))

--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -70,18 +70,18 @@ static JPH_INLINE const TriangleCodec::TriangleHeader *sGetTriangleHeader(const 
 	return inTree.Get<TriangleCodec::TriangleHeader>(NodeCodec::HeaderSize);
 }
 
-MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
-	mMaterials(inMaterials)
+MeshShapeSettings::MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials) :
+	mMaterials(std::move(inMaterials))
 {
 	Indexify(inTriangles, mTriangleVertices, mIndexedTriangles);
 
 	Sanitize();
 }
 
-MeshShapeSettings::MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials) :
-	mTriangleVertices(inVertices),
-	mIndexedTriangles(inTriangles),
-	mMaterials(inMaterials)
+MeshShapeSettings::MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials) :
+	mTriangleVertices(std::move(inVertices)),
+	mIndexedTriangles(std::move(inTriangles)),
+	mMaterials(std::move(inMaterials))
 {
 	Sanitize();
 }

--- a/Jolt/Physics/Collision/Shape/MeshShape.h
+++ b/Jolt/Physics/Collision/Shape/MeshShape.h
@@ -28,10 +28,8 @@ public:
 									MeshShapeSettings() = default;
 
 	/// Create a mesh shape.
-									MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
-									MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList &&inMaterials);
-									MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
-									MeshShapeSettings(VertexList &&inVertices, IndexedTriangleList &&inTriangles, PhysicsMaterialList &&inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
 
 	/// Sanitize the mesh data. Remove duplicate and degenerate triangles.
 	void							Sanitize();

--- a/Jolt/Physics/Collision/Shape/MeshShape.h
+++ b/Jolt/Physics/Collision/Shape/MeshShape.h
@@ -28,8 +28,8 @@ public:
 									MeshShapeSettings() = default;
 
 	/// Create a mesh shape.
-									MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
-									MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
 
 	/// Sanitize the mesh data. Remove duplicate and degenerate triangles.
 	void							Sanitize();

--- a/Jolt/Physics/Collision/Shape/MeshShape.h
+++ b/Jolt/Physics/Collision/Shape/MeshShape.h
@@ -28,8 +28,10 @@ public:
 									MeshShapeSettings() = default;
 
 	/// Create a mesh shape.
-									MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
-									MeshShapeSettings(VertexList inVertices, IndexedTriangleList inTriangles, PhysicsMaterialList inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(const TriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(const TriangleList &inTriangles, PhysicsMaterialList &&inMaterials);
+									MeshShapeSettings(const VertexList &inVertices, const IndexedTriangleList &inTriangles, const PhysicsMaterialList &inMaterials = PhysicsMaterialList());
+									MeshShapeSettings(VertexList &&inVertices, IndexedTriangleList &&inTriangles, PhysicsMaterialList &&inMaterials = PhysicsMaterialList());
 
 	/// Sanitize the mesh data. Remove duplicate and degenerate triangles.
 	void							Sanitize();

--- a/Samples/Tests/Character/CharacterBaseTest.cpp
+++ b/Samples/Tests/Character/CharacterBaseTest.cpp
@@ -435,7 +435,7 @@ void CharacterBaseTest::Initialize()
 				triangles.push_back(IndexedTriangle(end, end + angle, end + angle + 1));
 			}
 
-			MeshShapeSettings mesh(vertices, triangles);
+			MeshShapeSettings mesh(std::move(vertices), std::move(triangles));
 			mesh.SetEmbedded();
 			BodyCreationSettings mesh_cylinder(&mesh, cHalfCylinderPosition, Quat::sIdentity(), EMotionType::Static, Layers::NON_MOVING);
 			mBodyInterface->CreateAndAddBody(mesh_cylinder, EActivation::DontActivate);
@@ -469,7 +469,7 @@ void CharacterBaseTest::Initialize()
 				IndexedTriangle(0, 5, 4)
 			};
 
-			MeshShapeSettings mesh(vertices, triangles);
+			MeshShapeSettings mesh(std::move(vertices), std::move(triangles));
 			mesh.SetEmbedded();
 			BodyCreationSettings box(&mesh, cMeshBoxPosition, Quat::sIdentity(), EMotionType::Static, Layers::NON_MOVING);
 			mBodyInterface->CreateAndAddBody(box, EActivation::DontActivate);

--- a/Samples/Tests/General/FrictionPerTriangleTest.cpp
+++ b/Samples/Tests/General/FrictionPerTriangleTest.cpp
@@ -46,7 +46,7 @@ void FrictionPerTriangleTest::Initialize()
 	}
 
 	// A ramp
-	mBodyInterface->CreateAndAddBody(BodyCreationSettings(new MeshShapeSettings(triangles, materials), RVec3::sZero(), Quat::sRotation(Vec3::sAxisX(), 0.2f * JPH_PI), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
+	mBodyInterface->CreateAndAddBody(BodyCreationSettings(new MeshShapeSettings(triangles, std::move(materials)), RVec3::sZero(), Quat::sRotation(Vec3::sAxisX(), 0.2f * JPH_PI), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
 
 	// A box with friction 1 that slides down the ramp
 	Ref<BoxShape> box_shape = new BoxShape(Vec3(2.0f, 2.0f, 2.0f), cDefaultConvexRadius, new MyMaterial("Box Friction 1", Color::sYellow, 1.0f, 0.0f));

--- a/Samples/Tests/General/LoadSaveSceneTest.cpp
+++ b/Samples/Tests/General/LoadSaveSceneTest.cpp
@@ -88,7 +88,7 @@ static MeshShapeSettings *sCreateMesh()
 	for (uint i = 0; i <= max_material_index; ++i)
 		materials.push_back(new PhysicsMaterialSimple("Mesh Material " + ConvertToString(i), Color::sGetDistinctColor(i)));
 
-	return new MeshShapeSettings(triangles, materials);
+	return new MeshShapeSettings(triangles, std::move(materials));
 }
 
 static HeightFieldShapeSettings *sCreateHeightField()

--- a/Samples/Tests/General/ManifoldReductionTest.cpp
+++ b/Samples/Tests/General/ManifoldReductionTest.cpp
@@ -43,7 +43,7 @@ void ManifoldReductionTest::Initialize()
 		}
 	PhysicsMaterialList materials;
 	materials.push_back(new PhysicsMaterialSimple());
-	Ref<ShapeSettings> mesh_shape = new MeshShapeSettings(triangles, materials);
+	Ref<ShapeSettings> mesh_shape = new MeshShapeSettings(triangles, std::move(materials));
 
 	// Floor
 	Body &floor = *mBodyInterface->CreateBody(BodyCreationSettings(new ScaledShapeSettings(mesh_shape, Vec3::sReplicate(20)), RVec3::sZero(), Quat::sIdentity(), EMotionType::Static, Layers::NON_MOVING));

--- a/Samples/Tests/Shapes/MeshShapeTest.cpp
+++ b/Samples/Tests/Shapes/MeshShapeTest.cpp
@@ -47,7 +47,7 @@ void MeshShapeTest::Initialize()
 		materials.push_back(new PhysicsMaterialSimple("Material " + ConvertToString(i), Color::sGetDistinctColor(i)));
 
 	// Floor
-	Body &floor = *mBodyInterface->CreateBody(BodyCreationSettings(new MeshShapeSettings(triangles, materials), RVec3::sZero(), Quat::sRotation(Vec3::sAxisX(), 0.25f * JPH_PI), EMotionType::Static, Layers::NON_MOVING));
+	Body &floor = *mBodyInterface->CreateBody(BodyCreationSettings(new MeshShapeSettings(triangles, std::move(materials)), RVec3::sZero(), Quat::sRotation(Vec3::sAxisX(), 0.25f * JPH_PI), EMotionType::Static, Layers::NON_MOVING));
 	mBodyInterface->AddBody(floor.GetID(), EActivation::DontActivate);
 
 	// 1 body with zero friction to test active edge detection


### PR DESCRIPTION
It's currently not possible to hand over ownership (through `std::move`) of `VertexList`, `IndexedTriangleList` or `PhysicsMaterialList` to `MeshShapeSettings`, due to it taking these parameters as `const&`, leading to it always copying said data.

This PR fixes that by instead taking the triangle data by-value and moving it into each respective member.

For the case where you're not handing off ownership of the data, this will potentially incur an extra (presumably negligable) move constructor invocation for each member, but for the case where you do hand off the data, you will now avoid having to copy the data.