### PR TITLE
Renaming Body::ResetSleepTestSpheres to ResetSleepTimer and making it public.

### DIFF
--- a/Jolt/Physics/Body/Body.cpp
+++ b/Jolt/Physics/Body/Body.cpp
@@ -75,7 +75,7 @@ void Body::SetAllowSleeping(bool inAllow)
 {
 	mMotionProperties->mAllowSleeping = inAllow;
 	if (inAllow)
-		ResetSleepTestSpheres();
+		ResetSleepTimer();
 }
 
 void Body::MoveKinematic(RVec3Arg inTargetPosition, QuatArg inTargetRotation, float inDeltaTime)
@@ -99,7 +99,7 @@ void Body::CalculateWorldSpaceBoundsInternal()
 	mBounds = mShape->GetWorldSpaceBounds(GetCenterOfMassTransform(), Vec3::sReplicate(1.0f));
 }
 
-void Body::SetPositionAndRotationInternal(RVec3Arg inPosition, QuatArg inRotation, bool inResetSleepTestSpheres)
+void Body::SetPositionAndRotationInternal(RVec3Arg inPosition, QuatArg inRotation, bool inResetSleepTimer)
 {
 	JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sPositionAccess, BodyAccess::EAccess::ReadWrite));
 
@@ -110,8 +110,8 @@ void Body::SetPositionAndRotationInternal(RVec3Arg inPosition, QuatArg inRotatio
 	CalculateWorldSpaceBoundsInternal();
 
 	// Reset sleeping test
-	if (inResetSleepTestSpheres && mMotionProperties != nullptr)
-		ResetSleepTestSpheres();
+	if (inResetSleepTimer && mMotionProperties != nullptr)
+		ResetSleepTimer();
 }
 
 void Body::UpdateCenterOfMassInternal(Vec3Arg inPreviousCenterOfMass, bool inUpdateMassProperties)

--- a/Jolt/Physics/Body/Body.h
+++ b/Jolt/Physics/Body/Body.h
@@ -124,6 +124,9 @@ public:
 	bool					GetAllowSleeping() const										{ return mMotionProperties->mAllowSleeping; }
 	void					SetAllowSleeping(bool inAllow);
 
+	/// Resets the sleep timer. This does not wake up the body if it is sleeping, but allows resetting the system that detects when a body is sleeping.
+	inline void				ResetSleepTimer();												
+
 	/// Friction (dimensionless number, usually between 0 and 1, 0 = no friction, 1 = friction force equals force that presses the two bodies together). Note that bodies can have negative friction but the combined friction (see PhysicsSystem::SetCombineFriction) should never go below zero.
 	inline float			GetFriction() const												{ return mFriction; }
 	void					SetFriction(float inFriction)									{ mFriction = inFriction; }
@@ -289,7 +292,7 @@ public:
 	void					CalculateWorldSpaceBoundsInternal();
 
 	/// Function to update body's position (should only be called by the BodyInterface since it also requires updating the broadphase)
-	void					SetPositionAndRotationInternal(RVec3Arg inPosition, QuatArg inRotation, bool inResetSleepTestSpheres = true);
+	void					SetPositionAndRotationInternal(RVec3Arg inPosition, QuatArg inRotation, bool inResetSleepTimer = true);
 
 	/// Updates the center of mass and optionally mass propertes after shifting the center of mass or changes to the shape (should only be called by the BodyInterface since it also requires updating the broadphase)
 	/// @param inPreviousCenterOfMass Center of mass of the shape before the alterations
@@ -323,7 +326,6 @@ private:
 	explicit				Body(bool);														///< Alternative constructor that initializes all members
 
 	inline void				GetSleepTestPoints(RVec3 *outPoints) const;						///< Determine points to test for checking if body is sleeping: COM, COM + largest bounding box axis, COM + second largest bounding box axis
-	inline void				ResetSleepTestSpheres();										///< Reset spheres to current position as returned by GetSleepTestPoints
 
 	enum class EFlags : uint8
 	{

--- a/Jolt/Physics/Body/Body.inl
+++ b/Jolt/Physics/Body/Body.inl
@@ -196,7 +196,7 @@ void Body::GetSleepTestPoints(RVec3 *outPoints) const
 	}
 }
 
-void Body::ResetSleepTestSpheres()
+void Body::ResetSleepTimer()
 {
 	RVec3 points[3];
 	GetSleepTestPoints(points);

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -558,7 +558,7 @@ void BodyManager::ActivateBodies(const BodyID *inBodyIDs, int inNumber)
 				&& body.mMotionProperties->mIndexInActiveBodies == Body::cInactiveIndex)
 			{
 				// Reset sleeping
-				body.ResetSleepTestSpheres();
+				body.ResetSleepTimer();
 
 				AddBodyToActiveBodies(body);
 


### PR DESCRIPTION
This allows more fine grained control over when an object goes to sleep.