### PR TITLE
Enforce MustIncludeC in GetClosestPointOnTriangle

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -2,7 +2,7 @@ name: Determinism Check
 
 env:
     CONVEX_VS_MESH_HASH: '0x10139effe747511'
-    RAGDOLL_HASH: '0xf6e41ad9d35ffa7f'
+    RAGDOLL_HASH: '0xcdcbb4da185d1a13'
 
 on:
   push:

--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -2,7 +2,7 @@ name: Determinism Check
 
 env:
     CONVEX_VS_MESH_HASH: '0x10139effe747511'
-    RAGDOLL_HASH: '0xfb18854efbb36f83'
+    RAGDOLL_HASH: '0xf6e41ad9d35ffa7f'
 
 on:
   push:

--- a/Jolt/Geometry/ClosestPoint.h
+++ b/Jolt/Geometry/ClosestPoint.h
@@ -183,6 +183,29 @@ namespace ClosestPoint
 			Vec3 closest_point = inC;
 			float best_dist_sq = inC.LengthSq();
 
+			// If the closest point must include C then A or B cannot be closest
+			// Note that we test vertices first because we want to prefer a closest vertex over a closest edge (this results in an outSet with fewer bits set)
+			if constexpr (!MustIncludeC)
+			{
+				// Try vertex A
+				float a_len_sq = inA.LengthSq();
+				if (a_len_sq < best_dist_sq)
+				{
+					closest_set = 0b0001;
+					closest_point = inA;
+					best_dist_sq = a_len_sq;
+				}
+
+				// Try vertex B
+				float b_len_sq = inB.LengthSq();
+				if (b_len_sq < best_dist_sq)
+				{
+					closest_set = 0b0010;
+					closest_point = inB;
+					best_dist_sq = b_len_sq;
+				}
+			}
+
 			// Edge AC
 			float ac_len_sq = ac.LengthSq();
 			if (ac_len_sq > Square(FLT_EPSILON))
@@ -214,27 +237,9 @@ namespace ClosestPoint
 				}
 			}
 
-			// If the closest point must include C then A or B cannot be closest
+			// If the closest point must include C then AB cannot be closest
 			if constexpr (!MustIncludeC)
 			{
-				// Try vertex A
-				float a_len_sq = inA.LengthSq();
-				if (a_len_sq < best_dist_sq)
-				{
-					closest_set = 0b0001;
-					closest_point = inA;
-					best_dist_sq = a_len_sq;
-				}
-
-				// Try vertex B
-				float b_len_sq = inB.LengthSq();
-				if (b_len_sq < best_dist_sq)
-				{
-					closest_set = 0b0010;
-					closest_point = inB;
-					best_dist_sq = b_len_sq;
-				}
-
 				// Edge AB
 				ab = inB - inA;
 				float ab_len_sq = ab.LengthSq();

--- a/Jolt/Geometry/ClosestPoint.h
+++ b/Jolt/Geometry/ClosestPoint.h
@@ -205,15 +205,16 @@ namespace ClosestPoint
 				}
 
 				// Edge AB
+				ab = inB - inA;
 				float ab_len_sq = ab.LengthSq();
 				if (ab_len_sq > Square(FLT_EPSILON))
 				{
-					float v = Clamp(-a.Dot(ab) / ab_len_sq, 0.0f, 1.0f);
-					Vec3 q = a + v * ab;
+					float v = Clamp(-inA.Dot(ab) / ab_len_sq, 0.0f, 1.0f);
+					Vec3 q = inA + v * ab;
 					float dist_sq = q.LengthSq();
 					if (dist_sq < best_dist_sq)
 					{
-						closest_set = swap_ac.GetX()? 0b0110 : 0b0011;
+						closest_set = 0b0011;
 						closest_point = q;
 						best_dist_sq = dist_sq;
 					}
@@ -236,7 +237,7 @@ namespace ClosestPoint
 			}
 
 			// Edge BC
-			Vec3 bc = c - inB;
+			Vec3 bc = inC - inB;
 			float bc_len_sq = bc.LengthSq();
 			if (bc_len_sq > Square(FLT_EPSILON))
 			{
@@ -245,7 +246,7 @@ namespace ClosestPoint
 				float dist_sq = q.LengthSq();
 				if (dist_sq < best_dist_sq)
 				{
-					closest_set = swap_ac.GetX()? 0b0011 : 0b0110;
+					closest_set = 0b0110;
 					closest_point = q;
 					best_dist_sq = dist_sq;
 				}

--- a/Jolt/Geometry/ClosestPoint.h
+++ b/Jolt/Geometry/ClosestPoint.h
@@ -183,6 +183,37 @@ namespace ClosestPoint
 			Vec3 closest_point = inC;
 			float best_dist_sq = inC.LengthSq();
 
+			// Edge AC
+			float ac_len_sq = ac.LengthSq();
+			if (ac_len_sq > Square(FLT_EPSILON))
+			{
+				float v = Clamp(-a.Dot(ac) / ac_len_sq, 0.0f, 1.0f);
+				Vec3 q = a + v * ac;
+				float dist_sq = q.LengthSq();
+				if (dist_sq < best_dist_sq)
+				{
+					closest_set = 0b0101;
+					closest_point = q;
+					best_dist_sq = dist_sq;
+				}
+			}
+
+			// Edge BC
+			Vec3 bc = inC - inB;
+			float bc_len_sq = bc.LengthSq();
+			if (bc_len_sq > Square(FLT_EPSILON))
+			{
+				float v = Clamp(-inB.Dot(bc) / bc_len_sq, 0.0f, 1.0f);
+				Vec3 q = inB + v * bc;
+				float dist_sq = q.LengthSq();
+				if (dist_sq < best_dist_sq)
+				{
+					closest_set = 0b0110;
+					closest_point = q;
+					best_dist_sq = dist_sq;
+				}
+			}
+
 			// If the closest point must include C then A or B cannot be closest
 			if constexpr (!MustIncludeC)
 			{
@@ -218,37 +249,6 @@ namespace ClosestPoint
 						closest_point = q;
 						best_dist_sq = dist_sq;
 					}
-				}
-			}
-
-			// Edge AC
-			float ac_len_sq = ac.LengthSq();
-			if (ac_len_sq > Square(FLT_EPSILON))
-			{
-				float v = Clamp(-a.Dot(ac) / ac_len_sq, 0.0f, 1.0f);
-				Vec3 q = a + v * ac;
-				float dist_sq = q.LengthSq();
-				if (dist_sq < best_dist_sq)
-				{
-					closest_set = 0b0101;
-					closest_point = q;
-					best_dist_sq = dist_sq;
-				}
-			}
-
-			// Edge BC
-			Vec3 bc = inC - inB;
-			float bc_len_sq = bc.LengthSq();
-			if (bc_len_sq > Square(FLT_EPSILON))
-			{
-				float v = Clamp(-inB.Dot(bc) / bc_len_sq, 0.0f, 1.0f);
-				Vec3 q = inB + v * bc;
-				float dist_sq = q.LengthSq();
-				if (dist_sq < best_dist_sq)
-				{
-					closest_set = 0b0110;
-					closest_point = q;
-					best_dist_sq = dist_sq;
 				}
 			}
 


### PR DESCRIPTION
This PR is referring to the discussion https://github.com/jrouwe/JoltPhysics/discussions/740#discussioncomment-7515585 and fixes the described problem.

Note that we can overwrite the variable _ab_ as the function returns after testing the edge BC and, therefore, its last use only involves testing the edge AB.
