### PR TITLE
Enabled optimizations for Distribution configuration on Android

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -169,6 +169,8 @@ elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQU
 
 	# Set linker flags
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+	set(CMAKE_CXX_FLAGS_DISTRIBUTION "${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
 
 # Set linker flags


### PR DESCRIPTION
This enables optimizations when building the `Distribution` configuration for Android, by simply copying the compile flags from `CMAKE_CXX_FLAGS_RELEASE` into `CMAKE_CXX_FLAGS_DISTRIBUTION`, which at the moment consists of `-O3` and `-DNDEBUG`.

I'm not very familiar with Android Studio and Gradle, so I'm not sure what the deal has been until now, but I get the feeling that the `buildTypes` defined in the Gradle files are limited to `debug` and `release`, which presumably translate to something like `CMAKE_BUILD_TYPE=Debug` and `CMAKE_BUILD_TYPE=Release` respectively, meaning projects like `PerformanceTest` has only ever been running `Release` on Android?

In either case, when building from command-line using the NDK it seems to be like any other LLVM toolchain and you can use whatever configurations you want, and the `Distribution` configuration doesn't currently define any flags on Android, thereby omitting optimizations entirely.

I wasn't sure whether to copy the flags from `CMAKE_CXX_FLAGS_RELEASE` or whether to just define them explicitly, but seeing as how none of the other configurations have defined them explicitly I opted to simply copy them.