### PR TITLE
Tautology in GetPenetrationDepthStepEPA

### DIFF
--- a/Jolt/Geometry/EPAConvexHullBuilder.h
+++ b/Jolt/Geometry/EPAConvexHullBuilder.h
@@ -209,7 +209,7 @@ public:
 		/// Get next closest triangle
 		Triangle *		PopClosest()
 		{
-			// Move largest to end
+			// Move closest to end
 			std::pop_heap(begin(), end(), sTriangleSorter);
 
 			// Remove last triangle

--- a/Jolt/Geometry/EPAPenetrationDepth.h
+++ b/Jolt/Geometry/EPAPenetrationDepth.h
@@ -284,9 +284,9 @@ public:
 			if (!t->IsFacing(w) || !hull.AddPoint(t, new_index, FLT_MAX, new_triangles))
 				return false;
 
-			// If the triangle was removed we can free it now
-			if (t->mRemoved)
-				hull.FreeTriangle(t);
+			// The triangle is facing the origin and can now be safely removed
+			JPH_ASSERT(t->mRemoved);
+			hull.FreeTriangle(t);
 
 			// If we run out of triangles or points, we couldn't include the origin in the hull so there must be very little penetration and we report no collision.
 			if (!hull.HasNextTriangle() || support_points.mY.size() >= cMaxPointsToIncludeOriginInHull)

--- a/Jolt/Geometry/EPAPenetrationDepth.h
+++ b/Jolt/Geometry/EPAPenetrationDepth.h
@@ -284,7 +284,7 @@ public:
 			if (!t->IsFacing(w) || !hull.AddPoint(t, new_index, FLT_MAX, new_triangles))
 				return false;
 
-			// The triangle is facing the origin and can now be safely removed
+			// The triangle is facing the support point "w" and can now be safely removed
 			JPH_ASSERT(t->mRemoved);
 			hull.FreeTriangle(t);
 


### PR DESCRIPTION
The function ConvexHullBuilder::AddPoint calls ConvexHullBuilder::FindEdge, which sets `inFacingFace->mRemoved = true`. Thus, the condition `if (t->mRemoved)` in GetPenetrationDepthStepEPA is always true.

Furthermore, this PR also fixes a "misleading" comment in TriangleQueue::PopClosest: Given sTriangleSorter, the function pop_heap moves the closest point to the end, not the largest one.