### PR TITLE
Each invocation of va_start must be matched by a va_end

### DIFF
--- a/TestFramework/Utils/Log.cpp
+++ b/TestFramework/Utils/Log.cpp
@@ -28,6 +28,7 @@ void FatalError [[noreturn]] (const char *inFMT, ...)
 	va_start(list, inFMT);
 	char buffer[1024];
 	vsnprintf(buffer, sizeof(buffer), inFMT, list);
+	va_end(list);
 
 	Trace("Fatal Error: %s", buffer);
 


### PR DESCRIPTION
You don't want to smash the stack.