### PR TITLE
README.md:  add weblink to the jolt-jni project (Java bindings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If you're interested in how Jolt scales with multiple CPUs and compares to other
 
 * C [here](https://github.com/michal-z/zig-gamedev/tree/main/libs/zphysics/libs) and [here](https://github.com/amerkoleci/JoltPhysicsSharp/tree/main/src/joltc)
 * [C#](https://github.com/amerkoleci/JoltPhysicsSharp)
+* [Java](https://github.com/stephengold/jolt-jni)
 * [JavaScript](https://github.com/jrouwe/JoltPhysics.js)
 * [Zig](https://github.com/michal-z/zig-gamedev/tree/main/libs/zphysics)
 


### PR DESCRIPTION
Though not yet complete, I believe the jolt-jni project is far enough along for a weblink.
README.md seems the most appropriate place for it.
I'm happy to answer any questions you have about the project.