### PR TITLE
Added Body::ResetMotion and DebugRenderer::NextFrame

### DIFF
--- a/Jolt/Physics/Body/Body.h
+++ b/Jolt/Physics/Body/Body.h
@@ -191,6 +191,9 @@ public:
 	// Reset the total accumulated torque, not that this will be done automatically after every time step.
 	JPH_INLINE void			ResetTorque()													{ JPH_ASSERT(IsDynamic()); return mMotionProperties->ResetTorque(); }
 
+	// Reset the current velocity and accumulated force and torque.
+	JPH_INLINE void			ResetMotion()													{ JPH_ASSERT(!IsStatic()); return mMotionProperties->ResetMotion(); }
+
 	/// Get inverse inertia tensor in world space
 	inline Mat44			GetInverseInertia() const;
 

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -140,6 +140,14 @@ public:
 	// Reset the total accumulated torque, not that this will be done automatically after every time step.
 	JPH_INLINE void			ResetTorque()													{ mTorque = Float3(0, 0, 0); }
 
+	// Reset the current velocity and accumulated force and torque.
+	JPH_INLINE void			ResetMotion()
+	{
+		JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess, BodyAccess::EAccess::ReadWrite));
+		mLinearVelocity = mAngularVelocity = Vec3::sZero();
+		mForce = mTorque = Float3(0, 0, 0);
+	}
+
 	/// Returns a vector where the linear components that are not allowed by mAllowedDOFs are set to 0 and the rest to 0xffffffff
 	JPH_INLINE UVec4		GetLinearDOFsMask() const
 	{

--- a/Jolt/Renderer/DebugRenderer.cpp
+++ b/Jolt/Renderer/DebugRenderer.cpp
@@ -867,6 +867,12 @@ void DebugRenderer::DrawSwingConeLimits(RMat44Arg inMatrix, float inSwingYHalfAn
 	GeometryRef &geometry = mSwingConeLimits[limits];
 	if (geometry == nullptr)
 	{
+		SwingConeBatches::iterator it = mPrevSwingConeLimits.find(limits);
+		if (it != mPrevSwingConeLimits.end())
+			geometry = it->second;
+	}
+	if (geometry == nullptr)
+	{
 		// Number of segments to draw the cone with
 		const int num_segments = 64;
 		int half_num_segments = num_segments / 2;
@@ -944,6 +950,12 @@ void DebugRenderer::DrawSwingPyramidLimits(RMat44Arg inMatrix, float inMinSwingY
 	GeometryRef &geometry = mSwingPyramidLimits[limits];
 	if (geometry == nullptr)
 	{
+		SwingPyramidBatches::iterator it = mPrevSwingPyramidLimits.find(limits);
+		if (it != mPrevSwingPyramidLimits.end())
+			geometry = it->second;
+	}
+	if (geometry == nullptr)
+	{
 		// Number of segments to draw the cone with
 		const int num_segments = 64;
 		int quarter_num_segments = num_segments / 4;
@@ -992,6 +1004,12 @@ void DebugRenderer::DrawPie(RVec3Arg inCenter, float inRadius, Vec3Arg inNormal,
 	GeometryRef &geometry = mPieLimits[delta_angle];
 	if (geometry == nullptr)
 	{
+		PieBatces::iterator it = mPrevPieLimits.find(delta_angle);
+		if (it != mPrevPieLimits.end())
+			geometry = it->second;
+	}
+	if (geometry == nullptr)
+	{
 		int num_parts = (int)ceil(64.0f * delta_angle / (2.0f * JPH_PI));
 
 		Float3 normal = { 0, 1, 0 };
@@ -1034,6 +1052,18 @@ void DebugRenderer::DrawPie(RVec3Arg inCenter, float inRadius, Vec3Arg inNormal,
 	RMat44 matrix = RMat44(Vec4(inRadius * inAxis, 0), Vec4(inRadius * inNormal, 0), Vec4(inRadius * inNormal.Cross(inAxis), 0), inCenter) * Mat44::sRotationY(-inMinAngle);
 
 	DrawGeometry(matrix, inColor, geometry, ECullMode::Off, inCastShadow, inDrawMode);
+}
+
+void DebugRenderer::NextFrame()
+{
+	mPrevSwingConeLimits.clear();
+	std::swap(mSwingConeLimits, mPrevSwingConeLimits);
+
+	mPrevSwingPyramidLimits.clear();
+	std::swap(mSwingPyramidLimits, mPrevSwingPyramidLimits);
+
+	mPrevPieLimits.clear();
+	std::swap(mPieLimits, mPrevPieLimits);
 }
 
 JPH_NAMESPACE_END

--- a/Jolt/Renderer/DebugRenderer.h
+++ b/Jolt/Renderer/DebugRenderer.h
@@ -35,6 +35,9 @@ public:
 										DebugRenderer();
 	virtual								~DebugRenderer();
 
+	/// Call once after frame is complete. Releases unused dynamically generated geometry assets.
+	void								NextFrame();
+
 	/// Draw line
 	virtual void						DrawLine(RVec3Arg inFrom, RVec3Arg inTo, ColorArg inColor) = 0;
 
@@ -280,6 +283,7 @@ private:
 
 	using SwingConeBatches = UnorderedMap<SwingConeLimits, GeometryRef, SwingConeLimitsHasher>;
 	SwingConeBatches					mSwingConeLimits;
+	SwingConeBatches					mPrevSwingConeLimits;
 
 	struct SwingPyramidLimits
 	{
@@ -301,9 +305,11 @@ private:
 
 	using SwingPyramidBatches = UnorderedMap<SwingPyramidLimits, GeometryRef, SwingPyramidLimitsHasher>;
 	SwingPyramidBatches					mSwingPyramidLimits;
+	SwingPyramidBatches					mPrevSwingPyramidLimits;
 
 	using PieBatces = UnorderedMap<float, GeometryRef>;
 	PieBatces							mPieLimits;
+	PieBatces							mPrevPieLimits;
 };
 
 JPH_NAMESPACE_END

--- a/TestFramework/Renderer/DebugRendererImp.cpp
+++ b/TestFramework/Renderer/DebugRendererImp.cpp
@@ -529,4 +529,5 @@ void DebugRendererImp::Clear()
 	ClearLines();
 	ClearTriangles();
 	ClearTexts();
+	NextFrame();
 }


### PR DESCRIPTION
- ResetMotion will reset the linear/angular velocity and accumulated force/torque
- DebugRenderer::NextFrame will destroy dynamic render primitives when they haven't been used in the previous frame