### PR TITLE
State units and improve comment

### DIFF
--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -2371,12 +2371,6 @@ void SamplesApp::DrawPhysics()
 	mShapeToGeometry = std::move(shape_to_geometry);
 }
 
-/** 
- * \brief Steps the physics simulation at a fixed rate
- *
- * \note This means the simulation is dependent on how fast 
- * your computer is.
- */
 void SamplesApp::StepPhysics(JobSystem *inJobSystem)
 {
 	float delta_time = 1.0f / mUpdateFrequency;

--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -2371,6 +2371,12 @@ void SamplesApp::DrawPhysics()
 	mShapeToGeometry = std::move(shape_to_geometry);
 }
 
+/** 
+ * \brief Steps the physics simulation at a fixed rate
+ *
+ * \note This means the simulation is dependent on how fast 
+ * your computer is.
+ */
 void SamplesApp::StepPhysics(JobSystem *inJobSystem)
 {
 	float delta_time = 1.0f / mUpdateFrequency;

--- a/Samples/SamplesApp.h
+++ b/Samples/SamplesApp.h
@@ -87,7 +87,7 @@ private:
 
 	// Global settings
 	int						mMaxConcurrentJobs = thread::hardware_concurrency();		// How many jobs to run in parallel
-	float					mUpdateFrequency = 60.0f;									// Physics update frequency
+	float					mUpdateFrequency = 60.0f;									// Physics update frequency, measured in Hz (cycles per second)
 	int						mCollisionSteps = 1;										// How many collision detection steps per physics update
 	TempAllocator *			mTempAllocator = nullptr;									// Allocator for temporary allocations
 	JobSystem *				mJobSystem = nullptr;										// The job system that runs physics jobs


### PR DESCRIPTION
Specified that mUpdateFreq... is measured in HZ and also specified that the simulation runs at a fixed time step in it's docstring. This is relevant to #864 