### PR TITLE
Sorting contacts before processing them

### DIFF
--- a/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Jolt/Physics/Character/CharacterVirtual.h
@@ -316,7 +316,7 @@ private:
 	// Sorting predicate for making contact order deterministic
 	struct ContactOrderingPredicate
 	{
-		inline bool						operator () (const Contact &inLHS, const Contact &inRHS)
+		inline bool						operator () (const Contact &inLHS, const Contact &inRHS) const
 		{
 			if (inLHS.mBodyB != inRHS.mBodyB)
 				return inLHS.mBodyB < inRHS.mBodyB;

--- a/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Jolt/Physics/Character/CharacterVirtual.h
@@ -313,6 +313,18 @@ public:
 	const ContactList &					GetActiveContacts() const								{ return mActiveContacts; }
 
 private:
+	// Sorting predicate for making contact order deterministic
+	struct ContactOrderingPredicate
+	{
+		inline bool						operator () (const Contact &inLHS, const Contact &inRHS)
+		{
+			if (inLHS.mBodyB != inRHS.mBodyB)
+				return inLHS.mBodyB < inRHS.mBodyB;
+
+			return inLHS.mSubShapeIDB.GetValue() < inRHS.mSubShapeIDB.GetValue();
+		}
+	};
+
 	// A contact that needs to be ignored
 	struct IgnoredContact
 	{


### PR DESCRIPTION
Contacts are returned in a non-deterministic way because the broadphase is updated concurrently, this means that we need to sort the character contacts before using them.