### PR TITLE
Added options to toggle exception-handling and RTTI

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -302,18 +302,6 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			set_property(TARGET UnitTests PROPERTY XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS[arch=x86_64] "$(inherited) -msse4.2 -mpopcnt")
 		endif()
 
-		# doctest requires exception-handling for its REQUIRE macro, so we re-enable it
-		if (MSVC)
-			target_compile_options(UnitTests PUBLIC /EHsc)
-			# Disable cross-compiland inlining to prevent warnings about __forceinline not being inlined, which is to be expected when mixing exception-handling models
-			set_property(TARGET UnitTests PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
-			set_property(TARGET UnitTests PROPERTY INTERPROCEDURAL_OPTIMIZATION_DISTRIBUTION OFF)
-			# Enable link-time code generation explicitly, since it'll be forced to do that anyway, due to the Jolt target using /GL
-			target_link_options(UnitTests PUBLIC /LTCG)
-		else()
-			target_compile_options(UnitTests PUBLIC -fexceptions)
-		endif()
-
 		# Register unit tests as a test so that it can be run with:
 		# ctest --output-on-failure
 		enable_testing()

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -33,6 +33,10 @@ option(INTERPROCEDURAL_OPTIMIZATION "Enable interprocedural optimizations" ON)
 # Note that this currently only works using MSVC. Clang turns Float2 into a SIMD vector sometimes causing floating point exceptions (the option is ignored).
 option(FLOATING_POINT_EXCEPTIONS_ENABLED "Enable floating point exceptions" ON)
 
+# When turning this on, the library will be compiled with C++ exceptions enabled.
+# This adds some overhead and Jolt doesn't use exceptions so by default it is off.
+option(CPP_EXCEPTIONS_ENABLED "Enable C++ exceptions" OFF)
+
 # Number of bits to use in ObjectLayer. Can be 16 or 32.
 option(OBJECT_LAYER_BITS "Number of bits in ObjectLayer" 16)
 
@@ -126,17 +130,17 @@ if (MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
 	endif()
 
-	# Remove any existing compiler flag that enables exceptions
-	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-
-	# Disable warning about STL and compiler-generated types using noexcept when exceptions are disabled
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4577")
-
 	# Set compiler flag for disabling RTTI
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 
-	if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
-		# On ARM the exception handling flag is missing which causes warnings
+	if (NOT CPP_EXCEPTIONS_ENABLED)
+		# Remove any existing compiler flag that enables exceptions
+		string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+		# Disable warning about STL and compiler-generated types using noexcept when exceptions are disabled
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4577")
+	else()
+		# Enable exceptions
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 	endif()
 
@@ -169,9 +173,6 @@ if (MSVC)
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASECOVERAGE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LIBPATH:${CLANG_LIB_PATH}")
 	endif()
 else()
-	# Disable exception-handling
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
-
 	# Enable warnings
 	if (ENABLE_ALL_WARNINGS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
@@ -180,6 +181,14 @@ else()
 	# Optionally generate debug symbols
 	if (GENERATE_DEBUG_SYMBOLS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+	endif()
+
+	# Set compiler flag for disabling RTTI
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+
+	# Disable exception-handling
+	if (NOT CPP_EXCEPTIONS_ENABLED)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 	endif()
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -37,6 +37,10 @@ option(FLOATING_POINT_EXCEPTIONS_ENABLED "Enable floating point exceptions" ON)
 # This adds some overhead and Jolt doesn't use exceptions so by default it is off.
 option(CPP_EXCEPTIONS_ENABLED "Enable C++ exceptions" OFF)
 
+# When turning this on, the library will be compiled with C++ RTTI enabled.
+# This adds some overhead and Jolt doesn't use RTTI so by default it is off.
+option(CPP_RTTI_ENABLED "Enable C++ RTTI" OFF)
+
 # Number of bits to use in ObjectLayer. Can be 16 or 32.
 option(OBJECT_LAYER_BITS "Number of bits in ObjectLayer" 16)
 
@@ -131,7 +135,9 @@ if (MSVC)
 	endif()
 
 	# Set compiler flag for disabling RTTI
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+	if (NOT CPP_RTTI_ENABLED)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+	endif()
 
 	if (NOT CPP_EXCEPTIONS_ENABLED)
 		# Remove any existing compiler flag that enables exceptions
@@ -184,7 +190,9 @@ else()
 	endif()
 
 	# Set compiler flag for disabling RTTI
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+	if (NOT CPP_RTTI_ENABLED)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+	endif()
 
 	# Disable exception-handling
 	if (NOT CPP_EXCEPTIONS_ENABLED)

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -126,6 +126,12 @@ if (MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
 	endif()
 
+	# Remove any existing compiler flag that enables exceptions
+	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+	# Disable warning about STL and compiler-generated types using noexcept when exceptions are disabled
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4577")
+
 	# Set compiler flag for disabling RTTI
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 
@@ -163,6 +169,9 @@ if (MSVC)
 		set(CMAKE_EXE_LINKER_FLAGS_RELEASECOVERAGE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LIBPATH:${CLANG_LIB_PATH}")
 	endif()
 else()
+	# Disable exception-handling
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+
 	# Enable warnings
 	if (ENABLE_ALL_WARNINGS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
@@ -291,6 +300,18 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 		if (XCODE)
 			# Ensure that we enable SSE4.2 for the x86_64 build, XCode builds multiple architectures
 			set_property(TARGET UnitTests PROPERTY XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS[arch=x86_64] "$(inherited) -msse4.2 -mpopcnt")
+		endif()
+
+		# doctest requires exception-handling for its REQUIRE macro, so we re-enable it
+		if (MSVC)
+			target_compile_options(UnitTests PUBLIC /EHsc)
+			# Disable cross-compiland inlining to prevent warnings about __forceinline not being inlined, which is to be expected when mixing exception-handling models
+			set_property(TARGET UnitTests PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
+			set_property(TARGET UnitTests PROPERTY INTERPROCEDURAL_OPTIMIZATION_DISTRIBUTION OFF)
+			# Enable link-time code generation explicitly, since it'll be forced to do that anyway, due to the Jolt target using /GL
+			target_link_options(UnitTests PUBLIC /LTCG)
+		else()
+			target_compile_options(UnitTests PUBLIC -fexceptions)
 		endif()
 
 		# Register unit tests as a test so that it can be run with:

--- a/Jolt/ConfigurationString.h
+++ b/Jolt/ConfigurationString.h
@@ -82,6 +82,12 @@ inline const char *GetConfigurationString()
 #ifdef JPH_DEBUG
 		"(Debug) "
 #endif
+#if defined(__cpp_rtti) && __cpp_rtti
+		"(C++ RTTI) "
+#endif
+#if defined(__cpp_exceptions) && __cpp_exceptions
+		"(C++ Exceptions) "
+#endif
 		;
 }
 

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -406,6 +406,9 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <functional>
 #include <algorithm>
 #include <cstdint>
+#ifdef JPH_COMPILER_MSVC
+	#include <malloc.h> // for alloca
+#endif
 #if defined(JPH_USE_SSE)
 	#include <immintrin.h>
 #elif defined(JPH_USE_NEON)

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -503,8 +503,10 @@ target_include_directories(Jolt PUBLIC
 # Code coverage doesn't work when using precompiled headers
 target_precompile_headers(Jolt PRIVATE "$<$<NOT:$<CONFIG:ReleaseCoverage>>:${JOLT_PHYSICS_ROOT}/Jolt.h>")
 
-# Disable use of exceptions in MSVC's STL
-target_compile_definitions(Jolt PUBLIC $<$<BOOL:${MSVC}>:_HAS_EXCEPTIONS=0>)
+if (NOT CPP_EXCEPTIONS_ENABLED)
+	# Disable use of exceptions in MSVC's STL
+	target_compile_definitions(Jolt PUBLIC $<$<BOOL:${MSVC}>:_HAS_EXCEPTIONS=0>)
+endif()
 
 # Set the debug/non-debug build flags
 target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug>:_DEBUG>")

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -503,6 +503,9 @@ target_include_directories(Jolt PUBLIC
 # Code coverage doesn't work when using precompiled headers
 target_precompile_headers(Jolt PRIVATE "$<$<NOT:$<CONFIG:ReleaseCoverage>>:${JOLT_PHYSICS_ROOT}/Jolt.h>")
 
+# Disable use of exceptions in MSVC's STL
+target_compile_definitions(Jolt PUBLIC $<$<BOOL:${MSVC}>:_HAS_EXCEPTIONS=0>)
+
 # Set the debug/non-debug build flags
 target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug>:_DEBUG>")
 target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Release,Distribution,ReleaseASAN,ReleaseUBSAN,ReleaseCoverage>:NDEBUG>")

--- a/Jolt/Math/UVec4.inl
+++ b/Jolt/Math/UVec4.inl
@@ -103,7 +103,12 @@ UVec4 UVec4::sGatherInt4(const uint32 *inBase, UVec4Arg inOffsets)
 #ifdef JPH_USE_AVX2
 	return _mm_i32gather_epi32(reinterpret_cast<const int *>(inBase), inOffsets.mValue, Scale);
 #else
-	return Vec4::sGatherFloat4<Scale>(reinterpret_cast<const float *>(inBase), inOffsets).ReinterpretAsInt();
+	const uint8 *base = reinterpret_cast<const uint8 *>(inBase);
+	uint32 x = *reinterpret_cast<const uint32 *>(base + inOffsets.GetX() * Scale);
+	uint32 y = *reinterpret_cast<const uint32 *>(base + inOffsets.GetY() * Scale);
+	uint32 z = *reinterpret_cast<const uint32 *>(base + inOffsets.GetZ() * Scale);
+	uint32 w = *reinterpret_cast<const uint32 *>(base + inOffsets.GetW() * Scale);
+	return UVec4(x, y, z, w);
 #endif
 }
 

--- a/UnitTests/Core/ArrayTest.cpp
+++ b/UnitTests/Core/ArrayTest.cpp
@@ -439,6 +439,7 @@ TEST_SUITE("ArrayTest")
 		CHECK(NonTriv::sNumDestructors == 0);
 	}
 
+#ifndef JPH_USE_STD_VECTOR // std::vector can choose to not shrink the array when calling shrink_to_fit so we can't test this
 	TEST_CASE("TestShrinkToFit")
 	{
 		Array<int> arr;
@@ -476,13 +477,12 @@ TEST_SUITE("ArrayTest")
 		CHECK(arr.size() == 5);
 		for (int i = 0; i < 5; ++i)
 			CHECK(arr[i].Value() == i);
-#ifndef JPH_USE_STD_VECTOR
 		CHECK(NonTriv::sNumConstructors == 0);
 		CHECK(NonTriv::sNumCopyConstructors == 0);
 		CHECK(NonTriv::sNumMoveConstructors == 5);
 		CHECK(NonTriv::sNumDestructors == 5); // Switched to a new block, all old elements are destroyed after being moved
-#endif // JPH_USE_STD_VECTOR
 	}
+#endif // JPH_USE_STD_VECTOR
 
 	TEST_CASE("TestAssignIterator")
 	{

--- a/UnitTests/ObjectStream/ObjectStreamTest.cpp
+++ b/UnitTests/ObjectStream/ObjectStreamTest.cpp
@@ -209,10 +209,12 @@ TEST_SUITE("ObjectStreamTest")
 		TestSerializable *test = CreateTestObject();
 
 		stringstream stream;
-		REQUIRE(ObjectStreamOut::sWriteObject(stream, ObjectStreamOut::EStreamType::Text, *test));
+		CHECK(ObjectStreamOut::sWriteObject(stream, ObjectStreamOut::EStreamType::Text, *test));
 
 		TestSerializable *test_out = nullptr;
-		REQUIRE(ObjectStreamIn::sReadObject(stream, test_out));
+		CHECK(ObjectStreamIn::sReadObject(stream, test_out));
+		if (test_out == nullptr)
+			return;
 
 		// Check that DynamicCast returns the right offsets
 		CHECK(DynamicCast<TestSerializable>(test_out) == test_out);
@@ -232,10 +234,12 @@ TEST_SUITE("ObjectStreamTest")
 		TestSerializable *test = CreateTestObject();
 
 		stringstream stream;
-		REQUIRE(ObjectStreamOut::sWriteObject(stream, ObjectStreamOut::EStreamType::Binary, *test));
+		CHECK(ObjectStreamOut::sWriteObject(stream, ObjectStreamOut::EStreamType::Binary, *test));
 
 		TestSerializable *test_out = nullptr;
-		REQUIRE(ObjectStreamIn::sReadObject(stream, test_out));
+		CHECK(ObjectStreamIn::sReadObject(stream, test_out));
+		if (test_out == nullptr)
+			return;
 
 		CompareObjects(test, test_out);
 


### PR DESCRIPTION
I'm not sure how I hadn't spotted this before, but when making #1207 I happened to see that the `/EHsc` flag is implicitly added to Jolt by CMake when compiling with MSVC/clang-cl, and given that you explicitly mention that Jolt doesn't use exceptions in the readme I figured this might be by accident, so I threw this together to see what you'd think about it.

~~The unit tests unsurprisingly all seem to pass still~~, but this does however seem to change the hashes in `PerformanceTest`, which surprised me, so that might need some investigation.

~~`UnitTests` required a bit of song-and-dance on MSVC unfortunately, since doctest's `REQUIRE` macro needs regular C++ exceptions, and re-enabling it for `UnitTests` specifically caused a bunch of `__forceinline` (aka `JPH_INLINE`) to stop being inlined during link-time optimizations, due to mixing exception-handling models, which resulted in link-time warnings that I just couldn't figure out how to disable.~~ Frankly this might be reason enough to put this all behind a CMake option, since this will almost certainly cause issues downstream somewhere.

Anyway, I'm seeing some differences in the binary size of the various Jolt applications (`Distribution`), presumably due to not needing all the unwinding everywhere:

- `HelloWorld.exe`: 2472 KB -> 2440 KB (-11%)
- `JoltViewer.exe`: 2544 KB -> 2499 KB (-2%)
- `PerformanceTest.exe`: 2684 KB -> 2684 KB (0%)
- `Samples.exe`: 4631 KB -> 4502 KB (-3%)
- ~~`UnitTests.exe`: 6701 KB -> 5910 KB (-12%)~~
- Godot Jolt: 9566 KB -> 9540 KB (-0.3%)

~~(Again, `UnitTests` still uses `/EHsc`, so shouldn't see any benefit from this, so those numbers are likely just from replacing `/GL` with `/LTCG`.)~~

The lack of improvement in Godot Jolt is a bit strange, but perhaps I was already seeing the benefits of this due to already disabling exception-handling on my end, while using LTCG/LTO and linking with Jolt statically? I'm just guessing though.

I believe I'm also seeing a slight bump (5%-ish) in `PerformanceTest` when using MSVC, which I guess might be due to something now being able to be inlined, or perhaps improved instruction cache usage, but the laptop I'm testing this on isn't very consistent, so take this with a grain of salt.

I haven't tested this on anything but MSVC yet, so I'll be amazed if this passes CI. I also believe this might break Android builds for me, so I still need to try that.