### PR TITLE
Fixed GCC 11.4 warning in JobSystemThreadPool.cpp

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -37,6 +37,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * When creating a MeshShape with triangles that have near identical positions it was possible that the degenerate check decided that a triangle was not degenerate while the triangle in fact would be degenerate after vertex quantization. The simulation would crash when colliding with this triangle.
 * A scaled compound shape with a center of mass of non zero would not apply the correct transform to its sub shapes when colliding with a soft body
 * A soft body without any edges would hang the solver
+* Fixed GCC 11.4 warning in JobSystemThreadPool.cpp: output may be truncated copying 15 bytes from a string of length 63
 
 ## v4.0.2
 

--- a/Jolt/Core/JobSystemThreadPool.cpp
+++ b/Jolt/Core/JobSystemThreadPool.cpp
@@ -297,16 +297,15 @@ void JobSystemThreadPool::QueueJobs(Job **inJobs, uint inNumJobs)
 #elif defined(JPH_PLATFORM_LINUX)
 	static void SetThreadName(const char *inName)
 	{
-		char truncated_name[16] = { 0 };
-		strncpy(truncated_name, inName, min<size_t>(sizeof(truncated_name), 15));
-		prctl(PR_SET_NAME, truncated_name, 0, 0, 0);
+		JPH_ASSERT(strlen(inName) < 16); // String will be truncated if it is longer
+		prctl(PR_SET_NAME, inName, 0, 0, 0);
 	}
 #endif // JPH_PLATFORM_LINUX
 
 void JobSystemThreadPool::ThreadMain(int inThreadIndex)
 {
 	// Name the thread
-	char name[64];
+	char name[16];
 	snprintf(name, sizeof(name), "Worker %d", int(inThreadIndex + 1));
 
 #if defined(JPH_PLATFORM_WINDOWS) || defined(JPH_PLATFORM_LINUX)


### PR DESCRIPTION
Output may be truncated copying 15 bytes from a string of length 63

Fixes #899 