### PR TITLE
TestFramework: Switched depth buffer to infinite reverse z

### DIFF
--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -2519,7 +2519,6 @@ void SamplesApp::GetInitialCamera(CameraState &ioState) const
 	// Default if the test doesn't override it
 	ioState.mPos = GetWorldScale() * RVec3(30, 10, 30);
 	ioState.mForward = -Vec3(ioState.mPos).Normalized();
-	ioState.mFarPlane = 1000.0f;
 
 	mTest->GetInitialCamera(ioState);
 }

--- a/TestFramework/Application/Application.cpp
+++ b/TestFramework/Application/Application.cpp
@@ -301,7 +301,7 @@ void Application::UpdateCamera(float inDeltaTime)
 	JPH_PROFILE_FUNCTION();
 
 	// Determine speed
-	float speed = GetWorldScale() * mWorldCamera.mFarPlane / 50.0f * inDeltaTime;
+	float speed = 20.0f * GetWorldScale() * inDeltaTime;
 	bool shift = mKeyboard->IsKeyPressed(DIK_LSHIFT) || mKeyboard->IsKeyPressed(DIK_RSHIFT);
 	bool control = mKeyboard->IsKeyPressed(DIK_LCONTROL) || mKeyboard->IsKeyPressed(DIK_RCONTROL);
 	bool alt = mKeyboard->IsKeyPressed(DIK_LALT) || mKeyboard->IsKeyPressed(DIK_RALT);

--- a/TestFramework/Renderer/Frustum.h
+++ b/TestFramework/Renderer/Frustum.h
@@ -14,24 +14,23 @@ public:
 	/// Empty constructor
 					Frustum() = default;
 
-	/// Construct frustum from position, forward, up, field of view x and y and near and far plane.
+	/// Construct frustum from position, forward, up, field of view x and y and near plane.
 	/// Note that inUp does not need to be perpendicular to inForward but cannot be collinear.
-	inline			Frustum(Vec3Arg inPosition, Vec3Arg inForward, Vec3Arg inUp, float inFOVX, float inFOVY, float inNear, float inFar)
+	inline			Frustum(Vec3Arg inPosition, Vec3Arg inForward, Vec3Arg inUp, float inFOVX, float inFOVY, float inNear)
 	{
 		Vec3 right = inForward.Cross(inUp).Normalized();
 		Vec3 up = right.Cross(inForward).Normalized(); // Calculate the real up vector (inUp does not need to be perpendicular to inForward)
 
-		// Near and far plane
+		// Near plane
 		mPlanes[0] = Plane::sFromPointAndNormal(inPosition + inNear * inForward, inForward);
-		mPlanes[1] = Plane::sFromPointAndNormal(inPosition + inFar * inForward, -inForward);
 
 		// Top and bottom planes
-		mPlanes[2] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(right, 0.5f * inFOVY) * -up);
-		mPlanes[3] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(right, -0.5f * inFOVY) * up);
+		mPlanes[1] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(right, 0.5f * inFOVY) * -up);
+		mPlanes[2] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(right, -0.5f * inFOVY) * up);
 
 		// Left and right planes
-		mPlanes[4] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(up, 0.5f * inFOVX) * right);
-		mPlanes[5] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(up, -0.5f * inFOVX) * -right);
+		mPlanes[3] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(up, 0.5f * inFOVX) * right);
+		mPlanes[4] = Plane::sFromPointAndNormal(inPosition, Mat44::sRotation(up, -0.5f * inFOVX) * -right);
 	}
 
 	/// Test if frustum overlaps with axis aligned box. Note that this is a conservative estimate and can return true if the
@@ -54,5 +53,5 @@ public:
 	}
 
 private:
-	Plane			mPlanes[6];																	///< Planes forming the frustum
+	Plane			mPlanes[5];																	///< Planes forming the frustum
 };

--- a/TestFramework/Renderer/PipelineState.cpp
+++ b/TestFramework/Renderer/PipelineState.cpp
@@ -59,7 +59,7 @@ PipelineState::PipelineState(Renderer *inRenderer, ID3DBlob *inVertexShader, con
 
 	pso_desc.DepthStencilState.DepthEnable = inDepthTest == EDepthTest::On? TRUE : FALSE;
 	pso_desc.DepthStencilState.DepthWriteMask = inDepthTest == EDepthTest::On? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
-	pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
+	pso_desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_GREATER;
 	pso_desc.DepthStencilState.StencilEnable = FALSE;
 
 	pso_desc.SampleMask = UINT_MAX;

--- a/TestFramework/Renderer/Renderer.h
+++ b/TestFramework/Renderer/Renderer.h
@@ -19,13 +19,12 @@ class Texture;
 /// Camera setup
 struct CameraState
 {
-									CameraState() : mPos(RVec3::sZero()), mForward(0, 0, -1), mUp(0, 1, 0), mFOVY(DegreesToRadians(70.0f)), mFarPlane(100.0f) { }
+									CameraState() : mPos(RVec3::sZero()), mForward(0, 0, -1), mUp(0, 1, 0), mFOVY(DegreesToRadians(70.0f)) { }
 
 	RVec3							mPos;								///< Camera position
 	Vec3							mForward;							///< Camera forward vector
 	Vec3							mUp;								///< Camera up vector
 	float							mFOVY;								///< Field of view in radians in up direction
-	float							mFarPlane;							///< Distance of far plane
 };
 
 /// Responsible for rendering primitives to the screen

--- a/TestFramework/Renderer/Texture.cpp
+++ b/TestFramework/Renderer/Texture.cpp
@@ -138,7 +138,7 @@ Texture::Texture(Renderer *inRenderer, int inWidth, int inHeight) :
 	// Allocate depth stencil buffer
 	D3D12_CLEAR_VALUE clear_value = {};
 	clear_value.Format = DXGI_FORMAT_D32_FLOAT;
-	clear_value.DepthStencil.Depth = 1.0f;
+	clear_value.DepthStencil.Depth = 0;
 	clear_value.DepthStencil.Stencil = 0;
 
 	D3D12_HEAP_PROPERTIES heap_properties = {};
@@ -201,7 +201,7 @@ void Texture::Bind(int inSlot) const
 
 void Texture::ClearRenderTarget()
 {
-	mRenderer->GetCommandList()->ClearDepthStencilView(mDSV, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+	mRenderer->GetCommandList()->ClearDepthStencilView(mDSV, D3D12_CLEAR_FLAG_DEPTH, 0, 0, 0, nullptr);
 }
 
 void Texture::SetAsRenderTarget(bool inSet) const


### PR DESCRIPTION
This pushes the far plane out to infinite and means that objects are no longer culled in the distance

See #1245