### PR TITLE
Adds a tool to validate the VirtualCharacter determinism, to find the code that is making it non deterministic.

### DIFF
--- a/Samples/Tests/Character/CharacterBaseTest.cpp
+++ b/Samples/Tests/Character/CharacterBaseTest.cpp
@@ -529,11 +529,8 @@ void CharacterBaseTest::Initialize()
 	}
 }
 
-void CharacterBaseTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
+void CharacterBaseTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Arg& outMovementDirection, bool &outJump, bool &outSwitchStance)
 {
-	// Update scene time
-	mTime += inParams.mDeltaTime;
-
 	// Determine controller input
 	Vec3 control_input = Vec3::sZero();
 	if (inParams.mKeyboard->IsKeyPressed(DIK_LEFT))		control_input.SetZ(-1);
@@ -560,6 +557,21 @@ void CharacterBaseTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 		else if (key == DIK_RCONTROL)
 			jump = true;
 	}
+
+	outMovementDirection = control_input;
+	outJump = jump;
+	outSwitchStance = switch_stance;
+}
+
+void CharacterBaseTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
+{
+	// Update scene time
+	mTime += inParams.mDeltaTime;
+
+	Vec3 control_input = Vec3::sZero();
+	bool jump = false;
+	bool switch_stance = false;
+	FetchNewInput(inParams, control_input, jump, switch_stance);
 
 	// Animate bodies
 	if (!mRotatingBody.IsInvalid())
@@ -684,5 +696,5 @@ void CharacterBaseTest::DrawCharacterState(const CharacterBase *inCharacter, RMa
 	const PhysicsMaterial *ground_material = inCharacter->GetGroundMaterial();
 	Vec3 horizontal_velocity = inCharacterVelocity;
 	horizontal_velocity.SetY(0);
-	mDebugRenderer->DrawText3D(inCharacterTransform.GetTranslation(), StringFormat("State: %s\nMat: %s\nHorizontal Vel: %.1f m/s\nVertical Vel: %.1f m/s", CharacterBase::sToString(ground_state), ground_material->GetDebugName(), (double)horizontal_velocity.Length(), (double)inCharacterVelocity.GetY()), Color::sWhite, 0.25f);
+	mDebugRenderer->DrawText3D(inCharacterTransform.GetTranslation(), StringFormat("State: %s\nMat: %s\nHorizontal Vel: %.1f m/s\nVertical Vel: %.1f m/s\n%s", CharacterBase::sToString(ground_state), ground_material->GetDebugName(), (double)horizontal_velocity.Length(), (double)inCharacterVelocity.GetY(), GetAdditionalCharacterStateInfo()), Color::sWhite, 0.25f);
 }

--- a/Samples/Tests/Character/CharacterBaseTest.h
+++ b/Samples/Tests/Character/CharacterBaseTest.h
@@ -19,6 +19,9 @@ public:
 	// Initialize the test
 	virtual void			Initialize() override;
 
+	// Fetches the character input to use on the next frame.
+	virtual void			FetchNewInput(const PreUpdateParams &inParams, Vec3Arg& outMovementDirection, bool &outJump, bool &outSwitchStance);
+
 	// Update the test, called before the physics update
 	virtual void			PrePhysicsUpdate(const PreUpdateParams &inParams) override;
 
@@ -45,6 +48,7 @@ protected:
 
 	// Draw the character state
 	void					DrawCharacterState(const CharacterBase *inCharacter, RMat44Arg inCharacterTransform, Vec3Arg inCharacterVelocity);
+	virtual const char*		GetAdditionalCharacterStateInfo() const { return ""; }
 
 	// Add character movement settings
 	virtual void			AddCharacterMovementSettings(DebugUI* inUI, UIElement* inSubMenu) { /* Nothing by default */ }

--- a/Samples/Tests/Character/CharacterVirtualTest.cpp
+++ b/Samples/Tests/Character/CharacterVirtualTest.cpp
@@ -61,12 +61,14 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 			recorder.WriteBytes(snapshot.mInitialState.data(), snapshot.mInitialState.size());
 			recorder.SetValidating(false);
 			mCharacter->RestoreState(recorder);
+			recorder.Read(mDesiredVelocity);
 			mNonDeterministicFrames.clear();
 		}
 
 		// Validate the frame state by comparing it with the one recorded previously.
 		StateRecorderImpl recorder;
 		mCharacter->SaveState(recorder);
