### PR TITLE
Fix error due to return value being implicitly ignored.

### DIFF
--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -38,7 +38,7 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlig
 	void *block = nullptr;
 	JPH_SUPPRESS_WARNING_PUSH
 	JPH_GCC_SUPPRESS_WARNING("-Wunused-result")
-	posix_memalign(&block, inAlignment, inSize);
+	(void)posix_memalign(&block, inAlignment, inSize);
 	JPH_SUPPRESS_WARNING_POP
 	return block;
 #endif

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -38,7 +38,8 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(AlignedAllocate)(size_t inSize, size_t inAlig
 	void *block = nullptr;
 	JPH_SUPPRESS_WARNING_PUSH
 	JPH_GCC_SUPPRESS_WARNING("-Wunused-result")
-	(void)posix_memalign(&block, inAlignment, inSize);
+	JPH_CLANG_SUPPRESS_WARNING("-Wunused-result")
+	posix_memalign(&block, inAlignment, inSize);
 	JPH_SUPPRESS_WARNING_POP
 	return block;
 #endif


### PR DESCRIPTION
As I'm currently packaging the project for [nix](https://nixos.org) I got this error while building:
```
[  0%] Building CXX object CMakeFiles/Jolt.dir/cmake_pch.hxx.pch                                                                                                                                
[  1%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/AABBTree/AABBTreeBuilder.cpp.o                                                                         
[  1%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Color.cpp.o                                                                                       
[  2%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Factory.cpp.o                                                                                     
[  2%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/IssueReporting.cpp.o                                                                              
[  3%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/JobSystemSingleThreaded.cpp.o                                                                     
[  4%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/JobSystemThreadPool.cpp.o                                                                         
[  4%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/JobSystemWithBarrier.cpp.o                                                                        
[  4%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/LinearCurve.cpp.o                                                                                 
[  5%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Memory.cpp.o                                                                                      
[  5%] Building CXX object CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Profiler.cpp.o                                                                                    
/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Memory.cpp:41:2: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]                
        posix_memalign(&block, inAlignment, inSize);                                                                                                                                            
        ^~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                              
1 error generated.                                                                                                                                                                              
make[2]: *** [CMakeFiles/Jolt.dir/build.make:221: CMakeFiles/Jolt.dir/mnt/data/homes/nixos/oss/JoltPhysics/Jolt/Core/Memory.cpp.o] Error 1                                                      
make[2]: *** Waiting for unfinished jobs....                                                                                                                                                    
make[1]: *** [CMakeFiles/Makefile2:89: CMakeFiles/Jolt.dir/all] Error 2                                                                                                                         
make: *** [Makefile:146: all] Error 2    
```

This patch fix the issue and I got the library building properly on NixOS.