### PR TITLE
Attempt to remove jitter in virtual character when moving towards steep slope

### DIFF
--- a/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Jolt/Physics/Character/CharacterVirtual.h
@@ -333,6 +333,7 @@ private:
 		float							mProjectedVelocity;										///< Velocity of the contact projected on the contact normal (negative if separating)
 		Vec3							mLinearVelocity;										///< Velocity of the contact (can contain a corrective velocity to resolve penetration)
 		Plane							mPlane;													///< Plane around the origin that describes how far we can displace (from the origin)
+		bool							mIsSteepSlope = false;									///< If this constraint belongs to a steep slope
 	};
 
 	using ConstraintList = std::vector<Constraint, STLTempAllocator<Constraint>>;


### PR DESCRIPTION
This can be seen in CharacterVirtualTest by walking towards the area that has varying slope angles and trying to slide against the base of the steep slopes. Due to numerical accuracy, you could randomly hit the vertical wall constraint or the slope constraint first. If you hit the constraint first it was possibler that you accumulated a small vertical velocity which caused the character to leave the floor a little bit. This was visible as a jitter in movement. Now we cancel the velocity towards the slope also in the steep slope so that we don't get this vertical velocity.