### PR TITLE
Resolve mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Why create yet another physics engine? Firstly, it has been a personal learning 
 	* Collision queries can run parallel to the main physics simulation. We do a coarse check (broad phase query) before the simulation step and do fine checks (narrow phase query) in the background. This way, long running processes (like navigation mesh generation) can be spread out across multiple frames.
 * Accidental wake up of bodies cause performance problems when loading / unloading content. Therefore, bodies will not automatically wake up when created. Neighboring bodies will not be woken up when bodies are removed. This can be triggered manually if desired.
 * The simulation runs deterministically. You can replicate a simulation to a remote client by merely replicating the inputs to the simulation. Read the [Deterministic Simulation](https://jrouwe.github.io/JoltPhysics/#deterministic-simulation) section to understand the limits.
-* We try to simulate behavior of rigid bodies in the real world but make approximations. Therefore, this library should should mainly be used for games or VR simulations.
+* We try to simulate behavior of rigid bodies in the real world but make approximations. Therefore, this library should mainly be used for games or VR simulations.
 
 ## Features
 


### PR DESCRIPTION
There is an extra `should` in the last point of the `Design Considerations` section in `README.md`, which should not be there, as it is likely a typo or mistake.