### PR TITLE
Fix Linux shared compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,26 @@ jobs:
       working-directory: ${{github.workspace}}/Build/Linux_${{matrix.build_type}}_${{matrix.clang_version}}
       run: ctest --output-on-failure
 
+  linux-gcc-so:
+    runs-on: ubuntu-latest
+    name: Linux GCC Shared Library
+    strategy:
+        fail-fast: false
+        matrix:
+            build_type: [Debug, Release, Distribution]
+            clang_version: [g++]
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/Build/Linux_${{matrix.build_type}}_${{matrix.clang_version}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_COMPILER=${{matrix.clang_version}} -DBUILD_SHARED_LIBS=Yes Build
+    - name: Build
+      run: cmake --build ${{github.workspace}}/Build/Linux_${{matrix.build_type}}_${{matrix.clang_version}} -j 2
+    - name: Test
+      working-directory: ${{github.workspace}}/Build/Linux_${{matrix.build_type}}_${{matrix.clang_version}}
+      run: ctest --output-on-failure
+
   msys2_mingw_gcc:
     runs-on: windows-latest
     defaults:

--- a/Jolt/Core/Color.h
+++ b/Jolt/Core/Color.h
@@ -12,7 +12,7 @@ class Color;
 using ColorArg = Color;
 
 /// Class that holds an RGBA color with 8-bits per component
-class [[nodiscard]] JPH_EXPORT Color
+class [[nodiscard]] JPH_EXPORT_TYPE Color
 {
 public:
 	/// Constructors

--- a/Jolt/Core/Color.h
+++ b/Jolt/Core/Color.h
@@ -12,7 +12,7 @@ class Color;
 using ColorArg = Color;
 
 /// Class that holds an RGBA color with 8-bits per component
-class [[nodiscard]] JPH_EXPORT_TYPE Color
+class [[nodiscard]] JPH_EXPORT_GCC_BUG_WORKAROUND Color
 {
 public:
 	/// Constructors

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -193,8 +193,8 @@
 		#else
 			#define JPH_EXPORT __attribute__ ((visibility ("default")))
 			#if defined(JPH_COMPILER_GCC)
-				// Prevents an issue with GCC attribute parsing
-				#define JPH_EXPORT_TYPE [[gnu::visibility("default")]]
+				// Prevents an issue with GCC attribute parsing (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69585)
+				#define JPH_EXPORT_GCC_BUG_WORKAROUND [[gnu::visibility("default")]]
 			#endif
 		#endif
 	#else
@@ -204,8 +204,8 @@
 		#else
 			#define JPH_EXPORT __attribute__ ((visibility ("default")))
 			#if defined(JPH_COMPILER_GCC)
-				// Prevents an issue with GCC attribute parsing
-				#define JPH_EXPORT_TYPE [[gnu::visibility("default")]]
+				// Prevents an issue with GCC attribute parsing (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69585)
+				#define JPH_EXPORT_GCC_BUG_WORKAROUND [[gnu::visibility("default")]]
 			#endif
 		#endif
 	#endif
@@ -214,8 +214,8 @@
 	#define JPH_EXPORT
 #endif
 
-#ifndef JPH_EXPORT_TYPE
-	#define JPH_EXPORT_TYPE JPH_EXPORT
+#ifndef JPH_EXPORT_GCC_BUG_WORKAROUND
+	#define JPH_EXPORT_GCC_BUG_WORKAROUND JPH_EXPORT
 #endif
 
 // Macro used by the RTTI macros to not export a function

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -192,6 +192,10 @@
 			#define JPH_EXPORT __declspec(dllexport)
 		#else
 			#define JPH_EXPORT __attribute__ ((visibility ("default")))
+			#if defined(JPH_COMPILER_GCC)
+				// Prevents an issue with GCC attribute parsing
+				#define JPH_EXPORT_TYPE [[gnu::visibility("default")]]
+			#endif
 		#endif
 	#else
 		// When linking against Jolt, we must import these symbols
@@ -199,11 +203,19 @@
 			#define JPH_EXPORT __declspec(dllimport)
 		#else
 			#define JPH_EXPORT __attribute__ ((visibility ("default")))
+			#if defined(JPH_COMPILER_GCC)
+				// Prevents an issue with GCC attribute parsing
+				#define JPH_EXPORT_TYPE [[gnu::visibility("default")]]
+			#endif
 		#endif
 	#endif
 #else
 	// If the define is not set, we use static linking and symbols don't need to be imported or exported
 	#define JPH_EXPORT
+#endif
+
+#ifndef JPH_EXPORT_TYPE
+	#define JPH_EXPORT_TYPE JPH_EXPORT
 #endif
 
 // Macro used by the RTTI macros to not export a function

--- a/Jolt/Core/Profiler.h
+++ b/Jolt/Core/Profiler.h
@@ -166,7 +166,7 @@ private:
 };
 
 // Class that contains the information of a single scoped measurement
-class alignas(16) JPH_EXPORT_TYPE ProfileSample : public NonCopyable
+class alignas(16) JPH_EXPORT_GCC_BUG_WORKAROUND ProfileSample : public NonCopyable
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE

--- a/Jolt/Core/Profiler.h
+++ b/Jolt/Core/Profiler.h
@@ -166,7 +166,7 @@ private:
 };
 
 // Class that contains the information of a single scoped measurement
-class alignas(16) JPH_EXPORT ProfileSample : public NonCopyable
+class alignas(16) JPH_EXPORT_TYPE ProfileSample : public NonCopyable
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE

--- a/Jolt/Geometry/OrientedBox.h
+++ b/Jolt/Geometry/OrientedBox.h
@@ -14,7 +14,7 @@ JPH_NAMESPACE_BEGIN
 class AABox;
 
 /// Oriented box
-class [[nodiscard]] JPH_EXPORT OrientedBox
+class [[nodiscard]] JPH_EXPORT_TYPE OrientedBox
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE

--- a/Jolt/Geometry/OrientedBox.h
+++ b/Jolt/Geometry/OrientedBox.h
@@ -14,7 +14,7 @@ JPH_NAMESPACE_BEGIN
 class AABox;
 
 /// Oriented box
-class [[nodiscard]] JPH_EXPORT_TYPE OrientedBox
+class [[nodiscard]] JPH_EXPORT_GCC_BUG_WORKAROUND OrientedBox
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE

--- a/Jolt/Physics/Body/Body.h
+++ b/Jolt/Physics/Body/Body.h
@@ -31,7 +31,7 @@ class SoftBodyCreationSettings;
 /// The functions that get/set the position of the body all indicate if they are relative to the center of mass or to the original position in which the shape was created.
 ///
 /// The linear velocity is also velocity of the center of mass, to correct for this: \f$VelocityCOM = Velocity - AngularVelocity \times ShapeCOM\f$.
-class alignas(JPH_RVECTOR_ALIGNMENT) JPH_EXPORT_TYPE Body : public NonCopyable
+class alignas(JPH_RVECTOR_ALIGNMENT) JPH_EXPORT_GCC_BUG_WORKAROUND Body : public NonCopyable
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE

--- a/Jolt/Physics/Body/Body.h
+++ b/Jolt/Physics/Body/Body.h
@@ -31,7 +31,7 @@ class SoftBodyCreationSettings;
 /// The functions that get/set the position of the body all indicate if they are relative to the center of mass or to the original position in which the shape was created.
 ///
 /// The linear velocity is also velocity of the center of mass, to correct for this: \f$VelocityCOM = Velocity - AngularVelocity \times ShapeCOM\f$.
-class alignas(JPH_RVECTOR_ALIGNMENT) JPH_EXPORT Body : public NonCopyable
+class alignas(JPH_RVECTOR_ALIGNMENT) JPH_EXPORT_TYPE Body : public NonCopyable
 {
 public:
 	JPH_OVERRIDE_NEW_DELETE


### PR DESCRIPTION
(Looks like I created this PR on the main repo instead of my fork, sorry about that, I'm making this a draft until I fix this)

Jolt doesn't compile as a shared library on Linux using GCC (works fine with Clang), because of a weird parsing conflict between the `[[nodiscard]]` and the visibility attribute on Color and OrientedBox classes