### PR TITLE
Fixed integer literal type in SetThreadName

### DIFF
--- a/Jolt/Core/JobSystemThreadPool.cpp
+++ b/Jolt/Core/JobSystemThreadPool.cpp
@@ -298,7 +298,7 @@ void JobSystemThreadPool::QueueJobs(Job **inJobs, uint inNumJobs)
 	static void SetThreadName(const char *inName)
 	{
 		char truncated_name[16] = { 0 };
-		strncpy(truncated_name, inName, min(sizeof(truncated_name), 15ul));
+		strncpy(truncated_name, inName, min<size_t>(sizeof(truncated_name), 15));
 		prctl(PR_SET_NAME, truncated_name, 0, 0, 0);
 	}
 #endif // JPH_PLATFORM_LINUX


### PR DESCRIPTION
As of #823 my 32-bit Linux builds are failing in `SetThreadName` with both GCC and Clang due to `error: no matching function for call to 'min'`, which if I'm reading the errors correctly seems to be because `sizeof` is returning an `unsigned int`, which differs from the `unsigned long` literal passed in as the second argument, causing the type deduction to fail as both parameters to `min` are expected to be of the same type.

This changes the `min` call in question to explicitly specify `size_t` as its type to fix this.