### PR TITLE
Improvements to soft body skinning constraints

### DIFF
--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1092,7 +1092,7 @@ void BodyManager::Draw(const DrawSettings &inDrawSettings, const PhysicsSettings
 					mp->DrawVolumeConstraints(inRenderer, com, inDrawSettings.mDrawSoftBodyConstraintColor);
 
 				if (inDrawSettings.mDrawSoftBodySkinConstraints)
-					mp->DrawSkinConstraints(inRenderer, com);
+					mp->DrawSkinConstraints(inRenderer, com, inDrawSettings.mDrawSoftBodyConstraintColor);
 
 				if (inDrawSettings.mDrawSoftBodyLRAConstraints)
 					mp->DrawLRAConstraints(inRenderer, com, inDrawSettings.mDrawSoftBodyConstraintColor);

--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
@@ -102,7 +102,7 @@ public:
 	void								DrawEdgeConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, ESoftBodyConstraintColor inConstraintColor) const;
 	void								DrawBendConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, ESoftBodyConstraintColor inConstraintColor) const;
 	void								DrawVolumeConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, ESoftBodyConstraintColor inConstraintColor) const;
-	void								DrawSkinConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform) const;
+	void								DrawSkinConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, ESoftBodyConstraintColor inConstraintColor) const;
 	void								DrawLRAConstraints(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform, ESoftBodyConstraintColor inConstraintColor) const;
 	void								DrawPredictedBounds(DebugRenderer *inRenderer, RMat44Arg inCenterOfMassTransform) const;
 #endif // JPH_DEBUG_RENDERER
@@ -191,6 +191,7 @@ private:
 	// Information about the state of all skinned vertices
 	struct SkinState
 	{
+		Vec3							mPreviousPosition = Vec3::sNaN();
 		Vec3							mPosition = Vec3::sNaN();
 		Vec3							mNormal = Vec3::sNaN();
 	};
@@ -211,7 +212,7 @@ private:
 	void								ApplyVolumeConstraints(const SoftBodyUpdateContext &inContext, uint inStartIndex, uint inEndIndex);
 
 	/// Enforce all skin constraints
-	void								ApplySkinConstraints(const SoftBodyUpdateContext &inContext);
+	void								ApplySkinConstraints(const SoftBodyUpdateContext &inContext, uint inStartIndex, uint inEndIndex);
 
 	/// Enforce all edge constraints
 	void								ApplyEdgeConstraints(const SoftBodyUpdateContext &inContext, uint inStartIndex, uint inEndIndex);

--- a/Jolt/Physics/SoftBody/SoftBodySharedSettings.h
+++ b/Jolt/Physics/SoftBody/SoftBodySharedSettings.h
@@ -80,6 +80,7 @@ public:
 		Array<uint>		mLRARemap;									///< Maps old LRA index to new LRA index
 		Array<uint>		mDihedralBendRemap;							///< Maps old dihedral bend index to new dihedral bend index
 		Array<uint>		mVolumeRemap;								///< Maps old volume constraint index to new volume constraint index
+		Array<uint>		mSkinnedRemap;								///< Maps old skinned constraint index to new skinned constraint index
 	};
 
 	/// Optimize the soft body settings for simulation. This will reorder constraints so they can be executed in parallel.
@@ -320,6 +321,7 @@ private:
 		uint			mLRAEndIndex;								///< The end index of the LRA constraints in this group
 		uint			mDihedralBendEndIndex;						///< The end index of the dihedral bend constraints in this group
 		uint			mVolumeEndIndex;							///< The end index of the volume constraints in this group
+		uint			mSkinnedEndIndex;							///< The end index of the skinned constraints in this group
 	};
 
 	Array<ClosestKinematic> mClosestKinematic;						///< The closest kinematic vertex to each vertex in mVertices

--- a/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.cpp
+++ b/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.cpp
@@ -124,6 +124,10 @@ void SoftBodySkinnedConstraintTest::Initialize()
 	// Calculate the information needed for skinned constraints
 	settings->CalculateSkinnedConstraintNormals();
 
+	// Optimize the settings (note that this is the second time we call this, the first time was in SoftBodyCreator::CreateCloth,
+	// this is a bit wasteful but we must do it because we added more constraints)
+	settings->Optimize();
+
 	// Create the body
 	SoftBodyCreationSettings cloth(settings, body_translation, Quat::sIdentity(), Layers::MOVING);
 	mBody = mBodyInterface->CreateSoftBody(cloth);


### PR DESCRIPTION
- Multithreading skinned constraints
- Fixed bug where the the skinned position would update in the first iteration, causing a large velocity spike
- Fixed bug where the velocity of vertices would increase indefinitely when resting on the back stop