### PR TITLE
Removed redundant /GR trimming for MSVC-like builds

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -126,9 +126,6 @@ if (MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
 	endif()
 
-	# Remove any existing compiler flag that enables RTTI
-	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-
 	# Set compiler flag for disabling RTTI
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 


### PR DESCRIPTION
With the minimum CMake version having been bumped in #1149 this is no longer needed, as CMake no longer implicitly adds `/GR` to `CMAKE_CXX_FLAGS` as of 3.20 ([CMP0117](https://cmake.org/cmake/help/latest/policy/CMP0117.html)).