+		recorder.Write(mDesiredVelocity);
 		const string data = recorder.GetData();
 		const bool is_valid = data == snapshot.mInitialState;
 		if (!is_valid)
@@ -100,6 +102,7 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 		{
 			StateRecorderImpl recorder;
 			mCharacter->SaveState(recorder);
+			recorder.Write(mDesiredVelocity);
 
 			FrameSnapshot frame_snapshot;
 			frame_snapshot.mInitialState = recorder.GetData();

--- a/Samples/Tests/Character/CharacterVirtualTest.cpp
+++ b/Samples/Tests/Character/CharacterVirtualTest.cpp
@@ -61,6 +61,7 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 			recorder.WriteBytes(snapshot.mInitialState.data(), snapshot.mInitialState.size());
 			recorder.SetValidating(false);
 			mCharacter->RestoreState(recorder);
+			recorder.Read(mAllowSliding);
 			recorder.Read(mDesiredVelocity);
 			mNonDeterministicFrames.clear();
 		}
@@ -68,6 +69,7 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 		// Validate the frame state by comparing it with the one recorded previously.
 		StateRecorderImpl recorder;
 		mCharacter->SaveState(recorder);
+		recorder.Write(mAllowSliding);
 		recorder.Write(mDesiredVelocity);
 		const string data = recorder.GetData();
 		const bool is_valid = data == snapshot.mInitialState;
@@ -102,6 +104,7 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 		{
 			StateRecorderImpl recorder;
 			mCharacter->SaveState(recorder);
+			recorder.Write(mAllowSliding);
 			recorder.Write(mDesiredVelocity);
 
 			FrameSnapshot frame_snapshot;

--- a/Samples/Tests/Character/CharacterVirtualTest.cpp
+++ b/Samples/Tests/Character/CharacterVirtualTest.cpp
@@ -63,17 +63,15 @@ void CharacterVirtualTest::FetchNewInput(const PreUpdateParams &inParams, Vec3Ar
 			mCharacter->RestoreState(recorder);
 			mNonDeterministicFrames.clear();
 		}
-		else
+
+		// Validate the frame state by comparing it with the one recorded previously.
+		StateRecorderImpl recorder;
+		mCharacter->SaveState(recorder);
+		const string data = recorder.GetData();
+		const bool is_valid = data == snapshot.mInitialState;
+		if (!is_valid)
 		{
-			// On all the other frames we check the state is exactly like the one initially recorded.
-			StateRecorderImpl recorder;
-			mCharacter->SaveState(recorder);
-			const string data = recorder.GetData();
-			const bool is_valid = data == snapshot.mInitialState;
-			if (!is_valid)
-			{
-				mNonDeterministicFrames.push_back(mReplayingFrame);
-			}
+			mNonDeterministicFrames.push_back(mReplayingFrame);
 		}
 
 		// Set the recorded input.
@@ -333,7 +331,7 @@ const char* CharacterVirtualTest::GetAdditionalCharacterStateInfo() const
 		}
 	}
 
