### PR TITLE
Generate a CMake config file when the project is installed

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -243,7 +243,9 @@ if (XCODE)
 endif()
 
 # Install Jolt library and includes
-install(TARGETS Jolt DESTINATION lib)
+install(TARGETS Jolt
+	EXPORT JoltExport
+	DESTINATION lib)
 foreach(SRC_FILE ${JOLT_PHYSICS_SRC_FILES})
 	string(REPLACE ${PHYSICS_REPO_ROOT} "" RELATIVE_SRC_FILE ${SRC_FILE})
 	get_filename_component(DESTINATION_PATH ${RELATIVE_SRC_FILE} DIRECTORY)
@@ -251,6 +253,15 @@ foreach(SRC_FILE ${JOLT_PHYSICS_SRC_FILES})
 		install(FILES ${SRC_FILE} DESTINATION include/${DESTINATION_PATH})
 	endif()
 endforeach()
+
+# Export Jolt library
+export(TARGETS Jolt
+	NAMESPACE Jolt::
+	FILE JoltConfig.cmake)
+install(EXPORT JoltExport
+	DESTINATION lib/cmake/Jolt/
+	NAMESPACE Jolt::
+	FILE JoltConfig.cmake)
 
 # Check if we're the root CMakeLists.txt, if not we are included by another CMake file and we should disable everything except for the main library
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -495,7 +495,10 @@ if (BUILD_SHARED_LIBS)
 	target_compile_definitions(Jolt PRIVATE JPH_BUILD_SHARED_LIBRARY)
 endif()
 
-target_include_directories(Jolt PUBLIC ${PHYSICS_REPO_ROOT})
+# Use repository as include directory when building, install directory when installing
+target_include_directories(Jolt PUBLIC
+	$<BUILD_INTERFACE:${PHYSICS_REPO_ROOT}>
+	$<INSTALL_INTERFACE:include/>)
 target_precompile_headers(Jolt PRIVATE ${JOLT_PHYSICS_ROOT}/Jolt.h)
 
 # Set the debug/non-debug build flags


### PR DESCRIPTION
I noticed that Jolt only installs its header files and its library file, and that it was lacking a config file for `find_package()` to work automatically.

This commit adds an `export()` and `install(EXPORT)` command in CMakeLists.txt so that one is automatically generated when Jolt is built, and automatically installed when Jolt is installed.

This allows for other CMake projects to do something like:

```CMake
find_package(Jolt)

# snip

add_executable(Generic main.cpp)
target_link_libraries(Generic PRIVATE Jolt::Jolt)
```