### PR TITLE
QuadTree / FixedSizeFreeList: Reorder variable layout to reduce false sharing & thread syncs

### DIFF
--- a/Jolt/Core/FixedSizeFreeList.h
+++ b/Jolt/Core/FixedSizeFreeList.h
@@ -34,17 +34,6 @@ private:
 	const ObjectStorage &	GetStorage(uint32 inObjectIndex) const	{ return mPages[inObjectIndex >> mPageShift][inObjectIndex & mObjectMask]; }
 	ObjectStorage &			GetStorage(uint32 inObjectIndex)		{ return mPages[inObjectIndex >> mPageShift][inObjectIndex & mObjectMask]; }
 
-	/// Number of objects that we currently have in the free list / new pages
-#ifdef JPH_ENABLE_ASSERTS
-	atomic<uint32>			mNumFreeObjects;
-#endif // JPH_ENABLE_ASSERTS
-
-	/// Simple counter that makes the first free object pointer update with every CAS so that we don't suffer from the ABA problem
-	atomic<uint32>			mAllocationTag;
-
-	/// Index of first free object, the first 32 bits of an object are used to point to the next free object
-	atomic<uint64>			mFirstFreeObjectAndTag;
-
 	/// Size (in objects) of a single page
 	uint32					mPageSize;
 
@@ -60,14 +49,27 @@ private:
 	/// Total number of objects that have been allocated
 	uint32					mNumObjectsAllocated;
 
-	/// The first free object to use when the free list is empty (may need to allocate a new page)
-	atomic<uint32>			mFirstFreeObjectInNewPage;
-
 	/// Array of pages of objects
 	ObjectStorage **		mPages = nullptr;
 
 	/// Mutex that is used to allocate a new page if the storage runs out
-	Mutex					mPageMutex;
+	/// This variable is aligned to the cache line to prevent false sharing with
+	/// the constants used to index into the list via `Get()`.
+	alignas(JPH_CACHE_LINE_SIZE) Mutex					mPageMutex;
+
+	/// Number of objects that we currently have in the free list / new pages
+#ifdef JPH_ENABLE_ASSERTS
+	atomic<uint32>			mNumFreeObjects;
+#endif // JPH_ENABLE_ASSERTS
+
+	/// Simple counter that makes the first free object pointer update with every CAS so that we don't suffer from the ABA problem
+	atomic<uint32>			mAllocationTag;
+
+	/// Index of first free object, the first 32 bits of an object are used to point to the next free object
+	atomic<uint64>			mFirstFreeObjectAndTag;
+
+	/// The first free object to use when the free list is empty (may need to allocate a new page)
+	atomic<uint32>			mFirstFreeObjectInNewPage;
 
 public:
 	/// Invalid index

--- a/Jolt/Core/FixedSizeFreeList.h
+++ b/Jolt/Core/FixedSizeFreeList.h
@@ -55,7 +55,7 @@ private:
 	/// Mutex that is used to allocate a new page if the storage runs out
 	/// This variable is aligned to the cache line to prevent false sharing with
 	/// the constants used to index into the list via `Get()`.
-	alignas(JPH_CACHE_LINE_SIZE) Mutex					mPageMutex;
+	alignas(JPH_CACHE_LINE_SIZE) Mutex mPageMutex;
 
 	/// Number of objects that we currently have in the free list / new pages
 #ifdef JPH_ENABLE_ASSERTS

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.h
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.h
@@ -334,7 +334,7 @@ private:
 	/// Number of bodies currently in the tree
 	/// This is aligned to be in a different cache line from the `Allocator` pointer to prevent cross-thread syncs
 	/// when reading nodes.
-	alignas(JPH_CACHE_LINE_SIZE) atomic<uint32>				mNumBodies { 0 };
+	alignas(JPH_CACHE_LINE_SIZE) atomic<uint32> mNumBodies { 0 };
 
 	/// We alternate between two tree root nodes. When updating, we activate the new tree and we keep the old tree alive.
 	/// for queries that are in progress until the next time DiscardOldTree() is called.
@@ -385,7 +385,6 @@ private:
 	/// Name of this tree for debugging purposes
 	const char *				mName = "Layer";
 #endif // JPH_EXTERNAL_PROFILE || JPH_PROFILE_ENABLED
-
 };
 
 JPH_NAMESPACE_END


### PR DESCRIPTION
## Summary

Currently, the bookkeeping variables used by `QuadTree` to access the storage of its `FixedSizeFreeList` allocator can reside in the same cache line as `atomic` variables which are modified on allocation. If one thread allocates a new object and another thread calls `mAllocator.Get()`, a cross-thread cache sync can occur, which causes a stall and reduces performance in multi-threaded use cases.

This PR reorders some variables in `QuadTree` and `FixedSizeFreeList` such that the hot path in most use cases (`FixedSizeFreeList::Get()`) should avoid loading unrelated/contentious `atomic` variables.

## Performance Improvement

[`PerformanceTest` before changes (AMD RZ9-7950X)](https://github.com/user-attachments/files/15794976/master_nochanges.txt)

[`PerformanceTest` after changes (AMD RZ9-7950X)](https://github.com/user-attachments/files/15794981/after_changes.txt)

Testing across thread counts on modern desktop x86 processors using the built-in `PerformanceTest` (compiled with LLVM 17 via Clang-CL on Windows), this seems to give around a 5% average improvement in the general case. On other workloads I've tested which are heavily memory-bound, I've seen improvements of up to 15% at specific thread counts. This has also been tested on Apple silicon with no regressions found.