### PR TITLE
Fix error in gcc 14.

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -34,6 +34,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 ### Bug fixes
 
 * Fix for new warning in MSVC 17.10 in immintrin.h: '__check_isa_support': unreferenced inline function has been removed.
+* Fix error in gcc 14. Using always_inline in debug mode causes error: "inlining failed in call to 'always_inline' 'XXX': function not considered for inlining"
 * Fixed clang-18 warning "LLVMgold.so: error loading plugin ... cannot open shared object file: No such file or directory", due to https://github.com/llvm/llvm-project/issues/84271 it currently doesn't support LTO.
 * When calling CharacterVirtual::SetShape, a collision with a sensor would cause the function to abort as if the character was in collision.
 * Fixed bug where the the skinned position of a soft body would update in the first sub-iteration, causing a large velocity spike and jittery behavior.

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -454,11 +454,24 @@ static_assert(sizeof(uint32) == 4, "Invalid size of uint32");
 static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
 static_assert(sizeof(void *) == (JPH_CPU_ADDRESS_BITS == 64? 8 : 4), "Invalid size of pointer" );
 
+// Determine if we want extra debugging code to be active
+#if !defined(NDEBUG) && !defined(JPH_NO_DEBUG)
+	#define JPH_DEBUG
+#endif
+
 // Define inline macro
 #if defined(JPH_NO_FORCE_INLINE)
 	#define JPH_INLINE inline
-#elif defined(JPH_COMPILER_CLANG) || defined(JPH_COMPILER_GCC)
+#elif defined(JPH_COMPILER_CLANG)
 	#define JPH_INLINE __inline__ __attribute__((always_inline))
+#elif defined(JPH_COMPILER_GCC)
+	// On gcc 14 using always_inline in debug mode causes error: "inlining failed in call to 'always_inline' 'XXX': function not considered for inlining"
+	// See: https://github.com/jrouwe/JoltPhysics/issues/1096
+	#if __GNUC__ >= 14 && defined(JPH_DEBUG) 
+		#define JPH_INLINE inline
+	#else
+		#define JPH_INLINE __inline__ __attribute__((always_inline))
+	#endif
 #elif defined(JPH_COMPILER_MSVC)
 	#define JPH_INLINE __forceinline
 #else
@@ -481,11 +494,6 @@ static_assert(sizeof(void *) == (JPH_CPU_ADDRESS_BITS == 64? 8 : 4), "Invalid si
 
 // Stack allocation
 #define JPH_STACK_ALLOC(n)		alloca(n)
-
-// Determine if we want extra debugging code to be active
-#if !defined(NDEBUG) && !defined(JPH_NO_DEBUG)
-	#define JPH_DEBUG
-#endif
 
 // Shorthand for #ifdef JPH_DEBUG / #endif
 #ifdef JPH_DEBUG


### PR DESCRIPTION
Using always_inline in debug mode causes error: "inlining failed in call to ‘always_inline’ ‘XXX’: function not considered for inlining".