### PR TITLE
Changed AlignedAllocate to default to posix_memalign

### DIFF
--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -36,7 +36,7 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlig
 	return _aligned_malloc(inSize, inAlignment);
 #else
 	void *block = nullptr;
-	(void)posix_memalign(&block, inAlignment, AlignUp(inSize, inAlignment));
+	(void)posix_memalign(&block, inAlignment, inSize);
 	return block;
 #endif
 }

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -32,13 +32,12 @@ JPH_ALLOC_SCOPE void JPH_ALLOC_FN(Free)(void *inBlock)
 JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlignment)
 {
 #if defined(JPH_PLATFORM_WINDOWS)
-	// Microsoft doesn't implement C++17 std::aligned_alloc
+	// Microsoft doesn't implement posix_memalign
 	return _aligned_malloc(inSize, inAlignment);
-#elif defined(JPH_PLATFORM_ANDROID)
-	return memalign(inAlignment, AlignUp(inSize, inAlignment));
 #else
-	// Using aligned_alloc instead of std::aligned_alloc because the latter is not available on some macOS versions
-	return aligned_alloc(inAlignment, AlignUp(inSize, inAlignment));
+	void *block = nullptr;
+	posix_memalign(&block, inAlignment, AlignUp(inSize, inAlignment));
+	return block;
 #endif
 }
 
@@ -46,8 +45,6 @@ JPH_ALLOC_SCOPE void JPH_ALLOC_FN(AlignedFree)(void *inBlock)
 {
 #if defined(JPH_PLATFORM_WINDOWS)
 	_aligned_free(inBlock);
-#elif defined(JPH_PLATFORM_ANDROID)
-	free(inBlock);
 #else
 	free(inBlock);
 #endif

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -36,7 +36,10 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlig
 	return _aligned_malloc(inSize, inAlignment);
 #else
 	void *block = nullptr;
-	(void)posix_memalign(&block, inAlignment, inSize);
+	JPH_SUPPRESS_WARNING_PUSH
+	JPH_GCC_SUPPRESS_WARNING("-Wunused-result")
+	posix_memalign(&block, inAlignment, inSize);
+	JPH_SUPPRESS_WARNING_POP
 	return block;
 #endif
 }

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -36,7 +36,7 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlig
 	return _aligned_malloc(inSize, inAlignment);
 #else
 	void *block = nullptr;
-	posix_memalign(&block, inAlignment, AlignUp(inSize, inAlignment));
+	(void)posix_memalign(&block, inAlignment, AlignUp(inSize, inAlignment));
 	return block;
 #endif
 }


### PR DESCRIPTION
I'm in the process of implementing iOS support for Godot Jolt, and it turns out that `aligned_alloc` is only available on iOS >=13, as seen [here](https://opensource.apple.com/source/libmalloc/libmalloc-317.140.5/include/malloc/_malloc.h.auto.html). According to that header it also appears that `aligned_alloc` is not available on macOS versions prior to 10.15 (Catalina).

What is available however (also found in the link above) is `posix_memalign`.

I figured instead of adding even more platform ifdef's to `AlignedAllocate` I would just simplify things a bit and always default to `posix_memalign` on anything but Windows, as this seems to be available on Android as well. Although, I'm not sure how this change fares on that one blue platform.

I ran `PerformanceTest` on macOS and saw no difference compared to `aligned_allocate`.

Also note that `posix_memalign` technically returns an error code, but seeing as how none of the other allocation functions had any error-handling I opted to just ignore it.