### PR TITLE
PhysicsLock: Export sLocks

### DIFF
--- a/Jolt/Physics/PhysicsLock.h
+++ b/Jolt/Physics/PhysicsLock.h
@@ -86,7 +86,7 @@ private:
 		PhysicsLockContext		mContext = nullptr;
 	};
 
-	static thread_local LockData sLocks[4];
+	JPH_EXPORT static thread_local LockData sLocks[4];
 
 	// Helper function to find the locked mutexes for a particular context
 	static uint32 &				sGetLockedMutexes(PhysicsLockContext inContext)


### PR DESCRIPTION
Fixes compilation when using Jolt as a DLL with asserts enabled