### PR TITLE
Implement 'Clear' function on StateRecorderImpl

### DIFF
--- a/Jolt/Physics/StateRecorderImpl.cpp
+++ b/Jolt/Physics/StateRecorderImpl.cpp
@@ -18,9 +18,10 @@ void StateRecorderImpl::Rewind()
 	mStream.seekg(0, std::stringstream::beg);
 }
 
-void StateRecorderImpl::Clear() {
+void StateRecorderImpl::Clear()
+{
 	mStream.clear();
-	mStream.str ({});
+	mStream.str({});
 }
 
 void StateRecorderImpl::ReadBytes(void *outData, size_t inNumBytes)

--- a/Jolt/Physics/StateRecorderImpl.cpp
+++ b/Jolt/Physics/StateRecorderImpl.cpp
@@ -18,6 +18,11 @@ void StateRecorderImpl::Rewind()
 	mStream.seekg(0, std::stringstream::beg);
 }
 
+void StateRecorderImpl::Clear() {
+	mStream.clear();
+	mStream.str ({});
+}
+
 void StateRecorderImpl::ReadBytes(void *outData, size_t inNumBytes)
 {
 	if (IsValidating())

--- a/Jolt/Physics/StateRecorderImpl.h
+++ b/Jolt/Physics/StateRecorderImpl.h
@@ -22,6 +22,9 @@ public:
 	/// Rewind the stream for reading
 	void				Rewind();
 
+	/// Clear the stream for reuse
+	void				Clear();
+
 	/// Read a string of bytes from the binary stream
 	virtual void		ReadBytes(void *outData, size_t inNumBytes) override;
 


### PR DESCRIPTION
Implement 'Clear' function on StateRecorderImpl. Allows for clearing the StateRecorder instance and re-recording on the same stringstream.

Given the dependency on specific versions of c++ and libc++, I was not able to guarantee that some alternate libcxx instances won't discard the underlying buffer on Clear(), but in my tests I was able to confirm buffer-reuse against the emscripten's toolchain instance of libcxx.

This does seem to quickly create and free a zero-length basic_string during the `str({})` call that I was unable to avoid without recoding core stringstream behavior. 

Based on the emscripten Debug compilation, using it's included std::libc++, and tracking of the 'std::basic_string::__grow_by', 'std::basic_string::__alloc' and 'std::allocator<char>::deallocate' invocations, I was able to watch the underlying buffer creation and growth. The buffer growth logic appears to only be invoked on the first full population of the StateRecorderImpl, (create new buffer, copy to new buffer, delete old buffer), as long as subsequent saved states are less-than or equal-to the capacity of the stringstream.

Subsequent StateRecordingImpl SaveState invocations did not trigger any buffer allocation or deallocation.
