### PR TITLE
Fixed ScaledShape::MakeScaleValid

### DIFF
--- a/Jolt/Physics/Collision/Shape/ScaledShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.cpp
@@ -178,9 +178,9 @@ bool ScaledShape::IsValidScale(Vec3Arg inScale) const
 
 Vec3 ScaledShape::MakeScaleValid(Vec3Arg inScale) const
 {
-	Vec3 scale = ScaleHelpers::MakeNonZeroScale(inScale);
+	Vec3 scale = ScaleHelpers::MakeNonZeroScale(mScale);
 
-	return mInnerShape->MakeScaleValid(mScale * scale) / scale;
+	return mInnerShape->MakeScaleValid(scale * inScale) / scale;
 }
 
 void ScaledShape::sCollideScaledVsShape(const Shape *inShape1, const Shape *inShape2, Vec3Arg inScale1, Vec3Arg inScale2, Mat44Arg inCenterOfMassTransform1, Mat44Arg inCenterOfMassTransform2, const SubShapeIDCreator &inSubShapeIDCreator1, const SubShapeIDCreator &inSubShapeIDCreator2, const CollideShapeSettings &inCollideShapeSettings, CollideShapeCollector &ioCollector, const ShapeFilter &inShapeFilter)

--- a/Jolt/Physics/Collision/Shape/ScaledShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.cpp
@@ -178,9 +178,7 @@ bool ScaledShape::IsValidScale(Vec3Arg inScale) const
 
 Vec3 ScaledShape::MakeScaleValid(Vec3Arg inScale) const
 {
-	Vec3 scale = ScaleHelpers::MakeNonZeroScale(mScale);
-
-	return mInnerShape->MakeScaleValid(scale * inScale) / scale;
+	return mInnerShape->MakeScaleValid(mScale * inScale) / mScale;
 }
 
 void ScaledShape::sCollideScaledVsShape(const Shape *inShape1, const Shape *inShape2, Vec3Arg inScale1, Vec3Arg inScale2, Mat44Arg inCenterOfMassTransform1, Mat44Arg inCenterOfMassTransform2, const SubShapeIDCreator &inSubShapeIDCreator1, const SubShapeIDCreator &inSubShapeIDCreator2, const CollideShapeSettings &inCollideShapeSettings, CollideShapeCollector &ioCollector, const ShapeFilter &inShapeFilter)

--- a/Jolt/Physics/Collision/Shape/ScaledShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.cpp
@@ -37,6 +37,12 @@ ScaledShape::ScaledShape(const ScaledShapeSettings &inSettings, ShapeResult &out
 	if (outResult.HasError())
 		return;
 
+	if (inSettings.mScale.IsNearZero())
+	{
+		outResult.SetError("Can't use zero scale!");
+		return;
+	}
+
 	outResult.Set(this);
 }
 

--- a/Jolt/Physics/Collision/Shape/ScaledShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.cpp
@@ -37,7 +37,7 @@ ScaledShape::ScaledShape(const ScaledShapeSettings &inSettings, ShapeResult &out
 	if (outResult.HasError())
 		return;
 
-	if (inSettings.mScale.IsNearZero())
+	if (ScaleHelpers::IsZeroScale(inSettings.mScale))
 	{
 		outResult.SetError("Can't use zero scale!");
 		return;

--- a/Jolt/Physics/Collision/Shape/ScaledShape.h
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.h
@@ -42,7 +42,7 @@ public:
 									ScaledShape(const ScaledShapeSettings &inSettings, ShapeResult &outResult);
 
 	/// Constructor that decorates another shape with a scale
-									ScaledShape(const Shape *inShape, Vec3Arg inScale)		: DecoratedShape(EShapeSubType::Scaled, inShape), mScale(inScale) { }
+									ScaledShape(const Shape *inShape, Vec3Arg inScale)		: DecoratedShape(EShapeSubType::Scaled, inShape), mScale(inScale) { JPH_ASSERT(!mScale.IsNearZero()); }
 
 	/// Get the scale
 	Vec3							GetScale() const										{ return mScale; }

--- a/Jolt/Physics/Collision/Shape/ScaledShape.h
+++ b/Jolt/Physics/Collision/Shape/ScaledShape.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <Jolt/Physics/Collision/Shape/DecoratedShape.h>
+#include <Jolt/Physics/Collision/Shape/ScaleHelpers.h>
 
 JPH_NAMESPACE_BEGIN
 
@@ -42,7 +43,7 @@ public:
 									ScaledShape(const ScaledShapeSettings &inSettings, ShapeResult &outResult);
 
 	/// Constructor that decorates another shape with a scale
-									ScaledShape(const Shape *inShape, Vec3Arg inScale)		: DecoratedShape(EShapeSubType::Scaled, inShape), mScale(inScale) { JPH_ASSERT(!mScale.IsNearZero()); }
+									ScaledShape(const Shape *inShape, Vec3Arg inScale)		: DecoratedShape(EShapeSubType::Scaled, inShape), mScale(inScale) { JPH_ASSERT(!ScaleHelpers::IsZeroScale(mScale)); }
 
 	/// Get the scale
 	Vec3							GetScale() const										{ return mScale; }

--- a/UnitTests/Physics/ShapeTests.cpp
+++ b/UnitTests/Physics/ShapeTests.cpp
@@ -202,6 +202,8 @@ TEST_SUITE("ShapeTests")
 		CHECK(!scaled->IsValidScale(Vec3(2, 1, 1)));
 		CHECK(!scaled->IsValidScale(Vec3(1, 2, 1)));
 		CHECK(!scaled->IsValidScale(Vec3(1, 1, 2)));
+		CHECK(scaled->MakeScaleValid(Vec3(3, 3, 3)) == Vec3(4, 2, 4));
+		CHECK(scaled->MakeScaleValid(Vec3(4, 2, 4)) == Vec3(4, 2, 4));
 
 		Ref<Shape> scaled2 = new ScaledShape(scaled, Vec3(1, 0.5f, 1));
 		CHECK(!scaled2->IsValidScale(Vec3::sZero()));
@@ -210,6 +212,8 @@ TEST_SUITE("ShapeTests")
 		CHECK(!scaled2->IsValidScale(Vec3(2, 1, 1)));
 		CHECK(!scaled2->IsValidScale(Vec3(1, 2, 1)));
 		CHECK(!scaled2->IsValidScale(Vec3(1, 1, 2)));
+		CHECK(scaled2->MakeScaleValid(Vec3(3, 3, 3)) == Vec3(3, 3, 3));
+		CHECK(scaled2->MakeScaleValid(Vec3(5, 2, 5)) == Vec3(4, 4, 4));
 
 		// Test a compound with shapes that can only be scaled uniformly
 		StaticCompoundShapeSettings compound_settings;


### PR DESCRIPTION
Currently when passing something like `(0.1, 0.1, 0.1)` into `ScaledShape::MakeScaleValid`, where `ScaledShape::mScale` is `(3, 3, 3)`, you end up getting `(3, 3, 3)` back, whereas you would expect to get `(0.1, 0.1, 0.1)` back.

I assume the divison by `scale` in `ScaledShape::MakeScaleValid` was supposed to be by `mScale` instead, so I went ahead and flipped those.