### PR TITLE
Added getter for job name

### DIFF
--- a/Jolt/Core/JobSystem.h
+++ b/Jolt/Core/JobSystem.h
@@ -266,6 +266,9 @@ protected:
 		/// Test if the job finished executing
 		inline bool			IsDone() const								{ return mNumDependencies.load(memory_order_relaxed) == cDoneState; }
 
+		/// Get the name of the job
+		const char *		GetName() const								{ return mJobName; }
+
 		static constexpr uint32 cExecutingState = 0xe0e0e0e0;			///< Value of mNumDependencies when job is executing
 		static constexpr uint32 cDoneState		= 0xd0d0d0d0;			///< Value of mNumDependencies when job is done executing
 

--- a/Jolt/Core/JobSystem.h
+++ b/Jolt/Core/JobSystem.h
@@ -266,8 +266,10 @@ protected:
 		/// Test if the job finished executing
 		inline bool			IsDone() const								{ return mNumDependencies.load(memory_order_relaxed) == cDoneState; }
 
+	#if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
 		/// Get the name of the job
 		const char *		GetName() const								{ return mJobName; }
+	#endif // defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
 
 		static constexpr uint32 cExecutingState = 0xe0e0e0e0;			///< Value of mNumDependencies when job is executing
 		static constexpr uint32 cDoneState		= 0xd0d0d0d0;			///< Value of mNumDependencies when job is done executing


### PR DESCRIPTION
Related to godot-jolt/godot-jolt#507.

This adds a `JobSystem::Job::GetName` method for getting the job name.

It ended up looking a bit strange to be storing a second copy of the job name in my derived job class just because the name was private in `JobSystem::Job`, so I went ahead and added the getter after all.