### PR TITLE
Move method for perspective projection matrix

### DIFF
--- a/Jolt/Math/Mat44.h
+++ b/Jolt/Math/Mat44.h
@@ -87,6 +87,9 @@ public:
 	/// @param inUp Up vector
 	static JPH_INLINE Mat44		sLookAt(Vec3Arg inPos, Vec3Arg inTarget, Vec3Arg inUp);
 
+	/// Returns a right-handed perspective projection matrix
+	static JPH_INLINE Mat44		sPerspective(float inFovY, float inAspect, float inNear, float inFar);
+
 	/// Get float component by element index
 	JPH_INLINE float			operator () (uint inRow, uint inColumn) const			{ JPH_ASSERT(inRow < 4); JPH_ASSERT(inColumn < 4); return mCol[inColumn].mF32[inRow]; }
 	JPH_INLINE float &			operator () (uint inRow, uint inColumn)					{ JPH_ASSERT(inRow < 4); JPH_ASSERT(inColumn < 4); return mCol[inColumn].mF32[inRow]; }

--- a/Jolt/Math/Mat44.inl
+++ b/Jolt/Math/Mat44.inl
@@ -213,6 +213,15 @@ Mat44 Mat44::sLookAt(Vec3Arg inPos, Vec3Arg inTarget, Vec3Arg inUp)
 	return Mat44(Vec4(right, 0), Vec4(up, 0), Vec4(-direction, 0), Vec4(inPos, 1)).InversedRotationTranslation();
 }
 
+Mat44 Mat44::sPerspective(float inFovY, float inAspect, float inNear, float inFar)
+{
+	float height = 1.0f / Tan(0.5f * inFovY);
+	float width = height / inAspect;
+	float range = inFar / (inNear - inFar);
+
+	return Mat44(Vec4(width, 0.0f, 0.0f, 0.0f),Vec4(0.0f, height, 0.0f, 0.0f), Vec4(0.0f, 0.0f, range, -1.0f), Vec4(0.0f, 0.0f, range * inNear, 0.0f));
+}
+
 bool Mat44::operator == (Mat44Arg inM2) const
 {
 	return UVec4::sAnd(

--- a/Jolt/Math/Mat44.inl
+++ b/Jolt/Math/Mat44.inl
@@ -219,7 +219,7 @@ Mat44 Mat44::sPerspective(float inFovY, float inAspect, float inNear, float inFa
 	float width = height / inAspect;
 	float range = inFar / (inNear - inFar);
 
-	return Mat44(Vec4(width, 0.0f, 0.0f, 0.0f),Vec4(0.0f, height, 0.0f, 0.0f), Vec4(0.0f, 0.0f, range, -1.0f), Vec4(0.0f, 0.0f, range * inNear, 0.0f));
+	return Mat44(Vec4(width, 0.0f, 0.0f, 0.0f), Vec4(0.0f, height, 0.0f, 0.0f), Vec4(0.0f, 0.0f, range, -1.0f), Vec4(0.0f, 0.0f, range * inNear, 0.0f));
 }
 
 bool Mat44::operator == (Mat44Arg inM2) const

--- a/TestFramework/Renderer/Renderer.cpp
+++ b/TestFramework/Renderer/Renderer.cpp
@@ -438,16 +438,6 @@ void Renderer::OnWindowResize()
 	CreateDepthBuffer();
 }
 
-/// Construct a perspective matrix
-static inline Mat44 sPerspective(float inFovY, float inAspect, float inNear, float inFar)
-{
-    float height = 1.0f / Tan(0.5f * inFovY);
-    float width = height / inAspect;
-    float range = inFar / (inNear - inFar);
-
-    return Mat44(Vec4(width, 0.0f, 0.0f, 0.0f), Vec4(0.0f, height, 0.0f, 0.0f), Vec4(0.0f, 0.0f, range, -1.0f), Vec4(0.0f, 0.0f, range * inNear, 0.0f));
-}
-
 void Renderer::BeginFrame(const CameraState &inCamera, float inWorldScale)
 {
 	JPH_PROFILE_FUNCTION();
@@ -506,13 +496,13 @@ void Renderer::BeginFrame(const CameraState &inCamera, float inWorldScale)
 	VertexShaderConstantBuffer *vs = mVertexShaderConstantBufferProjection[mFrameIndex]->Map<VertexShaderConstantBuffer>();
 
 	// Camera projection and view
-	vs->mProjection = sPerspective(camera_fovy, camera_aspect, camera_near, camera_far);
+	vs->mProjection = Mat44::sPerspective(camera_fovy, camera_aspect, camera_near, camera_far);
 	Vec3 cam_pos = Vec3(inCamera.mPos - mBaseOffset);
 	Vec3 tgt = cam_pos + inCamera.mForward;
 	vs->mView = Mat44::sLookAt(cam_pos, tgt, inCamera.mUp);
 
 	// Light projection and view
-	vs->mLightProjection = sPerspective(light_fov, 1.0f, light_near, light_far);
+	vs->mLightProjection = Mat44::sPerspective(light_fov, 1.0f, light_near, light_far);
 	vs->mLightView = Mat44::sLookAt(light_pos, light_tgt, light_up);
 
 	mVertexShaderConstantBufferProjection[mFrameIndex]->Unmap();


### PR DESCRIPTION
`Mat44` already contains a ton of methods for creating matrices useful for 3D rendering, such as `Mat44::sLookAt`.
My proposal is to move the method for creating perspective projection matrices from `TestFramework/Renderer/Renderer.cpp`, as it makes more sense to have it available as part of the core library.
Maybe an orthogonal projection matrix method would be useful as well.