### PR TITLE
Bugfix: Not calling SkinVertices every frame

### DIFF
--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
@@ -191,9 +191,9 @@ private:
 	// Information about the state of all skinned vertices
 	struct SkinState
 	{
-		Vec3							mPreviousPosition = Vec3::sNaN();
-		Vec3							mPosition = Vec3::sNaN();
-		Vec3							mNormal = Vec3::sNaN();
+		Vec3							mPreviousPosition = Vec3::sZero();			///< Previous position of the skinned vertex, used to interpolate between the previous and current position
+		Vec3							mPosition = Vec3::sNaN();					///< Current position of the skinned vertex
+		Vec3							mNormal = Vec3::sNaN();						///< Normal of the skinned vertex
 	};
 
 	/// Do a narrow phase check and determine the closest feature that we can collide with
@@ -245,9 +245,10 @@ private:
 	/// Helper function to draw constraints
 	template <typename GetEndIndex, typename DrawConstraint>
 		inline void						DrawConstraints(ESoftBodyConstraintColor inConstraintColor, const GetEndIndex &inGetEndIndex, const DrawConstraint &inDrawConstraint, ColorArg inBaseColor) const;
-#endif // JPH_DEBUG_RENDERER
 
 	RMat44								mSkinStateTransform = RMat44::sIdentity();	///< The matrix that transforms mSkinState to world space
+#endif // JPH_DEBUG_RENDERER
+
 	RefConst<SoftBodySharedSettings>	mSettings;									///< Configuration of the particles and constraints
 	Array<Vertex>						mVertices;									///< Current state of all vertices in the simulation
 	Array<CollidingShape>				mCollidingShapes;							///< List of colliding shapes retrieved during the last update
@@ -260,6 +261,7 @@ private:
 	bool								mUpdatePosition;							///< Update the position of the body while simulating (set to false for something that is attached to the static world)
 	bool								mHasContact = false;						///< True if the soft body has collided with anything in the last update
 	bool								mEnableSkinConstraints = true;				///< If skin constraints are enabled
+	bool								mSkinStatePreviousPositionValid = false;	///< True if the skinning was updated in the last update so that the previous position of the skin state is valid
 };
 
 JPH_NAMESPACE_END

--- a/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.cpp
+++ b/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.cpp
@@ -52,7 +52,8 @@ void SoftBodySkinnedConstraintTest::SkinVertices(bool inHardSkinAll)
 	SoftBodyMotionProperties *mp = static_cast<SoftBodyMotionProperties *>(mBody->GetMotionProperties());
 	mp->SetEnableSkinConstraints(sEnableSkinConstraints);
 	mp->SetSkinnedMaxDistanceMultiplier(sMaxDistanceMultiplier);
-	mp->SkinVertices(com, pose.data(), cNumJoints, inHardSkinAll, *mTempAllocator);
+	if (sUpdateSkinning || inHardSkinAll)
+		mp->SkinVertices(com, pose.data(), cNumJoints, inHardSkinAll, *mTempAllocator);
 }
 
 void SoftBodySkinnedConstraintTest::Initialize()
@@ -148,7 +149,7 @@ void SoftBodySkinnedConstraintTest::PrePhysicsUpdate(const PreUpdateParams &inPa
 	}
 
 	// Update time
-	mTime += inParams.mDeltaTime;
+	mTime += sTimeScale * inParams.mDeltaTime;
 
 	// Calculate skinned vertices but do not hard skin them
 	SkinVertices(false);
@@ -166,6 +167,8 @@ void SoftBodySkinnedConstraintTest::RestoreState(StateRecorder &inStream)
 
 void SoftBodySkinnedConstraintTest::CreateSettingsMenu(DebugUI *inUI, UIElement *inSubMenu)
 {
+	inUI->CreateSlider(inSubMenu, "Time Scale", sTimeScale, 0.0f, 10.0f, 0.1f, [](float inValue) { sTimeScale = inValue; });
+	inUI->CreateCheckBox(inSubMenu, "Update Skinning", sUpdateSkinning, [](UICheckBox::EState inState) { sUpdateSkinning = inState == UICheckBox::STATE_CHECKED; });
 	inUI->CreateCheckBox(inSubMenu, "Enable Skin Constraints", sEnableSkinConstraints, [](UICheckBox::EState inState) { sEnableSkinConstraints = inState == UICheckBox::STATE_CHECKED; });
 	inUI->CreateSlider(inSubMenu, "Max Distance Multiplier", sMaxDistanceMultiplier, 0.0f, 10.0f, 0.1f, [](float inValue) { sMaxDistanceMultiplier = inValue; });
 }

--- a/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.h
+++ b/Samples/Tests/SoftBody/SoftBodySkinnedConstraintTest.h
@@ -47,6 +47,8 @@ private:
 	float					mTime = 0.0f;
 
 	// Settings
+	static inline float		sTimeScale = 1.0f;
+	static inline bool		sUpdateSkinning = true;
 	static inline bool		sEnableSkinConstraints = true;
 	static inline float		sMaxDistanceMultiplier = 1.0f;
 };


### PR DESCRIPTION
- When SkinVertices is not called every frame, the previous position of the skin was still used causing a replay of the motion of the previous frame.
- Fixed issue in updating mSkinStateTransform when position of soft body changes
- Added some extra settings to the SoftBodySkinnedConstraintTest