### PR TITLE
Speed up reading of heightfield data.

### DIFF
--- a/Jolt/Core/StreamOut.h
+++ b/Jolt/Core/StreamOut.h
@@ -22,21 +22,32 @@ public:
 	virtual bool		IsFailed() const = 0;
 
 	/// Write a primitive (e.g. float, int, etc.) to the binary stream
-	template <class T>
+	template <class T, std::enable_if_t<std::is_trivially_copyable_v<T>, bool> = true>
 	void				Write(const T &inT)
 	{
 		WriteBytes(&inT, sizeof(inT));
 	}
 
 	/// Write a vector of primitives to the binary stream
-	template <class T, class A>
+	template <class T, class A, std::enable_if_t<std::is_trivially_copyable_v<T>, bool> = true>
 	void				Write(const std::vector<T, A> &inT)
 	{
 		typename Array<T>::size_type len = inT.size();
 		Write(len);
 		if (!IsFailed())
-			for (typename Array<T>::size_type i = 0; i < len; ++i)
-				Write(inT[i]);
+		{
+			if constexpr (std::is_same_v<T, Vec3> || std::is_same_v<T, DVec3> || std::is_same_v<T, DMat44>)
+			{
+				// These types have unused components that we don't want to write
+				for (typename Array<T>::size_type i = 0; i < len; ++i)
+					Write(inT[i]);
+			}
+			else
+			{
+				// Write all elements at once
+				WriteBytes(inT.data(), len * sizeof(T));
+			}
+		}
 	}
 
 	/// Write a string to the binary stream (writes the number of characters and then the characters)

--- a/Jolt/Math/Vector.h
+++ b/Jolt/Math/Vector.h
@@ -13,7 +13,7 @@ class [[nodiscard]] Vector
 public:
 	/// Constructor
 	inline						Vector() = default;
-	inline						Vector(const Vector &inRHS)								{ *this = inRHS; }
+	inline						Vector(const Vector &) = default;
 
 	/// Dimensions
 	inline uint					GetRows() const											{ return Rows; }
@@ -81,12 +81,7 @@ public:
 	}
 
 	/// Assignment
-	inline Vector &				operator = (const Vector &inV2)
-	{
-		for (uint r = 0; r < Rows; ++r)
-			mF32[r] = inV2.mF32[r];
-		return *this;
-	}
+	inline Vector &				operator = (const Vector &) = default;
 
 	/// Multiply vector with float
 	inline Vector				operator * (const float inV2) const


### PR DESCRIPTION
Reading arrays of simple types in a single read instead of per element.

Fixes #1080