### PR TITLE
Allow an external profiler to be installed dynamically

### DIFF
--- a/Jolt/Core/Profiler.cpp
+++ b/Jolt/Core/Profiler.cpp
@@ -17,16 +17,8 @@ JPH_NAMESPACE_BEGIN
 
 #if defined(JPH_EXTERNAL_PROFILE) && defined(JPH_SHARED_LIBRARY)
 
-static void DummyStartMeasurement(const char *inName, uint32 inColor, uint8 *inUserData)
-{
-}
-
-static void DummyEndMeasurement(uint8 *inUserData)
-{
-}
-
-StartMeasurementFunction StartMeasurement = DummyStartMeasurement;
-EndMeasurementFunction EndMeasurement = DummyEndMeasurement;
+ProfileStartMeasurementFunction ProfileStartMeasurement = [](const char *, uint32, uint8 *) { };
+ProfileEndMeasurementFunction ProfileEndMeasurement = [](uint8 *) { };
 
 #elif defined(JPH_PROFILE_ENABLED)
 

--- a/Jolt/Core/Profiler.cpp
+++ b/Jolt/Core/Profiler.cpp
@@ -13,9 +13,22 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <fstream>
 JPH_SUPPRESS_WARNINGS_STD_END
 
-#ifdef JPH_PROFILE_ENABLED
-
 JPH_NAMESPACE_BEGIN
+
+#if defined(JPH_EXTERNAL_PROFILE) && defined(JPH_SHARED_LIBRARY)
+
+static void DummyStartMeasurement(const char *inName, uint32 inColor, uint8 *inUserData)
+{
+}
+
+static void DummyEndMeasurement(uint8 *inUserData)
+{
+}
+
+StartMeasurementFunction StartMeasurement = DummyStartMeasurement;
+EndMeasurementFunction EndMeasurement = DummyEndMeasurement;
+
+#elif defined(JPH_PROFILE_ENABLED)
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Profiler
@@ -341,6 +354,6 @@ void Profiler::DumpChart(const char *inTag, const Threads &inThreads, const KeyT
 </tbody></table></body></html>)";
 }
 
-JPH_NAMESPACE_END
-
 #endif // JPH_PROFILE_ENABLED
+
+JPH_NAMESPACE_END

--- a/Jolt/Core/Profiler.h
+++ b/Jolt/Core/Profiler.h
@@ -18,27 +18,26 @@ JPH_SUPPRESS_WARNINGS_STD_END
 JPH_NAMESPACE_BEGIN
 
 #ifdef JPH_SHARED_LIBRARY
-/// Functions called when a profiler measurement starts or stops, need to be overriden by user.
-using StartMeasurementFunction = void(*)(const char *inName, uint32 inColor, uint8 *inUserData);
-using EndMeasurementFunction = void(*)(uint8 *inUserData);
+/// Functions called when a profiler measurement starts or stops, need to be overridden by the user.
+using ProfileStartMeasurementFunction = void (*)(const char *inName, uint32 inColor, uint8 *ioUserData);
+using ProfileEndMeasurementFunction = void (*)(uint8 *ioUserData);
 
-JPH_EXPORT extern StartMeasurementFunction StartMeasurement;
-JPH_EXPORT extern EndMeasurementFunction EndMeasurement;
+JPH_EXPORT extern ProfileStartMeasurementFunction ProfileStartMeasurement;
+JPH_EXPORT extern ProfileEndMeasurementFunction ProfileEndMeasurement;
 #endif // JPH_SHARED_LIBRARY
 
 /// Create this class on the stack to start sampling timing information of a particular scope.
 ///
-/// Left unimplemented intentionally. Needs to be implemented by the user of the library.
 /// For statically linked builds, this is left unimplemented intentionally. Needs to be implemented by the user of the library.
-/// For dynamically linked builds, the user should override `StartMeasurement` and `EndMeasurement`.
 /// On construction a measurement should start, on destruction it should be stopped.
+/// For dynamically linked builds, the user should override the ProfileStartMeasurement and ProfileEndMeasurement functions.
 class alignas(16) ExternalProfileMeasurement : public NonCopyable
 {
 public:
 	/// Constructor
 #ifdef JPH_SHARED_LIBRARY
-									ExternalProfileMeasurement(const char *inName, uint32 inColor = 0) { StartMeasurement(inName, inColor, mUserData); }
-									~ExternalProfileMeasurement() { EndMeasurement(mUserData); }
+	JPH_INLINE						ExternalProfileMeasurement(const char *inName, uint32 inColor = 0) { ProfileStartMeasurement(inName, inColor, mUserData); }
+	JPH_INLINE						~ExternalProfileMeasurement() { ProfileEndMeasurement(mUserData); }
 #else
 									ExternalProfileMeasurement(const char *inName, uint32 inColor = 0);
 									~ExternalProfileMeasurement();


### PR DESCRIPTION
I agree with your point about avoiding the dynamic overhead if it's not necessary, so I ended up adding a check for `JPH_SHARED_LIBRARY`. This may mean that `JPH_SHARED_LIBRARY` needs to be tested for in `RegisterTypesInternal`, but I wasn't sure. Happy to fix anything if necessary :)