### PR TITLE
Character: Add GetLayer method

### DIFF
--- a/Jolt/Physics/Character/Character.h
+++ b/Jolt/Physics/Character/Character.h
@@ -105,6 +105,9 @@ public:
 	/// Calculate the world transform of the character
 	RMat44								GetWorldTransform(bool inLockBodies = true) const;
 
+	/// Get the layer of the character
+	ObjectLayer							GetLayer() const										{ return mLayer; }
+
 	/// Update the layer of the character
 	void								SetLayer(ObjectLayer inLayer, bool inLockBodies = true);
 


### PR DESCRIPTION
The character class stores the object layer but the only way to retrieve it is via the body