### PR TITLE
Added non-settings constructor to OffsetCenterOfMassShape

### DIFF
--- a/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
+++ b/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
@@ -40,6 +40,7 @@ public:
 	/// Constructor
 									OffsetCenterOfMassShape() : DecoratedShape(EShapeSubType::OffsetCenterOfMass) { }
 									OffsetCenterOfMassShape(const OffsetCenterOfMassShapeSettings &inSettings, ShapeResult &outResult);
+									OffsetCenterOfMassShape(const Shape *inShape, Vec3Arg inOffset) : DecoratedShape(EShapeSubType::OffsetCenterOfMass, inShape), mOffset(inOffset) { }
 
 	/// Access the offset that is applied to the center of mass
 	Vec3							GetOffset() const										{ return mOffset; }


### PR DESCRIPTION
This adds a constructor overload to `OffsetCenterOfMassShape` that takes an inner shape and an offset directly, without having to go through `OffsetCenterOfMassShapeSettings`, which makes it line up better with `RotatedTranslatedShape` and `ScaledShape`.

I wasn't sure if `inShape` should be the first or last argument, since `RotatedTranslatedShape` and `ScaledShape` aren't consistent here, but you can change it as you see fit I guess.