### PR TITLE
Bugfix: Path Constraint: Fixed spelling in enum value

### DIFF
--- a/Jolt/Physics/Constraints/PathConstraint.cpp
+++ b/Jolt/Physics/Constraints/PathConstraint.cpp
@@ -168,7 +168,7 @@ void PathConstraint::CalculateConstraintProperties(float inDeltaTime)
 		mHingeConstraintPart.CalculateConstraintProperties(*mBody1, transform1.GetRotation(), mPathBinormal, *mBody2, transform2.GetRotation(), path_to_world_2.GetAxisY());
 		break;
 
-	case EPathRotationConstraintType::ConstainToPath:
+	case EPathRotationConstraintType::ConstrainToPath:
 		// We need to calculate the inverse of the rotation from body 1 to body 2 for the current path position (see: RotationEulerConstraintPart::sGetInvInitialOrientation)
 		// RotationBody2 = RotationBody1 * InitialOrientation <=> InitialOrientation^-1 = RotationBody2^-1 * RotationBody1
 		// We can express RotationBody2 in terms of RotationBody1: RotationBody2 = RotationBody1 * PathToBody1 * RotationClosestPointOnPath * PathToBody2^-1
@@ -244,7 +244,7 @@ void PathConstraint::WarmStartVelocityConstraint(float inWarmStartImpulseRatio)
 		mHingeConstraintPart.WarmStart(*mBody1, *mBody2, inWarmStartImpulseRatio);
 		break;
 
-	case EPathRotationConstraintType::ConstainToPath:
+	case EPathRotationConstraintType::ConstrainToPath:
 	case EPathRotationConstraintType::FullyConstrained:
 		mRotationConstraintPart.WarmStart(*mBody1, *mBody2, inWarmStartImpulseRatio);
 		break;
@@ -306,7 +306,7 @@ bool PathConstraint::SolveVelocityConstraint(float inDeltaTime)
 		rot = mHingeConstraintPart.SolveVelocityConstraint(*mBody1, *mBody2);
 		break;
 
-	case EPathRotationConstraintType::ConstainToPath:
+	case EPathRotationConstraintType::ConstrainToPath:
 	case EPathRotationConstraintType::FullyConstrained:
 		rot = mRotationConstraintPart.SolveVelocityConstraint(*mBody1, *mBody2);
 		break;
@@ -350,7 +350,7 @@ bool PathConstraint::SolvePositionConstraint(float inDeltaTime, float inBaumgart
 		rot = mHingeConstraintPart.SolvePositionConstraint(*mBody1, *mBody2, inBaumgarte);
 		break;
 
-	case EPathRotationConstraintType::ConstainToPath:
+	case EPathRotationConstraintType::ConstrainToPath:
 	case EPathRotationConstraintType::FullyConstrained:
 		rot = mRotationConstraintPart.SolvePositionConstraint(*mBody1, *mBody2, mInvInitialOrientation, inBaumgarte);
 		break;

--- a/Jolt/Physics/Constraints/PathConstraint.h
+++ b/Jolt/Physics/Constraints/PathConstraint.h
@@ -21,7 +21,7 @@ enum class EPathRotationConstraintType
 	ConstrainAroundTangent,			///< Only allow rotation around the tangent vector (following the path)
 	ConstrainAroundNormal,			///< Only allow rotation around the normal vector (perpendicular to the path)
 	ConstrainAroundBinormal,		///< Only allow rotation around the binormal vector (perpendicular to the path)
-	ConstainToPath,					///< Fully constrain the rotation of body 2 to the path (follwing the tangent and normal of the path)
+	ConstrainToPath,					///< Fully constrain the rotation of body 2 to the path (follwing the tangent and normal of the path)
 	FullyConstrained,				///< Fully constrain the rotation of the body 2 to the rotation of body 1
 };
 

--- a/Jolt/Physics/Constraints/PathConstraint.h
+++ b/Jolt/Physics/Constraints/PathConstraint.h
@@ -21,7 +21,7 @@ enum class EPathRotationConstraintType
 	ConstrainAroundTangent,			///< Only allow rotation around the tangent vector (following the path)
 	ConstrainAroundNormal,			///< Only allow rotation around the normal vector (perpendicular to the path)
 	ConstrainAroundBinormal,		///< Only allow rotation around the binormal vector (perpendicular to the path)
-	ConstrainToPath,					///< Fully constrain the rotation of body 2 to the path (follwing the tangent and normal of the path)
+	ConstrainToPath,				///< Fully constrain the rotation of body 2 to the path (follwing the tangent and normal of the path)
 	FullyConstrained,				///< Fully constrain the rotation of the body 2 to the rotation of body 1
 };
 

