### PR TITLE
Update README.md

### DIFF
--- a/Build/README.md
+++ b/Build/README.md
@@ -48,94 +48,130 @@ To implement your custom memory allocator override Allocate, Free, AlignedAlloca
 
 ## Building
 
-### Windows 10+ (CL - Default compiler)
+<details>
+	<summary>Windows 10+</summary>
+	<ul>
+		<details>
+			<summary>(CL - Default compiler)</summary>
+			<ul>
+				<li>Download Visual Studio 2022 (Community or other edition)</li>
+				<li>Download CMake 3.15+ (https://cmake.org/download/)</li>
+				<li>Run cmake_vs2022_cl.bat</li>
+				<li>Open the resulting project file VS2022_CL\JoltPhysics.sln</li>
+				<li>Compile and run either 'Samples' or 'UnitTests'</li>
+			</ul>
+		</details>
+		<details>
+			<summary>10+ (CL - 32 bit)</summary>
+			<ul>
+				<li>Download Visual Studio 2022 (Community or other edition)</li>
+				<li>Download CMake 3.15+ (https://cmake.org/download/)</li>
+				<li>Run cmake_vs2022_cl_32bit.bat</li>
+				<li>Open the resulting project file VS2022_CL_32BIT\JoltPhysics.sln</li>
+				<li>Compile and run either 'Samples' or 'UnitTests'</li>
+			</ul>
+		</details>
+		<details>
+			<summary>(Clang compiler)</summary>
+			<ul>
+				<li>Download Visual Studio 2022 (Community or other edition)</li>
+				<li>Make sure to install "C++ Clang Compiler for Windows 11.0.0+" and "C++ Clang-cl for v142+ build tools (x64/x86)" using the Visual Studio Installer</li>
+				<li>Download CMake 3.15+ (https://cmake.org/download/)</li>
+				<li>Run cmake_vs2022_clang.bat</li>
+				<li>Open the resulting project file VS2022_Clang\JoltPhysics.sln</li>
+				<li>Compile and run either 'Samples' or 'UnitTests'</li>
+			</ul>
+		</details>
+		<details>
+			<summary>(Universal Windows Platform)</summary>
+			<ul>
+				<li>Download Visual Studio 2022+ (Community or other edition)</li>
+				<li>Make sure to install "Universal Windows Platform development" using the Visual Studio Installer</li>
+				<li>Download CMake 3.15+ (https://cmake.org/download/)</li>
+				<li>Run cmake_vs2022_uwp.bat</li>
+				<li>Open the resulting project file VS2022_UWP\JoltPhysics.sln</li>
+				<li>Compile and run 'UnitTests'</li>
+			</ul>
+		</details>
+		<details>
+			<summary>(MinGW)</summary>
+			<ul>
+				<li>Follow download instructions for MSYS2 (https://www.msys2.org/)</li>
+				<li>From the MSYS2 MSYS app run: pacman -S --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake</li>
+				<li>From the MSYS2 MINGW x64 app, in the Build folder run: ./cmake_windows_mingw.sh</li>
+				<li>Run: cmake --build MinGW_Debug</li>
+				<li>Run: MinGW_Debug/UnitTests.exe</li>
+			</ul>
+		</details>
+	</ul>	
+</details>
 
-- Download Visual Studio 2022 (Community or other edition)
-- Download CMake 3.15+ (https://cmake.org/download/)
-- Run cmake_vs2022_cl.bat
-- Open the resulting project file VS2022_CL\JoltPhysics.sln
-- Compile and run either 'Samples' or 'UnitTests'
+<details>
+	<summary>Linux</summary>
+	<ul>
+		<details>
+			<summary>(Debian flavor, x64 or ARM64)</summary>
+			<ul>
+				<li>Install clang (apt-get install clang)</li>
+				<li>Install cmake (apt-get install cmake)</li>
+				<li>Run: ./cmake_linux_clang_gcc.sh</li>
+				<li>Go to the Linux_Debug folder</li>
+				<li>Run: make -j$(nproc) && ./UnitTests</li>
+			</ul>
+		</details>
+		<details>
+			<summary>(Debian flavor, MinGW Cross Compile)</summary>
+			<ul>
+				<li>This setup can be used to run samples on Linux using wine and vkd3d. Tested on Ubuntu 22.04</li>
+				<li>Graphics card must support Vulkan and related drivers must be installed</li>
+				<li>Install mingw-w64 (apt-get install mingw-w64)</li>
+				<li>Run: update-alternatives --config x86_64-w64-mingw32-g++ (Select /usr/bin/x86_64-w64-mingw32-g++-posix)</li>
+				<li>Install cmake (apt-get install cmake)</li>
+				<li>Install wine64 (apt-get install wine64)</li>
+				<li>Run: export WINEPATH="/usr/x86_64-w64-mingw32/lib;/usr/lib/gcc/x86_64-w64-mingw32/10-posix" (change it based on your environment)</li>
+				<li>Run: ./cmake_linux_mingw.sh Release (Debug doesn't work)</li>
+				<li>Go to the MinGW_Release folder</li>
+				<li>Run: make -j$(nproc) && wine UnitTests.exe</li>
+				<li>Run: wine Samples.exe</li>
+			</ul>
+		</details>
+	</ul>
+</details>
 
-### Windows 10+ (CL - 32 bit)
+<details>
+	<summary>Android</summary>
+	<ul>
+		<li>Install Android Studio 2020.3.1+ (https://developer.android.com/studio/)</li>
+		<li>Open the 'Android' folder in Android Studio and wait until gradle finishes</li>
+		<li>Select 'Run' / 'Run...' and 'UnitTests'</li>
+		<li>If the screen turns green after a while the unit tests succeeded, when red they failed (see the android log for details)</li>
+	</ul>
+</details>
 
-- Download Visual Studio 2022 (Community or other edition)
-- Download CMake 3.15+ (https://cmake.org/download/)
-- Run cmake_vs2022_cl_32bit.bat
-- Open the resulting project file VS2022_CL_32BIT\JoltPhysics.sln
-- Compile and run either 'Samples' or 'UnitTests'
+<details>
+	<summary>macOS</summary>
+	<ul>
+		<li>Install XCode</li>
+		<li>Download CMake 3.23+ (https://cmake.org/download/)</li>
+		<li>Run: ./cmake_xcode_macos.sh</li>
+		<li>This will open XCode with a newly generated project</li>
+		<li>Build and run the project</li>
+		<li>Note that you can also follow the steps in the 'Linux' section if you wish to build without XCode.</li>
+	</ul>
+</details>
 
-### Windows 10+ (Clang compiler)
+<details>
+	<summary>iOS</summary>
+	<ul>
+		<li>Install XCode</li>
+		<li>Download CMake 3.23+ (https://cmake.org/download/)</li>
+		<li>Run: ./cmake_xcode.ios.sh</li>
+		<li>This will open XCode with a newly generated project</li>
+		<li>Build and run the project (note that this will only work in the simulator as the code signing information is not set up)</li>
+	</ul>
+</details>
 
-- Download Visual Studio 2022 (Community or other edition)
-- Make sure to install "C++ Clang Compiler for Windows 11.0.0+" and "C++ Clang-cl for v142+ build tools (x64/x86)" using the Visual Studio Installer
-- Download CMake 3.15+ (https://cmake.org/download/)
-- Run cmake_vs2022_clang.bat
-- Open the resulting project file VS2022_Clang\JoltPhysics.sln
-- Compile and run either 'Samples' or 'UnitTests'
 
-### Windows 10+ (Universal Windows Platform)
-
-- Download Visual Studio 2022+ (Community or other edition)
-- Make sure to install "Universal Windows Platform development" using the Visual Studio Installer
-- Download CMake 3.15+ (https://cmake.org/download/)
-- Run cmake_vs2022_uwp.bat
-- Open the resulting project file VS2022_UWP\JoltPhysics.sln
-- Compile and run 'UnitTests'
-
-### Windows 10+ (MinGW)
-
-- Follow download instructions for MSYS2 (https://www.msys2.org/)
-- From the MSYS2 MSYS app run: pacman -S --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
-- From the MSYS2 MINGW x64 app, in the Build folder run: ./cmake_windows_mingw.sh
-- Run: cmake --build MinGW_Debug
-- Run: MinGW_Debug/UnitTests.exe
-
-### Linux (Debian flavor, x64 or ARM64)
-
-- Install clang (apt-get install clang)
-- Install cmake (apt-get install cmake)
-- Run: ./cmake_linux_clang_gcc.sh
-- Go to the Linux_Debug folder
-- Run: make -j$(nproc) && ./UnitTests
-
-### Linux (Debian flavor, MinGW Cross Compile)
-
-- This setup can be used to run samples on Linux using wine and vkd3d. Tested on Ubuntu 22.04
-- Graphics card must support Vulkan and related drivers must be installed
-- Install mingw-w64 (apt-get install mingw-w64)
-- Run: update-alternatives --config x86_64-w64-mingw32-g++ (Select /usr/bin/x86_64-w64-mingw32-g++-posix)
-- Install cmake (apt-get install cmake)
-- Install wine64 (apt-get install wine64)
-- Run: export WINEPATH="/usr/x86_64-w64-mingw32/lib;/usr/lib/gcc/x86_64-w64-mingw32/10-posix" (change it based on your environment)
-- Run: ./cmake_linux_mingw.sh Release (Debug doesn't work)
-- Go to the MinGW_Release folder
-- Run: make -j$(nproc) && wine UnitTests.exe
-- Run: wine Samples.exe
-
-### Android
-
-- Install Android Studio 2020.3.1+ (https://developer.android.com/studio/)
-- Open the 'Android' folder in Android Studio and wait until gradle finishes
-- Select 'Run' / 'Run...' and 'UnitTests'
-- If the screen turns green after a while the unit tests succeeded, when red they failed (see the android log for details)
-
-### macOS
-
-- Install XCode
-- Download CMake 3.23+ (https://cmake.org/download/)
-- Run: ./cmake_xcode_macos.sh
-- This will open XCode with a newly generated project
-- Build and run the project
-
-Note that you can also follow the steps in the 'Linux' section if you wish to build without XCode.
-
-### iOS
-
-- Install XCode
-- Download CMake 3.23+ (https://cmake.org/download/)
-- Run: ./cmake_xcode.ios.sh
-- This will open XCode with a newly generated project
-- Build and run the project (note that this will only work in the simulator as the code signing information is not set up)
 
 ## Other Build Tools
 


### PR DESCRIPTION
format build section in such a way so that the user is not bombarded by irrelevant build instructions to them. 

Instead they can access the relevant build instructions through at most 2 clicks.