### PR TITLE
Fix compile error: __builtin_bitreverse32 does not exist in gcc ARM version

### DIFF
--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -116,7 +116,9 @@ inline uint CountTrailingZeros(uint32 inValue)
 		_BitScanForward(&result, inValue);
 		return result;
 	#else
-		return __builtin_clz(__builtin_bitreverse32(inValue));
+		if (inValue == 0)
+			return 32;
+		return __builtin_ctz(inValue);
 	#endif
 #elif defined(JPH_CPU_E2K)
 		return inValue ? __builtin_ctz(inValue) : 32;

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -115,11 +115,7 @@ inline uint CountTrailingZeros(uint32 inValue)
 		unsigned long result;
 		_BitScanForward(&result, inValue);
 		return result;
-	#elif defined(JPH_COMPILER_CLANG)
-		// Using __builtin_ctz creates a loop on ARM containing a rbit and clz instruction, the following only creates a single rbit and clz instruction
-		return __builtin_clz(__builtin_bitreverse32(inValue));
 	#else
-		// GCC doesn't have __builtin_bitreverse32 so we fall back to __builtin_ctz
 		if (inValue == 0)
 			return 32;
 		return __builtin_ctz(inValue);

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -115,7 +115,11 @@ inline uint CountTrailingZeros(uint32 inValue)
 		unsigned long result;
 		_BitScanForward(&result, inValue);
 		return result;
+	#elif defined(JPH_COMPILER_CLANG)
+		// Using __builtin_ctz creates a loop on ARM containing a rbit and clz instruction, the following only creates a single rbit and clz instruction
+		return __builtin_clz(__builtin_bitreverse32(inValue));
 	#else
+		// GCC doesn't have __builtin_bitreverse32 so we fall back to __builtin_ctz
 		if (inValue == 0)
 			return 32;
 		return __builtin_ctz(inValue);

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -844,9 +844,9 @@ Vec3 Vec3::GetSign() const
 	Type one = vdupq_n_f32(1.0f);
 	return vorrq_s32(vandq_s32(mValue, minus_one), one);
 #else
-	return Vec3(signbit(mF32[0])? -1.0f : 1.0f,
-				signbit(mF32[1])? -1.0f : 1.0f,
-				signbit(mF32[2])? -1.0f : 1.0f);
+	return Vec3(std::signbit(mF32[0])? -1.0f : 1.0f,
+				std::signbit(mF32[1])? -1.0f : 1.0f,
+				std::signbit(mF32[2])? -1.0f : 1.0f);
 #endif
 }
 

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -692,10 +692,10 @@ Vec4 Vec4::GetSign() const
 	Type one = vdupq_n_f32(1.0f);
 	return vorrq_s32(vandq_s32(mValue, minus_one), one);
 #else
-	return Vec4(signbit(mF32[0])? -1.0f : 1.0f,
-				signbit(mF32[1])? -1.0f : 1.0f,
-				signbit(mF32[2])? -1.0f : 1.0f,
-				signbit(mF32[3])? -1.0f : 1.0f);
+	return Vec4(std::signbit(mF32[0])? -1.0f : 1.0f,
+				std::signbit(mF32[1])? -1.0f : 1.0f,
+				std::signbit(mF32[2])? -1.0f : 1.0f,
+				std::signbit(mF32[3])? -1.0f : 1.0f);
 #endif
 }
 
@@ -754,7 +754,7 @@ int Vec4::GetSignBits() const
 	int32x4_t shift = JPH_NEON_INT32x4(0, 1, 2, 3);
 	return vaddvq_u32(vshlq_u32(vshrq_n_u32(vreinterpretq_u32_f32(mValue), 31), shift));
 #else
-	return (signbit(mF32[0])? 1 : 0) | (signbit(mF32[1])? 2 : 0) | (signbit(mF32[2])? 4 : 0) | (signbit(mF32[3])? 8 : 0);
+	return (std::signbit(mF32[0])? 1 : 0) | (std::signbit(mF32[1])? 2 : 0) | (std::signbit(mF32[2])? 4 : 0) | (std::signbit(mF32[3])? 8 : 0);
 #endif
 }
 


### PR DESCRIPTION
1. specify `std` namespace for the `signbit()` function
2. avoid using `__builtin_bitreverse32()` when compiling for ARM with GCC