--- a/Jolt/Physics/LargeIslandSplitter.cpp
+++ b/Jolt/Physics/LargeIslandSplitter.cpp
@@ -175,7 +175,7 @@ void LargeIslandSplitter::Splits::MarkBatchProcessed(uint inNumProcessed, bool &
 LargeIslandSplitter::~LargeIslandSplitter()
 {
 	JPH_ASSERT(mSplitMasks == nullptr);
-	JPH_ASSERT(mContactAndConstaintsSplitIdx == nullptr);
+	JPH_ASSERT(mContactAndConstraintsSplitIdx == nullptr);
 	JPH_ASSERT(mContactAndConstraintIndices == nullptr);
 	JPH_ASSERT(mSplitIslands == nullptr);
 }
@@ -217,7 +217,7 @@ void LargeIslandSplitter::Prepare(const IslandBuilder &inIslandBuilder, uint32 i
 
 		// Allocate contact and constraint buffer
 		uint contact_and_constraint_indices_size = mContactAndConstraintsSize * sizeof(uint32);
-		mContactAndConstaintsSplitIdx = (uint32 *)inTempAllocator->Allocate(contact_and_constraint_indices_size);
+		mContactAndConstraintsSplitIdx = (uint32 *)inTempAllocator->Allocate(contact_and_constraint_indices_size);
 		mContactAndConstraintIndices = (uint32 *)inTempAllocator->Allocate(contact_and_constraint_indices_size);
 
 		// Allocate island split buffer
@@ -314,7 +314,7 @@ bool LargeIslandSplitter::SplitIsland(uint32 inIslandIndex, const IslandBuilder 
 
 	// Get space to store split indices
 	uint offset = mContactAndConstraintsNextFree.fetch_add(island_size, memory_order_relaxed);
-	uint32 *contact_split_idx = mContactAndConstaintsSplitIdx + offset;
+	uint32 *contact_split_idx = mContactAndConstraintsSplitIdx + offset;
 	uint32 *constraint_split_idx = contact_split_idx + num_contacts_in_island;
 
 	// Assign the contacts to a split
@@ -559,8 +559,8 @@ void LargeIslandSplitter::Reset(TempAllocator *inTempAllocator)
 		inTempAllocator->Free(mContactAndConstraintIndices, mContactAndConstraintsSize * sizeof(uint32));
 		mContactAndConstraintIndices = nullptr;
 
-		inTempAllocator->Free(mContactAndConstaintsSplitIdx, mContactAndConstraintsSize * sizeof(uint32));
-		mContactAndConstaintsSplitIdx = nullptr;
+		inTempAllocator->Free(mContactAndConstraintsSplitIdx, mContactAndConstraintsSize * sizeof(uint32));
+		mContactAndConstraintsSplitIdx = nullptr;
 
 		mContactAndConstraintsSize = 0;
 		mContactAndConstraintsNextFree.store(0, memory_order_relaxed);

--- a/Jolt/Physics/LargeIslandSplitter.h
+++ b/Jolt/Physics/LargeIslandSplitter.h
@@ -172,7 +172,7 @@ private:
 
 	SplitMask *				mSplitMasks = nullptr;								///< Bits that indicate for each body in the BodyManager::mActiveBodies list which split they already belong to
 
-	uint32 *				mContactAndConstaintsSplitIdx = nullptr;			///< Buffer to store the split index per constraint or contact
+	uint32 *				mContactAndConstraintsSplitIdx = nullptr;			///< Buffer to store the split index per constraint or contact
 	uint32 *				mContactAndConstraintIndices = nullptr;				///< Buffer to store the ordered constraint indices per split
 	uint					mContactAndConstraintsSize = 0;						///< Total size of mContactAndConstraintsSplitIdx and mContactAndConstraintIndices
 	atomic<uint>			mContactAndConstraintsNextFree { 0 };				///< Next element that is free in both buffers

--- a/Jolt/Skeleton/SkeletalAnimation.h
+++ b/Jolt/Skeleton/SkeletalAnimation.h
@@ -17,7 +17,7 @@ class JPH_EXPORT SkeletalAnimation : public RefTarget<SkeletalAnimation>
 public:
 	JPH_DECLARE_SERIALIZABLE_NON_VIRTUAL(JPH_EXPORT, SkeletalAnimation)
 
-	/// Constrains the current state of a joint, a local space transformation relative to its parent joint
+	/// Contains the current state of a joint, a local space transformation relative to its parent joint
 	class JointState
 	{
 	public:

--- a/Jolt/Skeleton/SkeletalAnimation.h
+++ b/Jolt/Skeleton/SkeletalAnimation.h
@@ -17,7 +17,7 @@ class JPH_EXPORT SkeletalAnimation : public RefTarget<SkeletalAnimation>
 public:
 	JPH_DECLARE_SERIALIZABLE_NON_VIRTUAL(JPH_EXPORT, SkeletalAnimation)
 
-	/// Constains the current state of a joint, a local space transformation relative to its parent joint
+	/// Constrains the current state of a joint, a local space transformation relative to its parent joint
 	class JointState
 	{
 	public:


### PR DESCRIPTION
I believe this has limited risk of breakage via 'breaking change' to end users, given the recent last spelling change was just this morning.

Searching the project, the other two cases of this spelling are:
`LargeIslandSplitter.(cpp|h)` - private variable, not exposed `mContactAndConstaintsSplitIdx` paralleling `mContactAndConstraintIndices`

`SkeletalAnimation.h` - comment only, `/// Constains the current state of a joint`. I believe the usage should be 'Contain'