### PR TITLE
Added OldSize argument to realloc function

### DIFF
--- a/Jolt/Core/Array.h
+++ b/Jolt/Core/Array.h
@@ -73,7 +73,7 @@ private:
 	}
 
 	/// Reallocate the data block to inNewCapacity
-	inline void				reallocate(size_type inNewCapacity)
+	inline void				reallocate(size_type inOldCapacity, size_type inNewCapacity)
 	{
 		JPH_ASSERT(inNewCapacity > 0 && inNewCapacity >= mSize);
 
@@ -111,7 +111,7 @@ public:
 	inline void				reserve(size_type inNewSize)
 	{
 		if (mCapacity < inNewSize)
-			reallocate(inNewSize);
+			reallocate(mCapacity, inNewSize);
 	}
 
 	/// Resize array to new length
@@ -334,7 +334,7 @@ public:
 			if (mSize == 0)
 				free();
 			else if (mCapacity > mSize)
-				reallocate(mSize);
+				reallocate(mCapacity, mSize);
 		}
 	}
 

--- a/Jolt/Core/Array.h
+++ b/Jolt/Core/Array.h
@@ -73,7 +73,7 @@ private:
 	}
 
 	/// Reallocate the data block to inNewCapacity
-	inline void				reallocate(size_type inOldCapacity, size_type inNewCapacity)
+	inline void				reallocate(size_type inNewCapacity)
 	{
 		JPH_ASSERT(inNewCapacity > 0 && inNewCapacity >= mSize);
 
@@ -111,7 +111,7 @@ public:
 	inline void				reserve(size_type inNewSize)
 	{
 		if (mCapacity < inNewSize)
-			reallocate(mCapacity, inNewSize);
+			reallocate(inNewSize);
 	}
 
 	/// Resize array to new length
@@ -334,7 +334,7 @@ public:
 			if (mSize == 0)
 				free();
 			else if (mCapacity > mSize)
-				reallocate(mCapacity, mSize);
+				reallocate(mSize);
 		}
 	}
 

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -25,7 +25,7 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Allocate)(size_t inSize)
 	return malloc(inSize);
 }
 
-JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Reallocate)(void *inBlock, size_t inSize)
+JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Reallocate)(void *inBlock, size_t inOldSize, size_t inSize)
 {
 	JPH_ASSERT(inSize > 0);
 	return realloc(inBlock, inSize);

--- a/Jolt/Core/Memory.cpp
+++ b/Jolt/Core/Memory.cpp
@@ -25,10 +25,10 @@ JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Allocate)(size_t inSize)
 	return malloc(inSize);
 }
 
-JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Reallocate)(void *inBlock, size_t inOldSize, size_t inSize)
+JPH_ALLOC_SCOPE void *JPH_ALLOC_FN(Reallocate)(void *inBlock, [[maybe_unused]] size_t inOldSize, size_t inNewSize)
 {
-	JPH_ASSERT(inSize > 0);
-	return realloc(inBlock, inSize);
+	JPH_ASSERT(inNewSize > 0);
+	return realloc(inBlock, inNewSize);
 }
 
 JPH_ALLOC_SCOPE void JPH_ALLOC_FN(Free)(void *inBlock)

--- a/Jolt/Core/Memory.h
+++ b/Jolt/Core/Memory.h
@@ -10,7 +10,7 @@ JPH_NAMESPACE_BEGIN
 
 // Normal memory allocation, must be at least 8 byte aligned on 32 bit platform and 16 byte aligned on 64 bit platform
 using AllocateFunction = void *(*)(size_t inSize);
-using ReallocateFunction = void *(*)(void *inBlock, size_t inSize);
+using ReallocateFunction = void *(*)(void *inBlock, size_t inOldSize, size_t inNewSize);
 using FreeFunction = void (*)(void *inBlock);
 
 // Aligned memory allocation
@@ -42,7 +42,7 @@ JPH_EXPORT void RegisterDefaultAllocator();
 
 // Directly define the allocation functions
 JPH_EXPORT void *Allocate(size_t inSize);
-JPH_EXPORT void *Reallocate(void *inBlock, size_t inSize);
+JPH_EXPORT void *Reallocate(void *inBlock, size_t inOldSize, size_t inNewSize);
 JPH_EXPORT void Free(void *inBlock);
 JPH_EXPORT void *AlignedAllocate(size_t inSize, size_t inAlignment);
 JPH_EXPORT void AlignedFree(void *inBlock);

--- a/Jolt/Core/STLAllocator.h
+++ b/Jolt/Core/STLAllocator.h
@@ -60,10 +60,10 @@ public:
 
 	/// Reallocate memory
 	template <bool has_reallocate_v = has_reallocate, typename = std::enable_if_t<has_reallocate_v>>
-	inline pointer			reallocate(pointer inOldPointer, [[maybe_unused]] size_type inOldSize, size_type inNewSize)
+	inline pointer			reallocate(pointer inOldPointer, size_type inOldSize, size_type inNewSize)
 	{
 		JPH_ASSERT(inNewSize > 0); // Reallocating to zero size is implementation dependent, so we don't allow it
-		return pointer(Reallocate(inOldPointer, inNewSize * sizeof(value_type)));
+		return pointer(Reallocate(inOldPointer, inOldSize * sizeof(value_type), inNewSize * sizeof(value_type)));
 	}
 
 	/// Free memory

--- a/TestFramework/Utils/CustomMemoryHook.cpp
+++ b/TestFramework/Utils/CustomMemoryHook.cpp
@@ -63,11 +63,11 @@ static void *AllocateHook(size_t inSize)
 	return TagAllocation(malloc(inSize + 16), 16, 'U');
 }
 
-static void *ReallocateHook(void *inBlock, size_t inSize)
+static void *ReallocateHook(void *inBlock, size_t inOldSize, size_t inNewSize)
 {
-	JPH_ASSERT(inSize > 0);
+	JPH_ASSERT(inNewSize > 0);
 	InCustomAllocator ica;
-	return TagAllocation(realloc(UntagAllocation(inBlock, 16, 'U'), inSize + 16), 16, 'U');
+	return TagAllocation(realloc(UntagAllocation(inBlock, 16, 'U'), inNewSize + 16), 16, 'U');
 }
 
 static void FreeHook(void *inBlock)


### PR DESCRIPTION
This is necessary so that implementations that need the old size (for copying the right amount of data over) don't need to track themselves how much memory is associated with the original pointer.