-	str += "\nNON DETERMINISTIC FRAMES";
+	str += "\nNON DETERMINISTIC FRAMES: ";
 	int c = 0;
 	for (int frame_index : mNonDeterministicFrames)
 	{

--- a/TestFramework/Input/Keyboard.cpp
+++ b/TestFramework/Input/Keyboard.cpp
@@ -31,6 +31,7 @@ void Keyboard::Reset()
 void Keyboard::ResetKeyboard()
 {
 	memset(&mKeyPressed, 0, sizeof(mKeyPressed));
+	memset(&mKeyJustReleased, 0, sizeof(mKeyJustReleased));
 	memset(&mTimeKeyLastReleased, 0, sizeof(mTimeKeyLastReleased));
 	memset(&mKeyDoubleClicked, 0, sizeof(mKeyDoubleClicked));
 	memset(&mDOD, 0, sizeof(mDOD));
@@ -117,6 +118,10 @@ void Keyboard::Poll()
 {
 	JPH_PROFILE_FUNCTION();
 
+
+	char previously_pressed_keys[256];
+	memcpy(&previously_pressed_keys, &mKeyPressed, sizeof(previously_pressed_keys));
+
 	// Get the state of the keyboard
 	if (FAILED(mKeyboard->GetDeviceState(sizeof(mKeyPressed), mKeyPressed)))
 	{
@@ -127,6 +132,12 @@ void Keyboard::Poll()
 			ResetKeyboard();
 			return;
 		}
+	}
+
+	// Check the just released
+	for(int key = 0; key < 256; key += 1)
+	{
+		mKeyJustReleased[key] = previously_pressed_keys[key] && !mKeyPressed[key];
 	}
 
 	// Get the state in a buffer

--- a/TestFramework/Input/Keyboard.h
+++ b/TestFramework/Input/Keyboard.h
@@ -27,6 +27,7 @@ public:
 
 	/// Checks if a key is pressed or not, use one of the DIK_* constants
 	bool							IsKeyPressed(int inKey) const		{ return mKeyPressed[inKey] != 0; }
+	bool							IsKeyJustReleased(int inKey) const	{ return mKeyJustReleased[inKey] != 0; }
 	bool							IsKeyDoubleClicked(int inKey) const	{ return mKeyDoubleClicked[inKey] != 0; }
 
 	/// Buffered keyboard input, returns 0 for none or one of the DIK_* constants
@@ -49,6 +50,7 @@ private:
 	ComPtr<IDirectInput8>			mDI;
 	ComPtr<IDirectInputDevice8>		mKeyboard;
 	char							mKeyPressed[256];
+	char							mKeyJustReleased[256];
 	int								mKeyDoubleClicked[256];
 	int								mTimeKeyLastReleased[256];
 	DIDEVICEOBJECTDATA				mDOD[BUFFERSIZE];


### PR DESCRIPTION
Hello, I've debugged a desync issue on the game [The Mirror](https://www.themirror.space/), that occurs when the Virtual Character leaves the ground (OR touches the ground for the first time). Which is easily reproducible by jumping.

![ezgif com-video-to-gif-converted](https://github.com/jrouwe/JoltPhysics/assets/8342599/7055dda7-8ad5-4c17-804b-07894852871f)

The purpose of this code is to find the route cause of this desync, which seems coming from Jolt, and give more tools to the Jolt's community to keep the code deterministic.

On the video below you will see the `VirtualCharacter` replaying a series of input, 4 times, recorded just few seconds before - offscreen. You can notice, from the array printed on the line **NON DETERMINISTIC FRAMES**, that even just moving the capsule horizontally on a flat plane (not even jumping) the taken snapshots differ, meaning the execution was not deterministic.
My educated guess is that there is some non deterministic code inside the `VirtualCharacter`, which result is much noticeable when the `VirtualCharacter` leaves or touches the ground.

https://github.com/jrouwe/JoltPhysics/assets/8342599/4e922935-2b97-4488-8a4f-091884915cd1

If you come up with something regarding this issue that can help me fixing it, please let me know.

# Change description
This commit introduce a basic rewinding mechanism, that allows to record a series of input and replay them. This mechanism can be used to test the VirtualCharacter determinism on many situations.

When playing, is now possible to press `Y` to start recording the inputs (press `Y` again to stop it), and then by pressing `U` it's possible to replay those inputs and validate the VirtualCharacter state on each frame. On the UI, will be displayed the list of frames which the state differs from the one originally recorded so the rewinding was not deterministic.

