### PR TITLE
indent_size always works even if it is switched to space

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,11 +3,13 @@ root = true
 [*.{cpp,h,inl,cmake,sh,bat,hlsl}]
 indent_style = tab
 indent_size = 4
+tab_width = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 [CMakeLists.txt]
 indent_style = tab
 indent_size = 4
+tab_width = 4
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,12 +2,12 @@ root = true
 
 [*.{cpp,h,inl,cmake,sh,bat,hlsl}]
 indent_style = tab
-tab_width = 4
+indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 [CMakeLists.txt]
 indent_style = tab
-tab_width = 4
+indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
Hi Jorrit,

a very very unimportant fix, I discovered it by chance.

By incorrectly editing the wrong .editorconfig (we always use space) I have noticed that the indentation in Jolt no longer works. By setting indent_size it is always given, because indent_size is evaluated in both cases (tab | space).

Best,
Jens

