### PR TITLE
Removed the use of size_t when saving to binary

### DIFF
--- a/Jolt/Core/StreamIn.h
+++ b/Jolt/Core/StreamIn.h
@@ -35,7 +35,7 @@ public:
 	template <class T, class A, std::enable_if_t<std::is_trivially_copyable_v<T>, bool> = true>
 	void				Read(Array<T, A> &outT)
 	{
-		typename Array<T, A>::size_type len = outT.size(); // Initialize to previous array size, this is used for validation in the StateRecorder class
+		uint32 len = uint32(outT.size()); // Initialize to previous array size, this is used for validation in the StateRecorder class
 		Read(len);
 		if (!IsEOF() && !IsFailed())
 		{
@@ -60,7 +60,7 @@ public:
 	template <class Type, class Traits, class Allocator>
 	void				Read(std::basic_string<Type, Traits, Allocator> &outString)
 	{
-		typename std::basic_string<Type, Traits, Allocator>::size_type len = 0;
+		uint32 len = 0;
 		Read(len);
 		if (!IsEOF() && !IsFailed())
 		{
@@ -75,7 +75,7 @@ public:
 	template <class T, class A, typename F>
 	void				Read(Array<T, A> &outT, const F &inReadElement)
 	{
-		typename Array<T, A>::size_type len = outT.size(); // Initialize to previous array size, this is used for validation in the StateRecorder class
+		uint32 len = uint32(outT.size()); // Initialize to previous array size, this is used for validation in the StateRecorder class
 		Read(len);
 		if (!IsEOF() && !IsFailed())
 		{

--- a/Jolt/Core/StreamOut.h
+++ b/Jolt/Core/StreamOut.h
@@ -32,7 +32,7 @@ public:
 	template <class T, class A, std::enable_if_t<std::is_trivially_copyable_v<T>, bool> = true>
 	void				Write(const Array<T, A> &inT)
 	{
-		typename Array<T, A>::size_type len = inT.size();
+		uint32 len = uint32(inT.size());
 		Write(len);
 		if (!IsFailed())
 		{
@@ -54,7 +54,7 @@ public:
 	template <class Type, class Traits, class Allocator>
 	void				Write(const std::basic_string<Type, Traits, Allocator> &inString)
 	{
-		typename std::basic_string<Type, Traits, Allocator>::size_type len = inString.size();
+		uint32 len = uint32(inString.size());
 		Write(len);
 		if (!IsFailed())
 			WriteBytes(inString.data(), len * sizeof(Type));
@@ -64,7 +64,7 @@ public:
 	template <class T, class A, typename F>
 	void				Write(const Array<T, A> &inT, const F &inWriteElement)
 	{
-		typename Array<T, A>::size_type len = inT.size();
+		uint32 len = uint32(inT.size());
 		Write(len);
 		if (!IsFailed())
 			for (typename Array<T, A>::size_type i = 0; i < len; ++i)

--- a/Jolt/Core/StreamUtils.h
+++ b/Jolt/Core/StreamUtils.h
@@ -126,7 +126,8 @@ Result<Ref<Type>>	RestoreObjectReference(StreamIn &inStream, IDToObjectMap<Type>
 template <class ArrayType, class ValueType>
 void				SaveObjectArray(StreamOut &inStream, const ArrayType &inArray, ObjectToIDMap<ValueType> *ioObjectToIDMap)
 {
-	inStream.Write(size_t(inArray.size()));
+	uint32 len = uint32(inArray.size());
+	inStream.Write(len);
 	for (const ValueType *value: inArray)
 		SaveObjectReference(inStream, value, ioObjectToIDMap);
 }
@@ -137,7 +138,7 @@ Result<ArrayType>	RestoreObjectArray(StreamIn &inStream, IDToObjectMap<ValueType
 {
 	Result<ArrayType> result;
 
-	size_t len;
+	uint32 len;
 	inStream.Read(len);
 	if (inStream.IsEOF() || inStream.IsFailed())
 	{

--- a/Jolt/Physics/Collision/Shape/Shape.cpp
+++ b/Jolt/Physics/Collision/Shape/Shape.cpp
@@ -117,7 +117,7 @@ void Shape::SaveWithChildren(StreamOut &inStream, ShapeToIDMap &ioShapeMap, Mate
 		// Write the ID's of all sub shapes
 		ShapeList sub_shapes;
 		SaveSubShapeState(sub_shapes);
-		inStream.Write(sub_shapes.size());
+		inStream.Write(uint32(sub_shapes.size()));
 		for (const Shape *shape : sub_shapes)
 		{
 			if (shape == nullptr)
@@ -173,7 +173,7 @@ Shape::ShapeResult Shape::sRestoreWithChildren(StreamIn &inStream, IDToShapeMap 
 	ioShapeMap.push_back(result.Get());
 
 	// Read the sub shapes
-	size_t len;
+	uint32 len;
 	inStream.Read(len);
 	if (inStream.IsEOF() || inStream.IsFailed())
 	{

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -491,7 +491,7 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 	inStream.Read(num_body_pairs);
 
 	// Read entire cache
-	for (size_t i = 0; i < num_body_pairs; ++i)
+	for (uint32 i = 0; i < num_body_pairs; ++i)
 	{
 		// Read key
 		BodyPair body_pair_key;
@@ -527,7 +527,7 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 		inStream.Read(num_manifolds);
 
 		uint32 handle = ManifoldMap::cInvalidHandle;
-		for (size_t j = 0; j < num_manifolds; ++j)
+		for (uint32 j = 0; j < num_manifolds; ++j)
 		{
 			// Read key
 			SubShapeIDPair sub_shape_key;
@@ -578,7 +578,7 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 		num_manifolds = uint32(all_m.size());
 	inStream.Read(num_manifolds);
 
-	for (size_t j = 0; j < num_manifolds; ++j)
+	for (uint32 j = 0; j < num_manifolds; ++j)
 	{
 		// Read key
 		SubShapeIDPair sub_shape_key;

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -408,7 +408,7 @@ void ContactConstraintManager::ManifoldCache::SaveState(StateRecorder &inStream,
 	}
 
 	// Write body pairs
-	size_t num_body_pairs = selected_bp.size();
+	uint32 num_body_pairs = uint32(selected_bp.size());
 	inStream.Write(num_body_pairs);
 	for (const BPKeyValue *bp_kv : selected_bp)
 	{
@@ -424,7 +424,7 @@ void ContactConstraintManager::ManifoldCache::SaveState(StateRecorder &inStream,
 		GetAllManifoldsSorted(bp, all_m);
 
 		// Write num manifolds
-		size_t num_manifolds = all_m.size();
+		uint32 num_manifolds = uint32(all_m.size());
 		inStream.Write(num_manifolds);
 
 		// Write all manifolds
@@ -464,7 +464,7 @@ void ContactConstraintManager::ManifoldCache::SaveState(StateRecorder &inStream,
 	}
 
 	// Write all CCD manifold keys
-	size_t num_manifolds = selected_m.size();
+	uint32 num_manifolds = uint32(selected_m.size());
 	inStream.Write(num_manifolds);
 	for (const MKeyValue *m_kv : selected_m)
 		inStream.Write(m_kv->GetKey());
@@ -485,9 +485,9 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 		inReadCache.GetAllBodyPairsSorted(all_bp);
 
 	// Read amount of body pairs
-	size_t num_body_pairs;
+	uint32 num_body_pairs;
 	if (inStream.IsValidating())
-		num_body_pairs = all_bp.size();
+		num_body_pairs = uint32(all_bp.size());
 	inStream.Read(num_body_pairs);
 
 	// Read entire cache
@@ -521,9 +521,9 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 			inReadCache.GetAllManifoldsSorted(all_bp[i]->GetValue(), all_m);
 
 		// Read amount of manifolds
-		size_t num_manifolds;
+		uint32 num_manifolds;
 		if (inStream.IsValidating())
-			num_manifolds = all_m.size();
+			num_manifolds = uint32(all_m.size());
 		inStream.Read(num_manifolds);
 
 		uint32 handle = ManifoldMap::cInvalidHandle;
@@ -573,9 +573,9 @@ bool ContactConstraintManager::ManifoldCache::RestoreState(const ManifoldCache &
 		inReadCache.GetAllCCDManifoldsSorted(all_m);
 
 	// Read amount of CCD manifolds
-	size_t num_manifolds;
+	uint32 num_manifolds;
 	if (inStream.IsValidating())
-		num_manifolds = all_m.size();
+		num_manifolds = uint32(all_m.size());
 	inStream.Read(num_manifolds);
 
 	for (size_t j = 0; j < num_manifolds; ++j)

--- a/PerformanceTest/PerformanceTest.cpp
+++ b/PerformanceTest/PerformanceTest.cpp
@@ -370,14 +370,14 @@ int main(int argc, char** argv)
 
 						// Write to file
 						string data = recorder.GetData();
-						size_t size = data.size();
+						uint32 size = uint32(data.size());
 						record_state_file.write((char *)&size, sizeof(size));
 						record_state_file.write(data.data(), size);
 					}
 					else if (validate_state)
 					{
 						// Read state
-						size_t size = 0;
+						uint32 size = 0;
 						validate_state_file.read((char *)&size, sizeof(size));
 						string data;
 						data.resize(size);

--- a/Samples/Utils/ContactListenerImpl.cpp
+++ b/Samples/Utils/ContactListenerImpl.cpp
@@ -109,7 +109,8 @@ void ContactListenerImpl::OnContactRemoved(const SubShapeIDPair &inSubShapePair)
 void ContactListenerImpl::SaveState(StateRecorder &inStream) const
 {
 	// Write length
-	inStream.Write(mState.size());
+	uint32 length = uint32(mState.size());
+	inStream.Write(length);
 
 	// Get and sort keys
 	Array<SubShapeIDPair> keys;
@@ -136,9 +137,9 @@ void ContactListenerImpl::RestoreState(StateRecorder &inStream)
 	Trace("Restore Contact State");
 
 	// Read length
-	StateMap::size_type length;
+	uint32 length;
 	if (inStream.IsValidating())
-		length = mState.size();
+		length = uint32(mState.size());
 	inStream.Read(length);
 
 	Array<SubShapeIDPair> keys;

--- a/Samples/Utils/ContactListenerImpl.cpp
+++ b/Samples/Utils/ContactListenerImpl.cpp
@@ -127,7 +127,7 @@ void ContactListenerImpl::SaveState(StateRecorder &inStream) const
 		// Write value
 		const StatePair &sp = mState.find(k)->second;
 		inStream.Write(sp.first);
-		inStream.Write(sp.second.size());
+		inStream.Write(uint32(sp.second.size()));
 		inStream.WriteBytes(sp.second.data(), sp.second.size() * sizeof(Vec3));
 	}
 }
@@ -176,9 +176,9 @@ void ContactListenerImpl::RestoreState(StateRecorder &inStream)
 		inStream.Read(sp.first);
 
 		// Read num contact points
-		ContactPoints::size_type num_contacts;
+		uint32 num_contacts;
 		if (inStream.IsValidating())
-			num_contacts = old_state[key].second.size();
+			num_contacts = uint32(old_state[key].second.size());
 		inStream.Read(num_contacts);
 
 		// Read contact points


### PR DESCRIPTION
This means that the 32 and 64 bit versions of the lib can now read each others streams

Fixes #1177