### PR TITLE
Added explicit setting of exception/RTTI flags when enabled

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -134,9 +134,12 @@ if (MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
 	endif()
 
-	# Set compiler flag for disabling RTTI
 	if (NOT CPP_RTTI_ENABLED)
+		# Set compiler flag for disabling RTTI
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+	else()
+		# Set compiler flag for enabling RTTI
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR")
 	endif()
 
 	if (NOT CPP_EXCEPTIONS_ENABLED)
@@ -189,14 +192,20 @@ else()
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 	endif()
 
-	# Set compiler flag for disabling RTTI
 	if (NOT CPP_RTTI_ENABLED)
+		# Set compiler flag for disabling RTTI
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+	else()
+		# Set compiler flag for enabling RTTI
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
 	endif()
 
-	# Disable exception-handling
 	if (NOT CPP_EXCEPTIONS_ENABLED)
+		# Set compiler flag for disabling exception-handling
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+	else()
+		# Set compiler flag for enabling exception-handling
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 	endif()
 
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
This obviously isn't strictly necessary, but I was toying around with trying to mismatch these new options with the values of `CMAKE_ANDROID_EXCEPTIONS` and `CMAKE_ANDROID_RTTI`, and found that even when explicitly enabling something like `CPP_RTTI_ENABLED` while disabling `CMAKE_ANDROID_RTTI` you end up with RTTI disabled in Jolt, which struck me as odd.

Clang doesn't seem to emit any warnings about one flag overriding the other either, which makes this even more precarious, so I figured it's better to just be explicit about it.