### PR TITLE
Changed C style casts to C++ style casts, or constructors where appro…

### DIFF
--- a/Jolt/Core/RTTI.h
+++ b/Jolt/Core/RTTI.h
@@ -192,7 +192,7 @@ protected:
 public:																												\
 	JPH_OVERRIDE_NEW_DELETE																							\
 	friend linkage RTTI *		GetRTTIOfType(class_name *);														\
-	friend inline const RTTI *	GetRTTI([[maybe_unused]] const class_name *inObject) { return GetRTTIOfType((class_name *)nullptr); }\
+	friend inline const RTTI *	GetRTTI([[maybe_unused]] const class_name *inObject) { return GetRTTIOfType(static_cast<class_name *>(nullptr)); }\
 	static void					sCreateRTTI(RTTI &inRTTI);															\
 
 // JPH_IMPLEMENT_RTTI_NON_VIRTUAL
@@ -312,7 +312,7 @@ public:																												\
 // Find the RTTI of a class
 //////////////////////////////////////////////////////////////////////////////////////////
 
-#define JPH_RTTI(class_name)	GetRTTIOfType((class_name *)nullptr)
+#define JPH_RTTI(class_name)	GetRTTIOfType(static_cast<class_name *>(nullptr))
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Macro to rename a class, useful for embedded classes:

--- a/Jolt/Core/STLAllocator.h
+++ b/Jolt/Core/STLAllocator.h
@@ -38,9 +38,9 @@ public:
 	inline pointer			allocate(size_type inN)
 	{
 		if constexpr (alignof(T) > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16))
-			return (pointer)AlignedAllocate(inN * sizeof(value_type), alignof(T));
+			return pointer(AlignedAllocate(inN * sizeof(value_type), alignof(T)));
 		else
-			return (pointer)Allocate(inN * sizeof(value_type));
+			return pointer(Allocate(inN * sizeof(value_type)));
 	}
 
 	/// Free memory

--- a/Jolt/Core/STLTempAllocator.h
+++ b/Jolt/Core/STLTempAllocator.h
@@ -37,7 +37,7 @@ public:
 	/// Allocate memory
 	inline pointer			allocate(size_type inN)
 	{
-		return (pointer)mAllocator.Allocate(uint(inN * sizeof(value_type)));
+		return pointer(mAllocator.Allocate(uint(inN * sizeof(value_type))));
 	}
 
 	/// Free memory

