### PR TITLE
Added overrides for IsValidScale/MakeScaleValid to DecoratedShape

### DIFF
--- a/Jolt/Physics/Collision/Shape/DecoratedShape.h
+++ b/Jolt/Physics/Collision/Shape/DecoratedShape.h
@@ -63,6 +63,12 @@ public:
 	// See Shape::GetStatsRecursive
 	virtual Stats					GetStatsRecursive(VisitedShapes &ioVisitedShapes) const override;
 
+	// See Shape::IsValidScale
+	virtual bool					IsValidScale(Vec3Arg inScale) const override			{ return mInnerShape->IsValidScale(inScale); }
+
+	// See Shape::MakeScaleValid
+	virtual Vec3					MakeScaleValid(Vec3Arg inScale) const override			{ return mInnerShape->MakeScaleValid(inScale); }
+
 protected:
 	RefConst<Shape>					mInnerShape;
 };

--- a/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
+++ b/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
@@ -120,12 +120,6 @@ public:
 	// See Shape::GetVolume
 	virtual float					GetVolume() const override								{ return mInnerShape->GetVolume(); }
 
-	// See Shape::IsValidScale
-	virtual bool					IsValidScale(Vec3Arg inScale) const override			{ return mInnerShape->IsValidScale(inScale); }
-
-	// See Shape::MakeScaleValid
-	virtual Vec3					MakeScaleValid(Vec3Arg inScale) const override			{ return mInnerShape->MakeScaleValid(inScale); }
-
 	// Register shape functions with the registry
 	static void						sRegister();
 

--- a/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.cpp
+++ b/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.cpp
@@ -282,7 +282,7 @@ void RotatedTranslatedShape::RestoreBinaryState(StreamIn &inStream)
 
 bool RotatedTranslatedShape::IsValidScale(Vec3Arg inScale) const
 {
-	if (!DecoratedShape::IsValidScale(inScale))
+	if (!Shape::IsValidScale(inScale))
 		return false;
 
 	if (mIsRotationIdentity || ScaleHelpers::IsUniformScale(inScale))


### PR DESCRIPTION
This might be by-design perhaps, but I found it a bit odd to have the default implementations of `DecoratedShape::IsValidScale` and `DecoratedShape::MakeScaleValid` not go through its `mInnerShape`, so this adds exactly that.

I removed the now redundant overrides in `OffsetCenterOfMassShape` as well, and changed `RotatedTranslatedShape::IsValidScale` to check with `Shape::IsValidScale` first instead.