### PR TITLE
Increased tolerance of GetClosestPointOnTriangle again

### DIFF
--- a/.github/workflows/determinism_check.yml
+++ b/.github/workflows/determinism_check.yml
@@ -2,7 +2,7 @@ name: Determinism Check
 
 env:
     CONVEX_VS_MESH_HASH: '0x10139effe747511'
-    RAGDOLL_HASH: '0xcdcbb4da185d1a13'
+    RAGDOLL_HASH: '0x777396947c3fff6a'
 
 on:
   push:

--- a/Jolt/Geometry/ClosestPoint.h
+++ b/Jolt/Geometry/ClosestPoint.h
@@ -181,7 +181,7 @@ namespace ClosestPoint
 		float n_len_sq = n.LengthSq();
 
 		// Check degenerate
-		if (n_len_sq < 1.0e-11f) // Square(FLT_EPSILON) was too small and caused numerical problems, see test case TestCollideParallelTriangleVsCapsule
+		if (n_len_sq < 1.0e-10f) // Square(FLT_EPSILON) was too small and caused numerical problems, see test case TestCollideParallelTriangleVsCapsule
 		{
 			// Degenerate, fallback to vertices and edges
 


### PR DESCRIPTION
There was another edge case where a capsule parallel to a triangle returned an incorrect result

Fixes #940