### PR TITLE
don't assume 64-bit ARM supports NEON

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -172,7 +172,6 @@
 	#define JPH_CPU_ARM
 	#if defined(__aarch64__) || defined(_M_ARM64)
 		#define JPH_CPU_ADDRESS_BITS 64
-		#define JPH_USE_NEON
 		#define JPH_VECTOR_ALIGNMENT 16
 		#define JPH_DVECTOR_ALIGNMENT 32
 	#else

--- a/Jolt/Core/FPControlWord.h
+++ b/Jolt/Core/FPControlWord.h
@@ -64,7 +64,7 @@ private:
 	unsigned int mPrevState;
 };
 
-#elif defined(JPH_CPU_ARM) && defined(JPH_USE_NEON)
+#elif defined(JPH_CPU_ARM) && (defined(__aarch64__) || defined(_M_ARM64))
 
 /// Helper class that needs to be put on the stack to update the state of the floating point control word.
 /// This state is kept per thread.


### PR DESCRIPTION
This PR addresses issue #1194.

1. `#define JPH_USE_NEON` is removed Core.h
2. Code to update the FP control word on ARM is selected based on `__aarch64__` and `_M_ARM64` instead of `JPH_USE_NEON`.

I don't fully understand the code being modified, so close review is requested.

For instance, it might be desirable to select `JPH_USE_NEON` via cmake, but I don't know how to do that.