### PR TITLE
softbody triangle backface test fix

### DIFF
--- a/Jolt/Physics/SoftBody/SoftBodyShape.cpp
+++ b/Jolt/Physics/SoftBody/SoftBodyShape.cpp
@@ -93,7 +93,7 @@ void SoftBodyShape::CastRay(const RayCast &inRay, const RayCastSettings &inRayCa
 
 		// Back facing check
 		if (inRayCastSettings.mBackFaceMode == EBackFaceMode::IgnoreBackFaces && (x2 - x1).Cross(x3 - x1).Dot(inRay.mDirection) > 0.0f)
-			return;
+			continue;
 
 		// Test ray against triangle
 		float fraction = RayTriangle(inRay.mOrigin, inRay.mDirection, x1, x2, x3);


### PR DESCRIPTION
When one triangle fails the backface test in RayCast, continue to check other triangles instead of exiting early. This was a problem for me when performing ray cast with `EBackFaceMode::IgnoreBackFaces`, because I was inconsistently missing ray hits.