### PR TITLE
Allowing WASM to use a custom memory allocator

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -57,6 +57,9 @@ option(TRACK_NARROWPHASE_STATS "Track Narrowphase Stats" OFF)
 # Note that enabling this reduces the performance of the library even if you're not drawing anything.
 option(DEBUG_RENDERER_IN_DISTRIBUTION "Enable debug renderer in Distribution builds" OFF)
 
+# Setting this option will force the library to use malloc/free instead of allowing the user to override the memory allocator
+option(DISABLE_CUSTOM_ALLOCATOR "Disable support for a custom memory allocator" OFF)
+
 include(CMakeDependentOption)
 
 # Ability to toggle between the static and DLL versions of the MSVC runtime library

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -181,7 +181,6 @@
 	#define JPH_CPU_ADDRESS_BITS 32
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 32
-	#define JPH_DISABLE_CUSTOM_ALLOCATOR
 #elif defined(__e2k__)
 	// Elbrus e2k architecture
 	#define JPH_CPU_E2K

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -500,6 +500,11 @@ if (FLOATING_POINT_EXCEPTIONS_ENABLED AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "M
 	target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Release>:JPH_FLOATING_POINT_EXCEPTIONS_ENABLED>")
 endif()
 
+# Setting the disable custom allocator flag
+if (DISABLE_CUSTOM_ALLOCATOR)
+	target_compile_definitions(Jolt PUBLIC JPH_DISABLE_CUSTOM_ALLOCATOR)
+endif()
+
 # Setting double precision flag
 if (DOUBLE_PRECISION)
 	target_compile_definitions(Jolt PUBLIC JPH_DOUBLE_PRECISION)


### PR DESCRIPTION
Added cmake option to disable the custom memory allocator

Fixes #956