### PR TITLE
Declare Job destructor as virtual.

### DIFF
--- a/Jolt/Core/JobSystem.h
+++ b/Jolt/Core/JobSystem.h
@@ -173,7 +173,7 @@ protected:
 		JPH_OVERRIDE_NEW_DELETE
 
 		/// Constructor
-							Job([[maybe_unused]] const char *inJobName, [[maybe_unused]] ColorArg inColor, JobSystem *inJobSystem, const JobFunction &inJobFunction, uint32 inNumDependencies) :
+		Job([[maybe_unused]] const char *inJobName, [[maybe_unused]] ColorArg inColor, JobSystem *inJobSystem, const JobFunction &inJobFunction, uint32 inNumDependencies) :
 		#if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
 			mJobName(inJobName),
 			mColor(inColor),
@@ -183,6 +183,9 @@ protected:
 			mNumDependencies(inNumDependencies)
 		{
 		}
+
+		/// Destructor
+		virtual ~Job() = default;
 
 		/// Get the jobs system to which this job belongs
 		inline JobSystem *	GetJobSystem()								{ return mJobSystem; }


### PR DESCRIPTION
This is needed to prevent leaks from user-derived jobs. For example:
```cpp
class JobImpl: final Job {
	const std::string internal_string;
};
```
In this case, the `internal_string` will not be automatically freed.