### PR TITLE
Do not define WIN32_LEAN_AND_MEAN if already defined

### DIFF
--- a/Jolt/Core/JobSystemThreadPool.cpp
+++ b/Jolt/Core/JobSystemThreadPool.cpp
@@ -11,7 +11,9 @@
 #ifdef JPH_PLATFORM_WINDOWS
 	JPH_SUPPRESS_WARNING_PUSH
 	JPH_MSVC_SUPPRESS_WARNING(5039) // winbase.h(13179): warning C5039: 'TpSetCallbackCleanupGroup': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.
-	#define WIN32_LEAN_AND_MEAN
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
 #ifndef JPH_COMPILER_MINGW
 	#include <Windows.h>
 #else

--- a/Jolt/Core/Semaphore.cpp
+++ b/Jolt/Core/Semaphore.cpp
@@ -9,7 +9,9 @@
 #ifdef JPH_PLATFORM_WINDOWS
 	JPH_SUPPRESS_WARNING_PUSH
 	JPH_MSVC_SUPPRESS_WARNING(5039) // winbase.h(13179): warning C5039: 'TpSetCallbackCleanupGroup': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.
-	#define WIN32_LEAN_AND_MEAN
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
 #ifndef JPH_COMPILER_MINGW
 	#include <Windows.h>
 #else

--- a/Jolt/Core/TickCounter.cpp
+++ b/Jolt/Core/TickCounter.cpp
@@ -9,7 +9,9 @@
 #if defined(JPH_PLATFORM_WINDOWS)
 	JPH_SUPPRESS_WARNING_PUSH
 	JPH_MSVC_SUPPRESS_WARNING(5039) // winbase.h(13179): warning C5039: 'TpSetCallbackCleanupGroup': pointer or reference to potentially throwing function passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this function throws an exception.
-	#define WIN32_LEAN_AND_MEAN
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
 #ifndef JPH_COMPILER_MINGW
 	#include <Windows.h>
 #else


### PR DESCRIPTION
This avoids macro redefinition warnings in environments that define WIN32_LEAN_AND_MEAN on the compiler command line (-D or /D options).