### PR TITLE
Disable -mfpmath=sse for emscripten builds

### DIFF
--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -651,7 +651,7 @@ else()
 			target_compile_options(Jolt PUBLIC -mfma)
 		endif()
 
-		if (NOT MSVC)
+		if (NOT MSVC AND NOT EMSCRIPTEN)
 			target_compile_options(Jolt PUBLIC -mfpmath=sse)
 		endif()
 


### PR DESCRIPTION
Hey, first of all thank you for creating this, I'm currently integrating this into our game creation tool and so far it's been great to work with :)

Just a little change I had make to compile the library with emscripten since `-mfpmath` doesn't seem to be a valid compile flag.
Aside from having to set `USE_SSE4_1` externally and enable web simd with `-msimd128 `