--- a/Jolt/Core/StaticArray.h
+++ b/Jolt/Core/StaticArray.h
@@ -211,7 +211,7 @@ public:
 	{
 		size_type rhs_size = inRHS.size();
 
-		if ((void *)this != (void *)&inRHS)
+		if (static_cast<const void *>(this) != static_cast<const void *>(&inRHS))
 		{
 			clear();
 
@@ -232,7 +232,7 @@ public:
 		size_type rhs_size = inRHS.size();
 		JPH_ASSERT(rhs_size <= N);
 
-		if ((void *)this != (void *)&inRHS)
+		if (static_cast<const void *>(this) != static_cast<const void *>(&inRHS))
 		{
 			clear();
 

--- a/Jolt/Core/StreamUtils.h
+++ b/Jolt/Core/StreamUtils.h
@@ -76,7 +76,7 @@ void				SaveObjectReference(StreamOut &inStream, const Type *inObject, ObjectToI
 		else
 		{
 			// New object, write the ID
-			uint32 new_id = (uint32)ioObjectToIDMap->size();
+			uint32 new_id = uint32(ioObjectToIDMap->size());
 			(*ioObjectToIDMap)[inObject] = new_id;
 			inStream.Write(new_id);
 
@@ -126,7 +126,7 @@ Result<Ref<Type>>	RestoreObjectReference(StreamIn &inStream, IDToObjectMap<Type>
 template <class ArrayType, class ValueType>
 void				SaveObjectArray(StreamOut &inStream, const ArrayType &inArray, ObjectToIDMap<ValueType> *ioObjectToIDMap)
 {
-	inStream.Write((size_t)inArray.size());
+	inStream.Write(size_t(inArray.size()));
 	for (const ValueType *value: inArray)
 		SaveObjectReference(inStream, value, ioObjectToIDMap);
 }

--- a/Jolt/Math/UVec4.h
+++ b/Jolt/Math/UVec4.h
@@ -89,7 +89,7 @@ public:
 
 	/// Get individual components
 #if defined(JPH_USE_SSE)
-	JPH_INLINE uint32			GetX() const										{ return (uint32)_mm_cvtsi128_si32(mValue); }
+	JPH_INLINE uint32			GetX() const										{ return uint32(_mm_cvtsi128_si32(mValue)); }
 	JPH_INLINE uint32			GetY() const										{ return mU32[1]; }
 	JPH_INLINE uint32			GetZ() const										{ return mU32[2]; }
 	JPH_INLINE uint32			GetW() const										{ return mU32[3]; }

--- a/Jolt/ObjectStream/ObjectStream.h
+++ b/Jolt/ObjectStream/ObjectStream.h
@@ -121,31 +121,31 @@ public:
 template <class T>
 bool OSIsType(Array<T> *, int inArrayDepth, EOSDataType inDataType, const char *inClassName)
 {
-	return (inArrayDepth > 0 && OSIsType((T *)nullptr, inArrayDepth - 1, inDataType, inClassName));
+	return (inArrayDepth > 0 && OSIsType(static_cast<T *>(nullptr), inArrayDepth - 1, inDataType, inClassName));
 }
 
 template <class T, uint N>
 bool OSIsType(StaticArray<T, N> *, int inArrayDepth, EOSDataType inDataType, const char *inClassName)
 {
-	return (inArrayDepth > 0 && OSIsType((T *)nullptr, inArrayDepth - 1, inDataType, inClassName));
+	return (inArrayDepth > 0 && OSIsType(static_cast<T *>(nullptr), inArrayDepth - 1, inDataType, inClassName));
 }
 
 template <class T, uint N>
 bool OSIsType(T (*)[N], int inArrayDepth, EOSDataType inDataType, const char *inClassName)
 {
-	return (inArrayDepth > 0 && OSIsType((T *)nullptr, inArrayDepth - 1, inDataType, inClassName));
+	return (inArrayDepth > 0 && OSIsType(static_cast<T *>(nullptr), inArrayDepth - 1, inDataType, inClassName));
 }
 
 template <class T>
 bool OSIsType(Ref<T> *, int inArrayDepth, EOSDataType inDataType, const char *inClassName)
 {
-	return OSIsType((T *)nullptr, inArrayDepth, inDataType, inClassName);
+	return OSIsType(static_cast<T *>(nullptr), inArrayDepth, inDataType, inClassName);
 }
 
 template <class T>
 bool OSIsType(RefConst<T> *, int inArrayDepth, EOSDataType inDataType, const char *inClassName)
 {
-	return OSIsType((T *)nullptr, inArrayDepth, inDataType, inClassName);
+	return OSIsType(static_cast<T *>(nullptr), inArrayDepth, inDataType, inClassName);
 }
 
 /// Define serialization templates for dynamic arrays
@@ -233,7 +233,7 @@ template <class T>
 void OSWriteDataType(IObjectStreamOut &ioStream, Array<T> *)
 {
 	ioStream.WriteDataType(EOSDataType::Array);
-	OSWriteDataType(ioStream, (T *)nullptr);
+	OSWriteDataType(ioStream, static_cast<T *>(nullptr));
 }
 
 template <class T>
@@ -241,7 +241,7 @@ void OSWriteData(IObjectStreamOut &ioStream, const Array<T> &inArray)
 {
 	// Write size of array
 	ioStream.HintNextItem();
-	ioStream.WriteCount((uint32)inArray.size());
+	ioStream.WriteCount(static_cast<uint32>(inArray.size()));
 
 	// Write data in array
 	ioStream.HintIndentUp();
@@ -255,7 +255,7 @@ template <class T, uint N>
 void OSWriteDataType(IObjectStreamOut &ioStream, StaticArray<T, N> *)
 {
 	ioStream.WriteDataType(EOSDataType::Array);
-	OSWriteDataType(ioStream, (T *)nullptr);
+	OSWriteDataType(ioStream, static_cast<T *>(nullptr));
 }
 
 template <class T, uint N>
@@ -277,7 +277,7 @@ template <class T, uint N>
 void OSWriteDataType(IObjectStreamOut &ioStream, T (*)[N])
 {
 	ioStream.WriteDataType(EOSDataType::Array);
-	OSWriteDataType(ioStream, (T *)nullptr);
+	OSWriteDataType(ioStream, static_cast<T *>(nullptr));
 }
 
 template <class T, uint N>
@@ -285,7 +285,7 @@ void OSWriteData(IObjectStreamOut &ioStream, const T (&inArray)[N])
 {
 	// Write size of array
 	ioStream.HintNextItem();
-	ioStream.WriteCount((uint32)N);
+	ioStream.WriteCount(uint32(N));
 
 	// Write data in array
 	ioStream.HintIndentUp();
@@ -298,7 +298,7 @@ void OSWriteData(IObjectStreamOut &ioStream, const T (&inArray)[N])
 template <class T>
 void OSWriteDataType(IObjectStreamOut &ioStream, Ref<T> *)
 {
-	OSWriteDataType(ioStream, (T *)nullptr);
+	OSWriteDataType(ioStream, static_cast<T *>(nullptr));
 }
 
 template <class T>
@@ -313,7 +313,7 @@ void OSWriteData(IObjectStreamOut &ioStream, const Ref<T> &inRef)
 template <class T>
 void OSWriteDataType(IObjectStreamOut &ioStream, RefConst<T> *)
 {
-	OSWriteDataType(ioStream, (T *)nullptr);
+	OSWriteDataType(ioStream, static_cast<T *>(nullptr));
 }
 
 template <class T>

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -43,7 +43,7 @@ public:
 	uint							GetNumBodies() const;
 
 	/// Gets the max bodies that we can support
-	uint							GetMaxBodies() const						{ return (uint)mBodies.capacity(); }
+	uint							GetMaxBodies() const						{ return uint(mBodies.capacity()); }
 
 	/// Helper struct that counts the number of bodies of each type
 	struct BodyStats
@@ -102,10 +102,10 @@ public:
 	void							GetActiveBodies(EBodyType inType, BodyIDVector &outBodyIDs) const;
 
 	/// Get the list of active bodies. Note: Not thread safe. The active bodies list can change at any moment.
-	const BodyID *					GetActiveBodiesUnsafe(EBodyType inType) const { return mActiveBodies[(int)inType]; }
+	const BodyID *					GetActiveBodiesUnsafe(EBodyType inType) const { return mActiveBodies[int(inType)]; }
 
 	/// Get the number of active bodies.
-	uint32							GetNumActiveBodies(EBodyType inType) const	{ return mNumActiveBodies[(int)inType]; }
+	uint32							GetNumActiveBodies(EBodyType inType) const	{ return mNumActiveBodies[int(inType)]; }
 
 	/// Get the number of active bodies that are using continuous collision detection
 	uint32							GetNumActiveCCDBodies() const				{ return mNumActiveCCDBodies; }

--- a/Jolt/Physics/Collision/Shape/CompoundShape.h
+++ b/Jolt/Physics/Collision/Shape/CompoundShape.h
@@ -244,7 +244,7 @@ public:
 	const SubShapes &				GetSubShapes() const									{ return mSubShapes; }
 
 	/// Get the total number of sub shapes
-	uint							GetNumSubShapes() const									{ return (uint)mSubShapes.size(); }
+	uint							GetNumSubShapes() const									{ return uint(mSubShapes.size()); }
 
 	/// Access to a particular sub shape
 	const SubShape &				GetSubShape(uint inIdx) const							{ return mSubShapes[inIdx]; }
@@ -319,7 +319,7 @@ protected:
 	inline uint						GetSubShapeIDBits() const
 	{
 		// Ensure we have enough bits to encode our shape [0, n - 1]
-		uint32 n = (uint32)mSubShapes.size() - 1;
+		uint32 n = uint32(mSubShapes.size()) - 1;
 		return 32 - CountLeadingZeros(n);
 	}
 

--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.h
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.h
@@ -114,13 +114,13 @@ public:
 	const Array<Plane> &	GetPlanes() const													{ return mPlanes; }
 
 	/// Get the number of vertices in this convex hull
-	inline uint				GetNumPoints() const												{ return (uint)mPoints.size(); }
+	inline uint				GetNumPoints() const												{ return uint(mPoints.size()); }
 
 	/// Get a vertex of this convex hull relative to the center of mass
 	inline Vec3				GetPoint(uint inIndex) const										{ return mPoints[inIndex].mPosition; }
 
 	/// Get the number of faces in this convex hull
-	inline uint				GetNumFaces() const													{ return (uint)mFaces.size(); }
+	inline uint				GetNumFaces() const													{ return uint(mFaces.size()); }
 
 	/// Get the number of vertices in a face
 	inline uint				GetNumVerticesInFace(uint inFaceIndex) const						{ return mFaces[inFaceIndex].mNumVertices; }

--- a/Jolt/Physics/Collision/Shape/Shape.h
+++ b/Jolt/Physics/Collision/Shape/Shape.h
@@ -123,7 +123,7 @@ static constexpr EShapeSubType sCompoundSubShapeTypes[] = { EShapeSubType::Stati
 static constexpr EShapeSubType sDecoratorSubShapeTypes[] = { EShapeSubType::RotatedTranslated, EShapeSubType::Scaled, EShapeSubType::OffsetCenterOfMass };
 
 /// How many shape types we support
-static constexpr uint NumSubShapeTypes = (uint)size(sAllSubShapeTypes);
+static constexpr uint NumSubShapeTypes = uint(size(sAllSubShapeTypes));
 
 /// Names of sub shape types
 static constexpr const char *sSubShapeTypeNames[] = { "Sphere", "Box", "Triangle", "Capsule", "TaperedCapsule", "Cylinder", "ConvexHull", "StaticCompound", "MutableCompound", "RotatedTranslated", "Scaled", "OffsetCenterOfMass", "Mesh", "HeightField", "SoftBody", "User1", "User2", "User3", "User4", "User5", "User6", "User7", "User8", "UserConvex1", "UserConvex2", "UserConvex3", "UserConvex4", "UserConvex5", "UserConvex6", "UserConvex7", "UserConvex8" };
@@ -163,7 +163,7 @@ public:
 	Color							mColor = Color::sBlack;
 
 	/// Get an entry in the registry for a particular sub type
-	static inline ShapeFunctions &	sGet(EShapeSubType inSubType)										{ return sRegistry[(int)inSubType]; }
+	static inline ShapeFunctions &	sGet(EShapeSubType inSubType)										{ return sRegistry[int(inSubType)]; }
 
 private:
 	static ShapeFunctions 			sRegistry[NumSubShapeTypes];

--- a/Jolt/Physics/Collision/SortReverseAndStore.h
+++ b/Jolt/Physics/Collision/SortReverseAndStore.h
@@ -26,7 +26,7 @@ JPH_INLINE int SortReverseAndStore(Vec4Arg inValues, float inMaxValue, UVec4 &io
 	ioIdentifiers = ioIdentifiers.ShiftComponents4Minus(num_results);
 
 	// Store the values
-	inValues.StoreFloat4((Float4 *)outValues);
+	inValues.StoreFloat4(reinterpret_cast<Float4 *>(outValues));
 
 	return num_results;
 }

--- a/Jolt/Physics/Constraints/ConstraintManager.h
+++ b/Jolt/Physics/Constraints/ConstraintManager.h
@@ -43,7 +43,7 @@ public:
 	Constraints				GetConstraints() const;
 
 	/// Get total number of constraints
-	inline uint32			GetNumConstraints() const					{ return (uint32)mConstraints.size(); }
+	inline uint32			GetNumConstraints() const					{ return uint32(mConstraints.size()); }
 
 	/// Determine the active constraints of a subset of the constraints
 	void					GetActiveConstraints(uint32 inStartConstraintIdx, uint32 inEndConstraintIdx, Constraint **outActiveConstraints, uint32 &outNumActiveConstraints) const;

--- a/Jolt/Physics/PhysicsLock.h
+++ b/Jolt/Physics/PhysicsLock.h
@@ -37,16 +37,16 @@ public:
 	static inline void			sCheckLock(PhysicsLockContext inContext, EPhysicsLockTypes inType)
 	{
 		uint32 &mutexes = sGetLockedMutexes(inContext);
-		JPH_ASSERT((uint32)inType > mutexes, "A lock of same or higher priority was already taken, this can create a deadlock!");
-		mutexes = mutexes | (uint32)inType;
+		JPH_ASSERT(uint32(inType) > mutexes, "A lock of same or higher priority was already taken, this can create a deadlock!");
+		mutexes = mutexes | uint32(inType);
 	}
 
 	/// Call after releasing the lock
 	static inline void			sCheckUnlock(PhysicsLockContext inContext, EPhysicsLockTypes inType)
 	{
 		uint32 &mutexes = sGetLockedMutexes(inContext);
-		JPH_ASSERT((mutexes & (uint32)inType) != 0, "Mutex was not locked!");
-		mutexes = mutexes & ~(uint32)inType;
+		JPH_ASSERT((mutexes & uint32(inType)) != 0, "Mutex was not locked!");
+		mutexes = mutexes & ~uint32(inType);
 	}
 #endif // !JPH_ENABLE_ASSERTS
 

--- a/Jolt/Renderer/DebugRenderer.h
+++ b/Jolt/Renderer/DebugRenderer.h
@@ -193,8 +193,8 @@ public:
 	/// Create a batch of triangles that can be drawn efficiently
 	virtual Batch						CreateTriangleBatch(const Triangle *inTriangles, int inTriangleCount) = 0;
 	virtual Batch						CreateTriangleBatch(const Vertex *inVertices, int inVertexCount, const uint32 *inIndices, int inIndexCount) = 0;
-	Batch								CreateTriangleBatch(const Array<Triangle> &inTriangles) { return CreateTriangleBatch(inTriangles.empty()? nullptr : &inTriangles[0], (int)inTriangles.size()); }
-	Batch								CreateTriangleBatch(const Array<Vertex> &inVertices, const Array<uint32> &inIndices) { return CreateTriangleBatch(inVertices.empty()? nullptr : &inVertices[0], (int)inVertices.size(), inIndices.empty()? nullptr : &inIndices[0], (int)inIndices.size()); }
+	Batch								CreateTriangleBatch(const Array<Triangle> &inTriangles) { return CreateTriangleBatch(inTriangles.empty()? nullptr : &inTriangles[0], int(inTriangles.size())); }
+	Batch								CreateTriangleBatch(const Array<Vertex> &inVertices, const Array<uint32> &inIndices) { return CreateTriangleBatch(inVertices.empty()? nullptr : &inVertices[0], int(inVertices.size()), inIndices.empty()? nullptr : &inIndices[0], int(inIndices.size())); }
 	Batch								CreateTriangleBatch(const VertexList &inVertices, const IndexedTriangleNoMaterialList &inTriangles);
 
 	/// Create a primitive for a convex shape using its support function


### PR DESCRIPTION
…priate

Only touched header files since these are the only ones that threw the old-style cast warning in my project.

Most changes are from `(T *)var` to `static_cast<T *>(var)` or `(T)var` to `T(var)`
Notable changes are:
`StaticArray<T, N>::operator=` and `template <uint M> StaticArray<T, N>::operator=`
	The `(void *)&inRHS` cast was casting away constness. Changed to `static_cast<const void *>(this)` and `static_cast<const void *>(&inRHS)`
SortReverseAndStore
	The `inValues.StoreFloat4((Float4 *)outValues)` was doing a `reinterpret_cast`. Changed to an explicit `reinterpret_cast<Float4 *>`