### PR TITLE
Added missing JPH_EXPORT macro

### DIFF
--- a/Jolt/Physics/Body/BodyFilter.h
+++ b/Jolt/Physics/Body/BodyFilter.h
@@ -12,7 +12,7 @@ JPH_NAMESPACE_BEGIN
 class Body;
 
 /// Class function to filter out bodies, returns true if test should collide with body
-class BodyFilter : public NonCopyable
+class JPH_EXPORT BodyFilter : public NonCopyable
 {
 public:
 	/// Destructor
@@ -32,7 +32,7 @@ public:
 };
 
 /// A simple body filter implementation that ignores a single, specified body
-class IgnoreSingleBodyFilter : public BodyFilter
+class JPH_EXPORT IgnoreSingleBodyFilter : public BodyFilter
 {
 public:
 	/// Constructor, pass the body you want to ignore
@@ -52,7 +52,7 @@ private:
 };
 
 /// A simple body filter implementation that ignores multiple, specified bodies
-class IgnoreMultipleBodiesFilter : public BodyFilter
+class JPH_EXPORT IgnoreMultipleBodiesFilter : public BodyFilter
 {
 public:
 	/// Remove all bodies from the filter
@@ -85,7 +85,7 @@ private:
 
 #ifdef JPH_DEBUG_RENDERER
 /// Class function to filter out bodies for debug rendering, returns true if body should be rendered
-class BodyDrawFilter : public NonCopyable
+class JPH_EXPORT BodyDrawFilter : public NonCopyable
 {
 public:
 	/// Destructor

--- a/Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h
@@ -57,7 +57,7 @@ private:
 static constexpr BroadPhaseLayer cBroadPhaseLayerInvalid(0xff);
 
 /// Interface that the application should implement to allow mapping object layers to broadphase layers
-class BroadPhaseLayerInterface : public NonCopyable
+class JPH_EXPORT BroadPhaseLayerInterface : public NonCopyable
 {
 public:
 	/// Destructor
@@ -76,7 +76,7 @@ public:
 };
 
 /// Class to test if an object can collide with a broadphase layer. Used while finding collision pairs.
-class ObjectVsBroadPhaseLayerFilter : public NonCopyable
+class JPH_EXPORT ObjectVsBroadPhaseLayerFilter : public NonCopyable
 {
 public:
 	/// Destructor
@@ -90,7 +90,7 @@ public:
 };
 
 /// Filter class for broadphase layers
-class BroadPhaseLayerFilter : public NonCopyable
+class JPH_EXPORT BroadPhaseLayerFilter : public NonCopyable
 {
 public:
 	/// Destructor
@@ -104,7 +104,7 @@ public:
 };
 
 /// Default filter class that uses the pair filter in combination with a specified layer to filter layers
-class DefaultBroadPhaseLayerFilter : public BroadPhaseLayerFilter
+class JPH_EXPORT DefaultBroadPhaseLayerFilter : public BroadPhaseLayerFilter
 {
 public:
 	/// Constructor
@@ -126,7 +126,7 @@ private:
 };
 
 /// Allows objects from a specific broad phase layer only
-class SpecifiedBroadPhaseLayerFilter : public BroadPhaseLayerFilter
+class JPH_EXPORT SpecifiedBroadPhaseLayerFilter : public BroadPhaseLayerFilter
 {
 public:
 	/// Constructor

--- a/Jolt/Physics/Collision/ObjectLayer.h
+++ b/Jolt/Physics/Collision/ObjectLayer.h
@@ -24,7 +24,7 @@ JPH_NAMESPACE_BEGIN
 static constexpr ObjectLayer cObjectLayerInvalid = ObjectLayer(~ObjectLayer(0U));
 
 /// Filter class for object layers
-class ObjectLayerFilter : public NonCopyable
+class JPH_EXPORT ObjectLayerFilter : public NonCopyable
 {
 public:
 	/// Destructor
@@ -46,7 +46,7 @@ public:
 };
 
 /// Filter class to test if two objects can collide based on their object layer. Used while finding collision pairs.
-class ObjectLayerPairFilter : public NonCopyable
+class JPH_EXPORT ObjectLayerPairFilter : public NonCopyable
 {
 public:
 	/// Destructor
@@ -60,7 +60,7 @@ public:
 };
 
 /// Default filter class that uses the pair filter in combination with a specified layer to filter layers
-class DefaultObjectLayerFilter : public ObjectLayerFilter
+class JPH_EXPORT DefaultObjectLayerFilter : public ObjectLayerFilter
 {
 public:
 	/// Constructor
@@ -89,7 +89,7 @@ private:
 };
 
 /// Allows objects from a specific layer only
-class SpecifiedObjectLayerFilter : public ObjectLayerFilter
+class JPH_EXPORT SpecifiedObjectLayerFilter : public ObjectLayerFilter
 {
 public:
 	/// Constructor


### PR DESCRIPTION
The DLL export definition was missing on a few classes, which means you can't derive from them when Jolt is used from a DLL or shared object.