### PR TITLE
Added missing constructor to EmptyShape

### DIFF
--- a/Jolt/Physics/Collision/Shape/EmptyShape.h
+++ b/Jolt/Physics/Collision/Shape/EmptyShape.h
@@ -29,7 +29,7 @@ class JPH_EXPORT EmptyShape final : public Shape
 public:
 	// Constructor
 							EmptyShape() : Shape(EShapeType::Empty, EShapeSubType::Empty) { }
-							EmptyShape(Vec3Arg inCenterOfMass) : Shape(EShapeType::Empty, EShapeSubType::Empty), mCenterOfMass(inCenterOfMass) { }
+	explicit				EmptyShape(Vec3Arg inCenterOfMass) : Shape(EShapeType::Empty, EShapeSubType::Empty), mCenterOfMass(inCenterOfMass) { }
 							EmptyShape(const EmptyShapeSettings &inSettings, ShapeResult &outResult) : Shape(EShapeType::Empty, EShapeSubType::Empty, inSettings, outResult), mCenterOfMass(inSettings.mCenterOfMass) { outResult.Set(this); }
 
 	// See: Shape

--- a/Jolt/Physics/Collision/Shape/EmptyShape.h
+++ b/Jolt/Physics/Collision/Shape/EmptyShape.h
@@ -29,6 +29,7 @@ class JPH_EXPORT EmptyShape final : public Shape
 public:
 	// Constructor
 							EmptyShape() : Shape(EShapeType::Empty, EShapeSubType::Empty) { }
+							EmptyShape(Vec3Arg inCenterOfMass) : Shape(EShapeType::Empty, EShapeSubType::Empty), mCenterOfMass(inCenterOfMass) { }
 							EmptyShape(const EmptyShapeSettings &inSettings, ShapeResult &outResult) : Shape(EShapeType::Empty, EShapeSubType::Empty, inSettings, outResult), mCenterOfMass(inSettings.mCenterOfMass) { outResult.Set(this); }
 
 	// See: Shape


### PR DESCRIPTION
This adds `EmptyShape::EmptyShape(Vec3Arg inCenterOfMass)`, allowing you to circumvent the use of `EmptyShapeSettings`.