### PR TITLE
support building for e2k (Elbrus2000) CPU architecture (VLIW)

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -180,6 +180,13 @@
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 32
 	#define JPH_DISABLE_CUSTOM_ALLOCATOR
+#elif defined(__e2k__)
+	// Elbrus e2k architecture
+	#define JPH_CPU_E2K
+	#define JPH_CPU_ADDRESS_BITS 64
+	#define JPH_USE_SSE
+	#define JPH_VECTOR_ALIGNMENT 16
+	#define JPH_DVECTOR_ALIGNMENT 32
 #else
 	#error Unsupported CPU architecture
 #endif
@@ -333,6 +340,8 @@
 	#if defined(JPH_CPU_X86)
 		#define JPH_BREAKPOINT	__asm volatile ("int $0x3")
 	#elif defined(JPH_CPU_ARM)
+		#define JPH_BREAKPOINT	__builtin_trap()
+	#elif defined(JPH_CPU_E2K)
 		#define JPH_BREAKPOINT	__builtin_trap()
 	#endif
 #elif defined(JPH_PLATFORM_WASM)

--- a/Jolt/Core/TickCounter.h
+++ b/Jolt/Core/TickCounter.h
@@ -9,6 +9,8 @@
 	#include <intrin.h>
 #elif defined(JPH_CPU_X86) && defined(JPH_COMPILER_GCC)
 	#include <x86intrin.h>
+#elif defined(JPH_CPU_E2K)
+	#include <x86intrin.h>
 #endif
 
 JPH_NAMESPACE_BEGIN
@@ -26,6 +28,8 @@ JPH_INLINE uint64 GetProcessorTickCount()
 #if defined(JPH_PLATFORM_BLUE)
 	return JPH_PLATFORM_BLUE_GET_TICKS();
 #elif defined(JPH_CPU_X86)
+	return __rdtsc();
+#elif defined(JPH_CPU_E2K)
 	return __rdtsc();
 #elif defined(JPH_CPU_ARM) && defined(JPH_USE_NEON)
 	uint64 val;

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -118,6 +118,8 @@ inline uint CountTrailingZeros(uint32 inValue)
 	#else
 		return __builtin_clz(__builtin_bitreverse32(inValue));
 	#endif
+#elif defined(JPH_CPU_E2K)
+		return inValue ? __builtin_ctz(inValue) : 32;
 #else
 	#error Undefined
 #endif
@@ -146,6 +148,8 @@ inline uint CountLeadingZeros(uint32 inValue)
 	#else
 		return __builtin_clz(inValue);
 	#endif
+#elif defined(JPH_CPU_E2K)
+		return inValue ? __builtin_clz(inValue) : 32;
 #else
 	#error Undefined
 #endif


### PR DESCRIPTION
Elbrus 2000 (aka e2k) is a 64-bit little-endian WLIV architecture (more info https://github.com/ilyakurdyukov/e2k-ports).
This change adds compilation for __e2k__ (using SSE intrinsics that are translated to close equivalents for Elbrus2000 CPU instructions) with LCC compiler (mimics GCC 9.3.0).

Since LCC issues more warnings JoltPhysics cannot be compiled with treat-warning-as-errors, so we setup and compile as:
  cmake . -DENABLE_ALL_WARNINGS=OFF

Internal tests passed:
`./UnitTests`
```
Single precision 64-bit with instructions: SSE2
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:    409 |    409 passed | 0 failed | 0 skipped
[doctest] assertions: 280481 | 280481 passed | 0 failed |
[doctest] Status: SUCCESS!
```
`./PerformanceTest`
```
Single precision 64-bit with instructions: SSE2
Running scene: Ragdoll
Motion Quality, Thread Count, Steps / Second, Hash
Discrete, 1, 9.346963, 0xa9daaf344fe673db
Discrete, 2, 17.908885, 0xa9daaf344fe673db
Discrete, 3, 25.916333, 0xa9daaf344fe673db
Discrete, 4, 33.719118, 0xa9daaf344fe673db
Discrete, 5, 41.038943, 0xa9daaf344fe673db
Discrete, 6, 47.863349, 0xa9daaf344fe673db
Discrete, 7, 54.226738, 0xa9daaf344fe673db
Discrete, 8, 52.689932, 0xa9daaf344fe673db
LinearCast, 1, 8.790343, 0xcdcbb4da185d1a13
LinearCast, 2, 16.644860, 0xcdcbb4da185d1a13
LinearCast, 3, 24.083228, 0xcdcbb4da185d1a13
LinearCast, 4, 31.272998, 0xcdcbb4da185d1a13
LinearCast, 5, 38.307285, 0xcdcbb4da185d1a13
LinearCast, 6, 44.485573, 0xcdcbb4da185d1a13
LinearCast, 7, 50.048080, 0xcdcbb4da185d1a13
LinearCast, 8, 48.670700, 0xcdcbb4da185d1a13
```