### PR TITLE
Some optimisations for reducing number of memory allocations and improving BVH build speed.

### DIFF
--- a/Jolt/AABBTree/AABBTreeBuilder.cpp
+++ b/Jolt/AABBTree/AABBTreeBuilder.cpp
@@ -10,82 +10,81 @@ JPH_NAMESPACE_BEGIN
 
 AABBTreeBuilder::Node::Node()
 {
-	mChild[0] = nullptr;
-	mChild[1] = nullptr;
+	mChildIndices[0] = invalidNodeIndex();
+	mChildIndices[1] = invalidNodeIndex();
+	num_tris = 0;
 }
 
 AABBTreeBuilder::Node::~Node()
 {
-	delete mChild[0];
-	delete mChild[1];
 }
 
-uint AABBTreeBuilder::Node::GetMinDepth() const
+uint AABBTreeBuilder::Node::GetMinDepth(const Array<Node>& nodes) const
 {
 	if (HasChildren())
 	{
-		uint left = mChild[0]->GetMinDepth();
-		uint right = mChild[1]->GetMinDepth();
+		uint left = nodes[mChildIndices[0]].GetMinDepth(nodes);
+		uint right = nodes[mChildIndices[1]].GetMinDepth(nodes);
 		return min(left, right) + 1;
 	}
 	else
 		return 1;
 }
 
-uint AABBTreeBuilder::Node::GetMaxDepth() const
+uint AABBTreeBuilder::Node::GetMaxDepth(const Array<Node>& nodes) const
 {
 	if (HasChildren())
 	{
-		uint left = mChild[0]->GetMaxDepth();
-		uint right = mChild[1]->GetMaxDepth();
+		uint left = nodes[mChildIndices[0]].GetMaxDepth(nodes);
+		uint right = nodes[mChildIndices[1]].GetMaxDepth(nodes);
 		return max(left, right) + 1;
 	}
 	else
 		return 1;
 }
 
-uint AABBTreeBuilder::Node::GetNodeCount() const
+uint AABBTreeBuilder::Node::GetNodeCount(const Array<Node>& nodes) const
 {
 	if (HasChildren())
-		return mChild[0]->GetNodeCount() + mChild[1]->GetNodeCount() + 1;
+		return nodes[mChildIndices[0]].GetNodeCount(nodes) + nodes[mChildIndices[1]].GetNodeCount(nodes) + 1;
 	else
 		return 1;
 }
 
-uint AABBTreeBuilder::Node::GetLeafNodeCount() const
+uint AABBTreeBuilder::Node::GetLeafNodeCount(const Array<Node>& nodes) const
 {
 	if (HasChildren())
-		return mChild[0]->GetLeafNodeCount() + mChild[1]->GetLeafNodeCount();
+		return nodes[mChildIndices[0]].GetLeafNodeCount(nodes) + nodes[mChildIndices[1]].GetLeafNodeCount(nodes);
 	else
 		return 1;
 }
 
-uint AABBTreeBuilder::Node::GetTriangleCountInTree() const
+uint AABBTreeBuilder::Node::GetTriangleCountInTree(const Array<Node>& nodes) const
 {
 	if (HasChildren())
-		return mChild[0]->GetTriangleCountInTree() + mChild[1]->GetTriangleCountInTree();
+		return nodes[mChildIndices[0]].GetTriangleCountInTree(nodes) + nodes[mChildIndices[1]].GetTriangleCountInTree(nodes);
 	else
 		return GetTriangleCount();
 }
 
-void AABBTreeBuilder::Node::GetTriangleCountPerNode(float &outAverage, uint &outMin, uint &outMax) const
+void AABBTreeBuilder::Node::GetTriangleCountPerNode(const Array<Node>& nodes, float &outAverage, uint &outMin, uint &outMax) const
 {
 	outMin = INT_MAX;
 	outMax = 0;
 	outAverage = 0;
 	uint avg_divisor = 0;
-	GetTriangleCountPerNodeInternal(outAverage, avg_divisor, outMin, outMax);
+	GetTriangleCountPerNodeInternal(nodes, outAverage, avg_divisor, outMin, outMax);
 	if (avg_divisor > 0)
 		outAverage /= avg_divisor;
 }
 
-float AABBTreeBuilder::Node::CalculateSAHCost(float inCostTraversal, float inCostLeaf) const
+float AABBTreeBuilder::Node::CalculateSAHCost(const Array<Node>& nodes, float inCostTraversal, float inCostLeaf) const
 {
 	float surface_area = mBounds.GetSurfaceArea();
-	return surface_area > 0.0f? CalculateSAHCostInternal(inCostTraversal / surface_area, inCostLeaf / surface_area) : 0.0f;
+	return surface_area > 0.0f? CalculateSAHCostInternal(nodes, inCostTraversal / surface_area, inCostLeaf / surface_area) : 0.0f;
 }
 
-void AABBTreeBuilder::Node::GetNChildren(uint inN, Array<const Node *> &outChildren) const
+void AABBTreeBuilder::Node::GetNChildren(const Array<Node>& nodes, uint inN, Array<const Node*> &outChildren) const
 {
 	JPH_ASSERT(outChildren.empty());
 
@@ -94,8 +93,8 @@ void AABBTreeBuilder::Node::GetNChildren(uint inN, Array<const Node *> &outChild
 		return;
 
 	// Start with the children of this node
-	outChildren.push_back(mChild[0]);
-	outChildren.push_back(mChild[1]);
+	outChildren.push_back(&nodes[mChildIndices[0]]);
+	outChildren.push_back(&nodes[mChildIndices[1]]);
 
 	size_t next = 0;
 	bool all_triangles = true;
@@ -116,8 +115,8 @@ void AABBTreeBuilder::Node::GetNChildren(uint inN, Array<const Node *> &outChild
 		if (to_expand->HasChildren())
 		{
 			outChildren.erase(outChildren.begin() + next);
-			outChildren.push_back(to_expand->mChild[0]);
-			outChildren.push_back(to_expand->mChild[1]);
+			outChildren.push_back(&nodes[to_expand->mChildIndices[0]]);
+			outChildren.push_back(&nodes[to_expand->mChildIndices[1]]);
 			all_triangles = false;
 		}
 		else
@@ -127,22 +126,22 @@ void AABBTreeBuilder::Node::GetNChildren(uint inN, Array<const Node *> &outChild
 	}
 }
 
-float AABBTreeBuilder::Node::CalculateSAHCostInternal(float inCostTraversalDivSurfaceArea, float inCostLeafDivSurfaceArea) const
+float AABBTreeBuilder::Node::CalculateSAHCostInternal(const Array<Node>& nodes, float inCostTraversalDivSurfaceArea, float inCostLeafDivSurfaceArea) const
 {
 	if (HasChildren())
 		return inCostTraversalDivSurfaceArea * mBounds.GetSurfaceArea()
-			+ mChild[0]->CalculateSAHCostInternal(inCostTraversalDivSurfaceArea, inCostLeafDivSurfaceArea)
-			+ mChild[1]->CalculateSAHCostInternal(inCostTraversalDivSurfaceArea, inCostLeafDivSurfaceArea);
+			+ nodes[mChildIndices[0]].CalculateSAHCostInternal(nodes, inCostTraversalDivSurfaceArea, inCostLeafDivSurfaceArea)
+			+ nodes[mChildIndices[1]].CalculateSAHCostInternal(nodes, inCostTraversalDivSurfaceArea, inCostLeafDivSurfaceArea);
 	else
 		return inCostLeafDivSurfaceArea * mBounds.GetSurfaceArea() * GetTriangleCount();
 }
 
-void AABBTreeBuilder::Node::GetTriangleCountPerNodeInternal(float &outAverage, uint &outAverageDivisor, uint &outMin, uint &outMax) const
+void AABBTreeBuilder::Node::GetTriangleCountPerNodeInternal(const Array<Node>& nodes, float &outAverage, uint &outAverageDivisor, uint &outMin, uint &outMax) const
 {
 	if (HasChildren())
 	{
-		mChild[0]->GetTriangleCountPerNodeInternal(outAverage, outAverageDivisor, outMin, outMax);
-		mChild[1]->GetTriangleCountPerNodeInternal(outAverage, outAverageDivisor, outMin, outMax);
+		nodes[mChildIndices[0]].GetTriangleCountPerNodeInternal(nodes, outAverage, outAverageDivisor, outMin, outMax);
+		nodes[mChildIndices[1]].GetTriangleCountPerNodeInternal(nodes, outAverage, outAverageDivisor, outMin, outMax);
 	}
 	else
 	{
@@ -159,31 +158,41 @@ AABBTreeBuilder::AABBTreeBuilder(TriangleSplitter &inSplitter, uint inMaxTriangl
 {
 }
 
-AABBTreeBuilder::Node *AABBTreeBuilder::Build(AABBTreeBuilderStats &outStats)
+uint AABBTreeBuilder::Build(AABBTreeBuilderStats &outStats)
 {
 	TriangleSplitter::Range initial = mTriangleSplitter.GetInitialRange();
-	Node *root = BuildInternal(initial);
+
+	// Worst case for number of nodes: 1 leaf node per triangle, so num leaf nodes = num tris
+	// For N leaf nodes there are max N - 1 internal nodes.  So <= 2N nodes overall where N = num tris.
+	// TODO: test on a few different meshes, use a conservative emperical bound.
+	mNodes.reserve(2 * initial.Count());
+
+	mLeafTriangles.reserve(initial.Count());
+
+	const uint root_node_index = BuildInternal(initial);
+
+	Node *root = &mNodes[root_node_index];
 
 	float avg_triangles_per_leaf;
 	uint min_triangles_per_leaf, max_triangles_per_leaf;
-	root->GetTriangleCountPerNode(avg_triangles_per_leaf, min_triangles_per_leaf, max_triangles_per_leaf);
+	root->GetTriangleCountPerNode(mNodes, avg_triangles_per_leaf, min_triangles_per_leaf, max_triangles_per_leaf);
 
 	mTriangleSplitter.GetStats(outStats.mSplitterStats);
 
-	outStats.mSAHCost = root->CalculateSAHCost(1.0f, 1.0f);
-	outStats.mMinDepth = root->GetMinDepth();
-	outStats.mMaxDepth = root->GetMaxDepth();
-	outStats.mNodeCount = root->GetNodeCount();
-	outStats.mLeafNodeCount = root->GetLeafNodeCount();
+	outStats.mSAHCost = root->CalculateSAHCost(mNodes, 1.0f, 1.0f);
+	outStats.mMinDepth = root->GetMinDepth(mNodes);
+	outStats.mMaxDepth = root->GetMaxDepth(mNodes);
+	outStats.mNodeCount = root->GetNodeCount(mNodes);
+	outStats.mLeafNodeCount = root->GetLeafNodeCount(mNodes);
 	outStats.mMaxTrianglesPerLeaf = mMaxTrianglesPerLeaf;
 	outStats.mTreeMinTrianglesPerLeaf = min_triangles_per_leaf;
 	outStats.mTreeMaxTrianglesPerLeaf = max_triangles_per_leaf;
 	outStats.mTreeAvgTrianglesPerLeaf = avg_triangles_per_leaf;
 
-	return root;
+	return root_node_index;
 }
 
-AABBTreeBuilder::Node *AABBTreeBuilder::BuildInternal(const TriangleSplitter::Range &inTriangles)
+uint AABBTreeBuilder::BuildInternal(const TriangleSplitter::Range &inTriangles)
 {
 	// Check if there are too many triangles left
 	if (inTriangles.Count() > mMaxTrianglesPerLeaf)
@@ -214,26 +223,30 @@ AABBTreeBuilder::Node *AABBTreeBuilder::BuildInternal(const TriangleSplitter::Ra
 		}
 
 		// Recursively build
-		Node *node = new Node();
-		node->mChild[0] = BuildInternal(left);
-		node->mChild[1] = BuildInternal(right);
-		node->mBounds = node->mChild[0]->mBounds;
-		node->mBounds.Encapsulate(node->mChild[1]->mBounds);
-		return node;
+		const uint node_index = (uint)mNodes.size();
+		mNodes.push_back(Node());
+		mNodes[node_index].mChildIndices[0] = BuildInternal(left);
+		mNodes[node_index].mChildIndices[1] = BuildInternal(right);
+		mNodes[node_index].mBounds = mNodes[mNodes[node_index].mChildIndices[0]].mBounds;
+		mNodes[node_index].mBounds.Encapsulate(mNodes[mNodes[node_index].mChildIndices[1]].mBounds);
+		return node_index;
 	}
 
 	// Create leaf node
-	Node *node = new Node();
-	node->mTriangles.reserve(inTriangles.Count());
+	const uint node_index = (uint)mNodes.size();
+	mNodes.push_back(Node());
+	mNodes[node_index].tris_begin = (uint)mLeafTriangles.size();
+	mNodes[node_index].num_tris = inTriangles.mEnd - inTriangles.mBegin;
 	for (uint i = inTriangles.mBegin; i < inTriangles.mEnd; ++i)
 	{
 		const IndexedTriangle &t = mTriangleSplitter.GetTriangle(i);
 		const VertexList &v = mTriangleSplitter.GetVertices();
-		node->mTriangles.push_back(t);
-		node->mBounds.Encapsulate(v, t);
+		mLeafTriangles.push_back(t);
+
+		mNodes[node_index].mBounds.Encapsulate(v, t);
 	}
 
-	return node;
+	return node_index;
 }
 
 JPH_NAMESPACE_END

--- a/Jolt/AABBTree/AABBTreeToBuffer.h
+++ b/Jolt/AABBTree/AABBTreeToBuffer.h
@@ -70,8 +70,8 @@ public:
 			uint *							mParentTrianglesStart = nullptr;			// Where to store mTriangleStart (to patch mChildTrianglesStart of my parent)
 		};
 
-		Deque<NodeData *> to_process;
-		Deque<NodeData *> to_process_triangles;
+		Array<NodeData *> to_process;
+		Array<NodeData *> to_process_triangles;
 		Array<NodeData> node_list;
 
 		node_list.reserve(node_count); // Needed to ensure that array is not reallocated, so we can keep pointers in the array

--- a/Jolt/AABBTree/TriangleCodec/TriangleCodecIndexed8BitPackSOA4Flags.h
+++ b/Jolt/AABBTree/TriangleCodec/TriangleCodecIndexed8BitPackSOA4Flags.h
@@ -149,13 +149,13 @@ public:
 
 		/// Pack the triangles in inContainer to ioBuffer. This stores the mMaterialIndex of a triangle in the 8 bit flags.
 		/// Returns uint(-1) on error.
-		uint						Pack(const IndexedTriangleList &inTriangles, bool inStoreUserData, ByteBuffer &ioBuffer, const char *&outError)
+		uint						Pack(const IndexedTriangle* inTriangles, uint num_triangles, bool inStoreUserData, ByteBuffer &ioBuffer, const char *&outError)
 		{
 			// Determine position of triangles start
 			uint offset = (uint)ioBuffer.size();
 
 			// Update stats
-			uint tri_count = (uint)inTriangles.size();
+			uint tri_count = num_triangles;
 			mNumTriangles += tri_count;
 
 			// Allocate triangle block header

--- a/Jolt/Core/Factory.cpp
+++ b/Jolt/Core/Factory.cpp
@@ -10,6 +10,11 @@ JPH_NAMESPACE_BEGIN
 
 Factory *Factory::sInstance = nullptr;
 
+Factory::Factory()
+:	mClassNameMap(/*empty key=*/string_view(nullptr, 0)),
+	mClassHashMap(/*empty key=*/std::numeric_limits<uint32>::max())
+{}
+
 void *Factory::CreateObject(const char *inName)
 {
 	const RTTI *ci = Find(inName);

--- a/Jolt/Core/Factory.h
+++ b/Jolt/Core/Factory.h
@@ -15,6 +15,8 @@ class JPH_EXPORT Factory
 public:
 	JPH_OVERRIDE_NEW_DELETE
 
+	Factory();
+
 	/// Create an object
 	void *						CreateObject(const char *inName);
 

--- a/Jolt/Core/UnorderedMap.h
+++ b/Jolt/Core/UnorderedMap.h
@@ -188,7 +188,7 @@ public:
 		num_items = other.num_items;
 		hash_mask = other.hash_mask;
 
-		buckets = (std::pair<Key, Value>*)MemAlloc::alignedMalloc(sizeof(std::pair<Key, Value>) * buckets_size, 64);
+		buckets = (std::pair<Key, Value>*)JPH::AlignedAllocate(sizeof(std::pair<Key, Value>) * buckets_size, 64);
 
 		// Initialise elements
 		for(size_t i=0; i<buckets_size; ++i)

--- a/Jolt/Core/UnorderedMap.h
+++ b/Jolt/Core/UnorderedMap.h
@@ -6,10 +6,543 @@
 
 JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <unordered_map>
+#include <assert.h>
 JPH_SUPPRESS_WARNINGS_STD_END
 
 JPH_NAMESPACE_BEGIN
 
-template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>> using UnorderedMap = std::unordered_map<Key, T, Hash, KeyEqual, STLAllocator<pair<const Key, T>>>;
+template <typename Key, typename Value, typename HashFunc> class HashMap;
+
+
+template <typename Key, typename Value, typename HashFunc>
+class HashMapIterator
+{
+public:
+	HashMapIterator(HashMap<Key, Value, HashFunc>* map_, std::pair<Key, Value>* bucket_)
+		: map(map_), bucket(bucket_) {}
+
+
+	bool operator == (const HashMapIterator& other) const
+	{
+		return bucket == other.bucket;
+	}
+
+	bool operator != (const HashMapIterator& other) const
+	{
+		return bucket != other.bucket;
+	}
+
+	void operator ++ ()
+	{
+		// Advance to next non-empty bucket
+		do
+		{
+			bucket++;
+		}
+		while((bucket < (map->buckets + map->buckets_size)) && (bucket->first == map->empty_key));
+	}
+
+	std::pair<Key, Value>& operator * ()
+	{
+		return *bucket;
+	}
+	const std::pair<Key, Value>& operator * () const
+	{
+		return *bucket;
+	}
+
+	std::pair<Key, Value>* operator -> ()
+	{
+		return bucket;
+	}
+	const std::pair<Key, Value>* operator -> () const
+	{
+		return bucket;
+	}
+
+	HashMap<Key, Value, HashFunc>* map;
+	std::pair<Key, Value>* bucket;
+};
+
+
+template <typename Key, typename Value, typename HashFunc>
+class ConstHashMapIterator
+{
+public:
+	ConstHashMapIterator(const HashMap<Key, Value, HashFunc>* map_, const std::pair<Key, Value>* bucket_)
+		: map(map_), bucket(bucket_) {}
+
+	ConstHashMapIterator(const HashMapIterator<Key, Value, HashFunc>& it)
+		: map(it.map), bucket(it.bucket) {}
+
+
+	bool operator == (const ConstHashMapIterator& other) const
+	{
+		return bucket == other.bucket;
+	}
+
+	bool operator != (const ConstHashMapIterator& other) const
+	{
+		return bucket != other.bucket;
+	}
+
+	void operator ++ ()
+	{
+		// Advance to next non-empty bucket
+		do
+		{
+			bucket++;
+		}
+		while((bucket < (map->buckets + map->buckets_size)) && (bucket->first == map->empty_key));
+	}
+
+	const std::pair<Key, Value>& operator * () const
+	{
+		return *bucket;
+	}
+
+	const std::pair<Key, Value>* operator -> () const
+	{
+		return bucket;
+	}
+
+	const HashMap<Key, Value, HashFunc>* map;
+	const std::pair<Key, Value>* bucket;
+};
+
+
+/*=====================================================================
+HashMap
+-------
+A map class using a hash table.
+This class requires passing an 'empty key' to the constructor.
+This is a sentinel value that is never inserted in the map, and marks empty buckets.
+=====================================================================*/
+template <typename Key, typename Value, typename HashFunc = std::hash<Key>>
+class HashMap
+{
+public:
+
+	typedef HashMapIterator<Key, Value, HashFunc> iterator;
+	typedef ConstHashMapIterator<Key, Value, HashFunc> const_iterator;
+	typedef std::pair<Key, Value> KeyValuePair;
+
+	typedef Key key_type;
+	typedef std::pair<Key, Value> value_type;
+
+
+	HashMap(Key empty_key_)
+	:	buckets((std::pair<Key, Value>*)JPH::AlignedAllocate(sizeof(std::pair<Key, Value>) * 32, 64)), buckets_size(32), num_items(0), hash_mask(31), empty_key(empty_key_)
+	{
+		// Initialise elements
+		std::pair<Key, Value> empty_key_val(empty_key, Value());
+		for(std::pair<Key, Value>* elem=buckets; elem<buckets + buckets_size; ++elem)
+			::new (elem) std::pair<Key, Value>(empty_key_val);
+	}
+
+	size_t myMax(size_t x, size_t y) { return x > y ? x : y; }
+
+	// Adapted from http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+	// Not correct for 0 input: returns 0 in this case.
+	inline uint64 roundToNextHighestPowerOf2(uint64 v)
+	{
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v |= v >> 32;
+		return v + 1;
+	}
+
+	HashMap(Key empty_key_, size_t expected_num_items)
+	:	num_items(0), empty_key(empty_key_)
+	{
+		buckets_size = myMax(32ULL, roundToNextHighestPowerOf2(expected_num_items*2));
+		
+		buckets = (std::pair<Key, Value>*)JPH::AlignedAllocate(sizeof(std::pair<Key, Value>) * buckets_size, 64);
+
+		// Initialise elements
+		if(std::is_pod<Key>::value && std::is_pod<Value>::value)
+		{
+			std::pair<Key, Value>* const buckets_ = buckets; // Having this as a local var gives better codegen in VS.
+			for(size_t z=0; z<buckets_size; ++z)
+				buckets_[z].first = empty_key_;
+		}
+		else
+		{
+			std::pair<Key, Value> empty_key_val(empty_key, Value());
+			for(std::pair<Key, Value>* elem=buckets; elem<buckets + buckets_size; ++elem)
+				::new (elem) std::pair<Key, Value>(empty_key_val);
+		}
+
+		hash_mask = buckets_size - 1;
+	}
+
+	HashMap(const HashMap& other)
+	{
+		buckets_size = other.buckets_size;
+		hash_func = other.hash_func;
+		empty_key = other.empty_key;
+		num_items = other.num_items;
+		hash_mask = other.hash_mask;
+
+		buckets = (std::pair<Key, Value>*)MemAlloc::alignedMalloc(sizeof(std::pair<Key, Value>) * buckets_size, 64);
+
+		// Initialise elements
+		for(size_t i=0; i<buckets_size; ++i)
+			::new (&buckets[i]) std::pair<Key, Value>(other.buckets[i]);
+	}
+
+	~HashMap()
+	{
+		// Destroy objects
+		for(size_t i=0; i<buckets_size; ++i)
+			(buckets + i)->~KeyValuePair();
+
+		JPH::AlignedFree(buckets);
+	}
+
+
+	iterator begin()
+	{
+		// Find first bucket with a value in it.
+		for(size_t i=0; i<buckets_size; ++i)
+			if(!(buckets[i].first == empty_key))
+				return iterator(this, buckets + i);
+
+		return iterator(this, buckets + buckets_size);
+	}
+
+	const_iterator begin() const
+	{
+		// Find first bucket with a value in it.
+		for(size_t i=0; i<buckets_size; ++i)
+			if(buckets[i].first != empty_key)
+				return const_iterator(this, buckets + i);
+
+		return const_iterator(this, buckets + buckets_size);
+	}
+
+	iterator end() { return HashMapIterator<Key, Value, HashFunc>(this, buckets + buckets_size); }
+	const_iterator end() const { return ConstHashMapIterator<Key, Value, HashFunc>(this, buckets + buckets_size); }
+
+
+	iterator find(const Key& k)
+	{
+		size_t bucket_i = hashKey(k);
+
+		// Search for bucket item is in
+		while(1)
+		{
+			if(buckets[bucket_i].first == k)
+				return HashMapIterator<Key, Value, HashFunc>(this, &buckets[bucket_i]); // Found it
+
+			if(buckets[bucket_i].first == empty_key)
+				return end(); // No such key in map.
+
+			// Else advance to next bucket, with wrap-around
+			bucket_i = (bucket_i + 1) & hash_mask; // (bucket_i + 1) % buckets.size();
+		}
+	}
+
+	const_iterator find(const Key& k) const
+	{
+		size_t bucket_i = hashKey(k);
+
+		// Search for bucket item is in
+		while(1)
+		{
+			if(buckets[bucket_i].first == k)
+				return ConstHashMapIterator<Key, Value, HashFunc>(this, &buckets[bucket_i]); // Found it
+
+			if(buckets[bucket_i].first == empty_key)
+				return end(); // No such key in map.
+
+			// Else advance to next bucket, with wrap-around
+			bucket_i = (bucket_i + 1) & hash_mask; // (bucket_i + 1) % buckets.size();
+		}
+		return end();
+	}
+
+	// NOTE: not sure if this code is correct.
+	template <class... Args>
+	std::pair<iterator, bool>
+	try_emplace(const key_type& k, Args&&... args)
+	{
+		auto it = find(k);
+		if(it == end())
+		{
+			return insert(
+				value_type(std::piecewise_construct,
+				std::forward_as_tuple(k),
+				std::forward_as_tuple(std::forward<Args>(args)...))
+			);
+		}
+		else
+			return {it, false};
+	}
+
+
+	// The basic idea here is instead of marking bucket i empty immediately, we will scan right, looking for objects that can be moved left to fill the empty slot.
+	// See https://en.wikipedia.org/wiki/Open_addressing and https://en.wikipedia.org/w/index.php?title=Hash_table&oldid=95275577
+	// This is also pretty much the same algorithm as 'Algorithm R (Deletion with linear probing)' in Section 6.4 of The Art of Computer Programming, Volume 3.
+	void erase(const Key& key)
+	{
+		// Search for bucket item is in, or until we get to an empty bucket, which indicates the key is not in the map.
+		// Bucket i is the bucket we will finally mark as empty.
+		size_t i = hashKey(key);
+		while(1)
+		{
+			if(buckets[i].first == empty_key)
+				return; // No such key in map.
+
+			if(buckets[i].first == key)
+				break;
+
+			// Else advance to next bucket, with wrap-around
+			i = (i + 1) & hash_mask;
+		}
+
+		assert(buckets[i].first == key);
+
+		size_t j = i; // j = current probe index to right of i, i = the current slot we will make empty
+		while(1)
+		{
+			j = (j + 1) & hash_mask;
+			if(buckets[j].first == empty_key)
+				break;
+			/*
+			We are considering whether the item at location j can be moved to location i.
+			This is allowed if the natural hash location k of the item is <= i, before modulo.
+
+			Two cases to handle here: case where j does not wrap relative to i (j > i):
+			Then acceptable ranges for k (natural hash location of j), such that j can be moved to location i:
+			basically k has to be <= i before the modulo.
+			
+			-------------------------------------
+			|   |   |   | a | b | c |   |   |   |
+			-------------------------------------
+			              i       j
+			----------------|       |-----------
+			  k <= i                     k > j
+
+			Case where j does wrap relative to i (j < i):
+			Then acceptable ranges for k (natural hash location of j), such that j can be moved to location i:
+			basically k has to be <= i before the modulo.
+
+			-------------------------------------
+			| c | d |   |   |   |   |   | a | b |
+			-------------------------------------
+			      j                       i
+			        |-----------------------|
+			          k > j && k <= i
+
+			Note that the natural hash location of an item at j is always <= j (before modulo)
+			*/
+			const size_t k = hashKey(buckets[j].first); // k = natural hash location of item in bucket j.
+			if((j > i) ? (k <= i || k > j) : (k <= i && k > j))
+			{
+				buckets[i] = buckets[j];
+				buckets[j].second = Value();
+				i = j;
+			}
+		}
+
+		buckets[i].first = empty_key;
+		buckets[i].second = Value();
+
+		num_items--;
+	}
+
+	size_t count(const Key& k) const
+	{
+		return (find(k) == end()) ? 0 : 1;
+	}
+
+
+	// If key was already in map, returns iterator to existing item and false.
+	// If key was not already in map, inserts it, then returns iterator to new item and true.
+	std::pair<iterator, bool> insert(const std::pair<Key, Value>& key_val_pair)
+	{
+		assert(!(key_val_pair.first == empty_key));
+
+		iterator find_res = find(key_val_pair.first);
+		if(find_res == end())
+		{
+			// Item is not already inserted, insert:
+
+			num_items++;
+			checkForExpand();
+
+			size_t bucket_i = hashKey(key_val_pair.first);
+			// Search for bucket item is in, or an empty bucket
+			while(1)
+			{
+				if(buckets[bucket_i].first == empty_key) // If bucket is empty:
+				{
+					buckets[bucket_i] = key_val_pair;
+					return std::make_pair(HashMapIterator<Key, Value, HashFunc>(this, buckets/*.begin()*/ + bucket_i), /*inserted=*/true);
+				}
+
+				// Else advance to next bucket, with wrap-around
+				bucket_i = (bucket_i + 1) & hash_mask; // bucket_i = (bucket_i + 1) % buckets.size();
+			}
+		}
+		else
+		{
+			// Item was already in map: return (iterator to existing item, false)
+			return std::make_pair(find_res, /*inserted=*/false);
+		}
+	}
+
+	Value& operator [] (const Key& k)
+	{
+		iterator i = find(k);
+		if(i == end())
+		{
+			std::pair<iterator, bool> result = insert(std::make_pair(k, Value()));
+			return result.first->second;
+		}
+		else
+		{
+			return i->second;
+		}
+	}
+
+
+	void clear()
+	{
+		for(size_t i=0; i<buckets_size; ++i)
+		{
+			buckets[i].first = empty_key;
+
+			if(!std::is_pod<Value>::value)
+				buckets[i].second = Value();
+		}
+		num_items = 0;
+	}
+
+	void invariant()
+	{
+		for(size_t i=0; i<buckets_size; ++i)
+		{
+			const Key key = buckets[i].first;
+			if(key != empty_key)
+			{
+				const size_t k = hashKey(key);
+
+				for(size_t z=k; z != i; z = (z + 1) & hash_mask)
+				{
+					assert(buckets[z].first != empty_key);
+				}
+			}
+		}
+	}
+
+	bool empty() const { return num_items == 0; }
+
+	size_t size() const { return num_items; }
+
+private:
+	size_t hashKey(const Key& k) const
+	{
+		//return hash_func(k) % buckets.size();
+		return hash_func(k) & hash_mask;
+	}
+
+	// Returns true if expanded
+	bool checkForExpand()
+	{
+		//size_t load_factor = num_items / buckets.size();
+		//const float load_factor = (float)num_items / buckets.size();
+
+		//if(load_factor > 0.5f)
+		if(num_items >= buckets_size / 2)
+		{
+			expand(/*buckets.size() * 2*/);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+
+	void expand(/*size_t new_num_buckets*/)
+	{
+		// Get pointer to old buckets
+		const std::pair<Key, Value>* const old_buckets = this->buckets;
+		const size_t old_buckets_size = this->buckets_size;
+
+		// Allocate new buckets
+		this->buckets_size = old_buckets_size * 2;
+		this->buckets = (std::pair<Key, Value>*)JPH::AlignedAllocate(sizeof(std::pair<Key, Value>) * this->buckets_size, 64);
+		
+		// Initialise elements
+		if(std::is_pod<Key>::value && std::is_pod<Value>::value)
+		{
+			const Key empty_key_ = empty_key; // Having this as a local var gives better codegen in VS.
+			std::pair<Key, Value>* const buckets_ = buckets; // Having this as a local var gives better codegen in VS.
+			for(size_t z=0; z<buckets_size; ++z)
+				buckets_[z].first = empty_key_;
+		}
+		else
+		{
+			// Initialise elements
+			std::pair<Key, Value> empty_key_val(empty_key, Value());
+			if(buckets)
+				for(size_t z=0; z<buckets_size; ++z)
+					::new (buckets + z) std::pair<Key, Value>(empty_key_val);
+		}
+
+		hash_mask = this->buckets_size - 1;
+
+		// Insert items into new buckets
+		
+		for(size_t b=0; b<old_buckets_size; ++b) // For each old bucket
+		{
+			if(!(old_buckets[b].first == empty_key)) // If there is an item in the old bucket:
+			{
+				size_t bucket_i = hashKey(old_buckets[b].first); // Hash key of item to get new bucket index:
+
+				// Search for an empty bucket
+				while(1)
+				{
+					if(buckets[bucket_i].first == empty_key) // If bucket is empty:
+					{
+						buckets[bucket_i] = old_buckets[b]; // Write item to bucket.
+						break;
+					}
+
+					// Else advance to next bucket, with wrap-around
+					bucket_i = (bucket_i + 1) & hash_mask; // bucket_i = (bucket_i + 1) % buckets.size();
+				}
+			}
+		}
+
+		// Destroy old bucket data
+		for(size_t i=0; i<old_buckets_size; ++i)
+			(old_buckets + i)->~KeyValuePair();
+		JPH::AlignedFree((std::pair<Key, Value>*)old_buckets);
+	}
+
+public:
+	std::pair<Key, Value>* buckets; // Elements
+	size_t buckets_size;
+	HashFunc hash_func;
+	Key empty_key;
+private:
+	size_t num_items;
+	size_t hash_mask;
+};
+
+
+
+template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>> using UnorderedMap = HashMap<Key, T, Hash>;
+
+//template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>> using UnorderedMap = std::unordered_map<Key, T, Hash, KeyEqual, STLAllocator<pair<const Key, T>>>;
 
 JPH_NAMESPACE_END

--- a/Jolt/Core/UnorderedSet.h
+++ b/Jolt/Core/UnorderedSet.h
@@ -6,10 +6,535 @@
 
 JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <unordered_set>
+#include <assert.h>
 JPH_SUPPRESS_WARNINGS_STD_END
 
 JPH_NAMESPACE_BEGIN
 
-template <class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>> using UnorderedSet = std::unordered_set<Key, Hash, KeyEqual, STLAllocator<Key>>;
+
+
+template <typename Key, typename HashFunc> class HashSet;
+
+
+template <typename Key, typename HashFunc>
+class HashSetIterator
+{
+public:
+	typedef std::ptrdiff_t difference_type;
+	typedef Key value_type;
+	typedef Key* pointer;
+	typedef Key& reference;
+	typedef std::forward_iterator_tag iterator_category;
+
+	HashSetIterator(HashSet<Key, HashFunc>* map_, Key* bucket_)
+		: map(map_), bucket(bucket_) {}
+
+
+	bool operator == (const HashSetIterator& other) const
+	{
+		return bucket == other.bucket;
+	}
+
+	bool operator != (const HashSetIterator& other) const
+	{
+		return bucket != other.bucket;
+	}
+
+	void operator ++ ()
+	{
+		// Advance to next non-empty bucket
+		do
+		{
+			bucket++;
+		}
+		while((bucket < (map->buckets + map->buckets_size)) && (*bucket == map->empty_key));
+	}
+
+	Key& operator * ()
+	{
+		return *bucket;
+	}
+	const Key& operator * () const
+	{
+		return *bucket;
+	}
+
+	Key* operator -> ()
+	{
+		return bucket;
+	}
+	const Key* operator -> () const
+	{
+		return bucket;
+	}
+
+	HashSet<Key, HashFunc>* map;
+	Key* bucket;
+};
+
+
+template <typename Key, typename HashFunc>
+class ConstHashSetIterator
+{
+public:
+	typedef std::ptrdiff_t difference_type;
+	typedef Key value_type;
+	typedef Key* pointer;
+	typedef Key& reference;
+	typedef std::forward_iterator_tag iterator_category;
+
+	ConstHashSetIterator(const HashSet<Key, HashFunc>* map_, const Key* bucket_)
+		: map(map_), bucket(bucket_) {}
+
+	ConstHashSetIterator(const HashSetIterator<Key, HashFunc>& it)
+		: map(it.map), bucket(it.bucket) {}
+
+
+	bool operator == (const ConstHashSetIterator& other) const
+	{
+		return bucket == other.bucket;
+	}
+
+	bool operator != (const ConstHashSetIterator& other) const
+	{
+		return bucket != other.bucket;
+	}
+
+	void operator ++ ()
+	{
+		// Advance to next non-empty bucket
+		do
+		{
+			bucket++;
+		}
+		while((bucket < (map->buckets + map->buckets_size)) && (*bucket == map->empty_key));
+	}
+
+	const Key& operator * () const
+	{
+		return *bucket;
+	}
+
+	const Key* operator -> () const
+	{
+		return bucket;
+	}
+
+	const HashSet<Key, HashFunc>* map;
+	const Key* bucket;
+};
+
+
+/*=====================================================================
+HashSet
+-------
+A set class using a hash table.
+This class requires passing an 'empty key' to the constructor.
+This is a sentinel value that is never inserted in the set, and marks empty buckets.
+=====================================================================*/
+template <typename Key, typename HashFunc = std::hash<Key>>
+class HashSet
+{
+public:
+
+	typedef HashSetIterator<Key, HashFunc> iterator;
+	typedef ConstHashSetIterator<Key, HashFunc> const_iterator;
+
+
+	// Initialise with 32 buckets.
+	HashSet(Key empty_key_)
+	:	buckets((Key*)JPH::AlignedAllocate(sizeof(Key) * 32, 64)), buckets_size(32), num_items(0), hash_mask(31), empty_key(empty_key_)
+	{
+		// Initialise elements
+		for(Key* elem=buckets; elem<buckets + buckets_size; ++elem)
+			::new (elem) Key(empty_key);
+	}
+
+	size_t myMax(size_t x, size_t y) { return x > y ? x : y; }
+
+	// Adapted from http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+	// Not correct for 0 input: returns 0 in this case.
+	inline uint64 roundToNextHighestPowerOf2(uint64 v)
+	{
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v |= v >> 32;
+		return v + 1;
+	}
+
+	HashSet(Key empty_key_, size_t expected_num_items)
+	:	num_items(0), empty_key(empty_key_)
+	{
+		buckets_size = myMax(4ULL, roundToNextHighestPowerOf2(expected_num_items*2));
+		
+		buckets = (Key*)JPH::AlignedAllocate(sizeof(Key) * buckets_size, 64);
+
+		// Initialise elements
+		if(std::is_pod<Key>::value)
+		{
+			Key* const buckets_ = buckets; // Having this as a local var gives better codegen in VS.
+			for(size_t z=0; z<buckets_size; ++z)
+				buckets_[z] = empty_key_;
+		}
+		else
+		{
+			for(Key* elem=buckets; elem<buckets + buckets_size; ++elem)
+				::new (elem) Key(empty_key);
+		}
+
+		hash_mask = buckets_size - 1;
+	}
+
+	HashSet(const HashSet& other)
+	{
+		buckets_size = other.buckets_size;
+		hash_func = other.hash_func;
+		empty_key = other.empty_key;
+		num_items = other.num_items;
+		hash_mask = other.hash_mask;
+
+		buckets = (Key*)JPH::AlignedAllocate(sizeof(Key) * buckets_size, 64);
+
+		for(size_t i=0; i<buckets_size; ++i)
+			::new (&buckets[i]) Key(other.buckets[i]);
+	}
+
+	~HashSet()
+	{
+		// Destroy objects
+		for(size_t i=0; i<buckets_size; ++i)
+			(buckets + i)->~Key();
+
+		JPH::AlignedFree(buckets);
+	}
+
+
+	iterator begin()
+	{
+		// Find first bucket with a value in it.
+		for(size_t i=0; i<buckets_size; ++i)
+			if(buckets[i] != empty_key)
+				return iterator(this, buckets + i);
+
+		return iterator(this, buckets + buckets_size);
+	}
+
+	const_iterator begin() const
+	{
+		// Find first bucket with a value in it.
+		for(size_t i=0; i<buckets_size; ++i)
+			if(buckets[i] != empty_key)
+				return const_iterator(this, buckets + i);
+
+		return const_iterator(this, buckets + buckets_size);
+	}
+
+	iterator end() { return HashSetIterator<Key, HashFunc>(this, buckets + buckets_size); }
+	const_iterator end() const { return ConstHashSetIterator<Key, HashFunc>(this, buckets + buckets_size); }
+
+
+	iterator find(const Key& k)
+	{
+		size_t bucket_i = hashKey(k);
+
+		// Search for bucket item is in
+		while(1)
+		{
+			if(buckets[bucket_i] == k)
+				return HashSetIterator<Key, HashFunc>(this, &buckets[bucket_i]); // Found it
+
+			if(buckets[bucket_i] == empty_key)
+				return end(); // No such key in set.
+
+			// Else advance to next bucket, with wrap-around
+			bucket_i = (bucket_i + 1) & hash_mask; // (bucket_i + 1) % buckets.size();
+		}
+	}
+
+	const_iterator find(const Key& k) const
+	{
+		size_t bucket_i = hashKey(k);
+
+		// Search for bucket item is in
+		while(1)
+		{
+			if(buckets[bucket_i] == k)
+				return ConstHashSetIterator<Key, HashFunc>(this, &buckets[bucket_i]); // Found it
+
+			if(buckets[bucket_i] == empty_key)
+				return end(); // No such key in set.
+
+			// Else advance to next bucket, with wrap-around
+			bucket_i = (bucket_i + 1) & hash_mask; // (bucket_i + 1) % buckets.size();
+		}
+		return end();
+	}
+
+
+	// The basic idea here is instead of marking bucket i empty immediately, we will scan right, looking for objects that can be moved left to fill the empty slot.
+	// See https://en.wikipedia.org/wiki/Open_addressing and https://en.wikipedia.org/w/index.php?title=Hash_table&oldid=95275577
+	// This is also pretty much the same algorithm as 'Algorithm R (Deletion with linear probing)' in Section 6.4 of The Art of Computer Programming, Volume 3.
+	void erase(const Key& key)
+	{
+		// Search for bucket item is in, or until we get to an empty bucket, which indicates the key is not in the set.
+		// Bucket i is the bucket we will finally mark as empty.
+		size_t i = hashKey(key);
+		while(1)
+		{
+			if(buckets[i] == empty_key)
+				return; // No such key in set.
+
+			if(buckets[i] == key)
+				break;
+
+			// Else advance to next bucket, with wrap-around
+			i = (i + 1) & hash_mask;
+		}
+
+		assert(buckets[i] == key);
+
+		size_t j = i; // j = current probe index to right of i, i = the current slot we will make empty
+		while(1)
+		{
+			j = (j + 1) & hash_mask;
+			if(buckets[j] == empty_key)
+				break;
+			/*
+			We are considering whether the item at location j can be moved to location i.
+			This is allowed if the natural hash location k of the item is <= i, before modulo.
+
+			Two cases to handle here: case where j does not wrap relative to i (j > i):
+			Then acceptable ranges for k (natural hash location of j), such that j can be moved to location i:
+			basically k has to be <= i before the modulo.
+			
+			-------------------------------------
+			|   |   |   | a | b | c |   |   |   |
+			-------------------------------------
+			              i       j
+			----------------|       |-----------
+			  k <= i                     k > j
+
+			Case where j does wrap relative to i (j < i):
+			Then acceptable ranges for k (natural hash location of j), such that j can be moved to location i:
+			basically k has to be <= i before the modulo.
+
+			-------------------------------------
+			| c | d |   |   |   |   |   | a | b |
+			-------------------------------------
+			      j                       i
+			        |-----------------------|
+			          k > j && k <= i
+
+			Note that the natural hash location of an item at j is always <= j (before modulo)
+			*/
+			const size_t k = hashKey(buckets[j]); // k = natural hash location of item in bucket j.
+			if((j > i) ? (k <= i || k > j) : (k <= i && k > j))
+			{
+				buckets[i] = buckets[j];
+				i = j;
+			}
+		}
+
+		buckets[i] = empty_key;
+
+		num_items--;
+	}
+
+	// it must be a valid iterator that is != end().
+	void erase(const iterator& it)
+	{
+		assert(it != end());
+		size_t i = it.bucket - buckets;
+
+		size_t j = i; // j = current probe index to right of i, i = the current slot we will make empty
+		while(1)
+		{
+			j = (j + 1) & hash_mask;
+			if(buckets[j] == empty_key)
+				break;
+
+			const size_t k = hashKey(buckets[j]); // k = natural hash location of item in bucket j.
+			if((j > i) ? (k <= i || k > j) : (k <= i && k > j))
+			{
+				buckets[i] = buckets[j];
+				i = j;
+			}
+		}
+
+		buckets[i] = empty_key;
+
+		num_items--;
+	}
+
+	size_t count(const Key& k) const
+	{
+		return (find(k) == end()) ? 0 : 1;
+	}
+
+
+	// If key was already in set, returns iterator to existing item and false.
+	// If key was not already in set, inserts it, then returns iterator to new item and true.
+	std::pair<iterator, bool> insert(const Key& key)
+	{
+		assert(!(key == empty_key));
+
+		iterator find_res = find(key);
+		if(find_res == end())
+		{
+			// Item is not already inserted, insert:
+
+			num_items++;
+			checkForExpand();
+
+			size_t bucket_i = hashKey(key);
+			// Search for bucket item is in, or an empty bucket
+			while(1)
+			{
+				if(buckets[bucket_i] == empty_key) // If bucket is empty:
+				{
+					buckets[bucket_i] = key;
+					return std::make_pair(HashSetIterator<Key, HashFunc>(this, buckets/*.begin()*/ + bucket_i), /*inserted=*/true);
+				}
+
+				// Else advance to next bucket, with wrap-around
+				bucket_i = (bucket_i + 1) & hash_mask; // bucket_i = (bucket_i + 1) % buckets.size();
+			}
+		}
+		else
+		{
+			// Item was already in set: return (iterator to existing item, false)
+			return std::make_pair(find_res, /*inserted=*/false);
+		}
+	}
+
+	void clear()
+	{
+		for(size_t i=0; i<buckets_size; ++i)
+			buckets[i] = empty_key;
+		num_items = 0;
+	}
+
+	void invariant()
+	{
+		for(size_t i=0; i<buckets_size; ++i)
+		{
+			const Key key = buckets[i];
+			if(key != empty_key)
+			{
+				const size_t k = hashKey(key);
+
+				for(size_t z=k; z != i; z = (z + 1) & hash_mask)
+				{
+					assert(buckets[z] != empty_key);
+				}
+			}
+		}
+	}
+
+	bool empty() const { return num_items == 0; }
+
+	size_t size() const { return num_items; }
+
+private:
+	size_t hashKey(const Key& k) const
+	{
+		//return hash_func(k) % buckets.size();
+		return hash_func(k) & hash_mask;
+	}
+
+	// Returns true if expanded
+	bool checkForExpand()
+	{
+		//size_t load_factor = num_items / buckets.size();
+		//const float load_factor = (float)num_items / buckets.size();
+
+		//if(load_factor > 0.5f)
+		if(num_items >= buckets_size / 2)
+		{
+			expand(/*buckets.size() * 2*/);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+
+	void expand(/*size_t new_num_buckets*/)
+	{
+		// Get pointer to old buckets
+		const Key* const old_buckets = this->buckets;
+		const size_t old_buckets_size = this->buckets_size;
+
+		// Allocate new buckets
+		this->buckets_size = old_buckets_size * 2;
+		this->buckets = (Key*)JPH::AlignedAllocate(sizeof(Key) * this->buckets_size, 64);
+		
+		// Initialise elements
+		if(std::is_pod<Key>::value)
+		{
+			const Key empty_key_ = empty_key; // Having this as a local var gives better codegen in VS.
+			Key* const buckets_ = buckets; // Having this as a local var gives better codegen in VS.
+			for(size_t z=0; z<buckets_size; ++z)
+				buckets_[z] = empty_key_;
+		}
+		else
+		{
+			// Initialise elements
+			const Key empty_key_ = empty_key;
+			if(buckets)
+				for(size_t z=0; z<buckets_size; ++z)
+					::new (buckets + z) Key(empty_key_);
+		}
+
+		hash_mask = this->buckets_size - 1;
+
+		// Insert items into new buckets
+		
+		for(size_t b=0; b<old_buckets_size; ++b) // For each old bucket
+		{
+			if(!(old_buckets[b] == empty_key)) // If there is an item in the old bucket:
+			{
+				size_t bucket_i = hashKey(old_buckets[b]); // Hash key of item to get new bucket index:
+
+				// Search for an empty bucket
+				while(1)
+				{
+					if(buckets[bucket_i] == empty_key) // If bucket is empty:
+					{
+						buckets[bucket_i] = old_buckets[b]; // Write item to bucket.
+						break;
+					}
+
+					// Else advance to next bucket, with wrap-around
+					bucket_i = (bucket_i + 1) & hash_mask; // bucket_i = (bucket_i + 1) % buckets.size();
+				}
+			}
+		}
+
+		// Destroy old bucket data
+		for(size_t i=0; i<old_buckets_size; ++i)
+			(old_buckets + i)->~Key();
+		JPH::AlignedFree((Key*)old_buckets);
+	}
+
+public:
+	Key* buckets; // Elements
+	size_t buckets_size;
+	HashFunc hash_func;
+	Key empty_key;
+private:
+	size_t num_items;
+	size_t hash_mask;
+};
+
+
+template <class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>> using UnorderedSet = HashSet<Key, Hash>;
+
 
 JPH_NAMESPACE_END

--- a/Jolt/Geometry/ConvexHullBuilder.cpp
+++ b/Jolt/Geometry/ConvexHullBuilder.cpp
@@ -246,7 +246,7 @@ float ConvexHullBuilder::DetermineCoplanarDistance() const
 
 int ConvexHullBuilder::GetNumVerticesUsed() const
 {
-	UnorderedSet<int> used_verts;
+	UnorderedSet<int> used_verts(/*empty_key=*/std::numeric_limits<int>::max());
 	for (Face *f : mFaces)
 	{
 		Edge *e = f->mFirstEdge;

--- a/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
+++ b/Jolt/Physics/Collision/Shape/ConvexHullShape.cpp
@@ -125,7 +125,7 @@ ConvexHullShape::ConvexHullShape(const ConvexHullShapeSettings &inSettings, Shap
 
 	// Convert polygons from the builder to our internal representation
 	using VtxMap = UnorderedMap<int, uint8>;
-	VtxMap vertex_map;
+	VtxMap vertex_map(/*empty key=*/std::numeric_limits<int>::max());
 	for (BuilderFace *builder_face : builder_faces)
 	{
 		// Determine where the vertices go

--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -195,20 +195,18 @@ MeshShape::MeshShape(const MeshShapeSettings &inSettings, ShapeResult &outResult
 	// Build tree
 	AABBTreeBuilder builder(splitter, inSettings.mMaxTrianglesPerLeaf);
 	AABBTreeBuilderStats builder_stats;
-	AABBTreeBuilder::Node *root = builder.Build(builder_stats);
+	const uint root_node_index = builder.Build(builder_stats);
+	AABBTreeBuilder::Node *root = &builder.mNodes[root_node_index];
 
 	// Convert to buffer
 	AABBTreeToBuffer<TriangleCodec, NodeCodec> buffer;
 	const char *error = nullptr;
-	if (!buffer.Convert(inSettings.mTriangleVertices, root, inSettings.mPerTriangleUserData, error))
+	if (!buffer.Convert(builder.mLeafTriangles, builder.mNodes, inSettings.mTriangleVertices, root, inSettings.mPerTriangleUserData, error))
 	{
 		outResult.SetError(error);
 		delete root;
 		return;
 	}
-
-	// Kill tree
-	delete root;
 
 	// Move data to this class
 	mTree.swap(buffer.GetBuffer());

--- a/Jolt/Physics/Collision/Shape/MeshShape.cpp
+++ b/Jolt/Physics/Collision/Shape/MeshShape.cpp
@@ -92,8 +92,8 @@ MeshShapeSettings::MeshShapeSettings(VertexList inVertices, IndexedTriangleList 
 void MeshShapeSettings::Sanitize()
 {
 	// Remove degenerate and duplicate triangles
-	UnorderedSet<IndexedTriangle> triangles;
-	triangles.reserve(mIndexedTriangles.size());
+	UnorderedSet<IndexedTriangle> triangles(/*empty_key=*/IndexedTriangle(std::numeric_limits<uint32>::max(), std::numeric_limits<uint32>::max(), std::numeric_limits<uint32>::max()),
+		/*expected num items=*/mIndexedTriangles.size());
 	TriangleCodec::ValidationContext validation_ctx(mIndexedTriangles, mTriangleVertices);
 	for (int t = (int)mIndexedTriangles.size() - 1; t >= 0; --t)
 	{
@@ -261,8 +261,7 @@ void MeshShape::sFindActiveEdges(const MeshShapeSettings &inSettings, IndexedTri
 
 	// Build a list of edge to triangles
 	using EdgeToTriangle = UnorderedMap<Edge, TriangleIndices, EdgeHash>;
-	EdgeToTriangle edge_to_triangle;
-	edge_to_triangle.reserve(ioIndices.size() * 3);
+	EdgeToTriangle edge_to_triangle(/*empty key=*/Edge(std::numeric_limits<int>::max(), std::numeric_limits<int>::max()), /*expected num items=*/ioIndices.size() * 3);
 	for (uint triangle_idx = 0; triangle_idx < ioIndices.size(); ++triangle_idx)
 	{
 		IndexedTriangle &triangle = ioIndices[triangle_idx];

--- a/Jolt/Physics/PhysicsScene.cpp
+++ b/Jolt/Physics/PhysicsScene.cpp
@@ -111,10 +111,10 @@ bool PhysicsScene::CreateBodies(PhysicsSystem *inSystem) const
 
 void PhysicsScene::SaveBinaryState(StreamOut &inStream, bool inSaveShapes, bool inSaveGroupFilter) const
 {
-	BodyCreationSettings::ShapeToIDMap shape_to_id;
-	BodyCreationSettings::MaterialToIDMap material_to_id;
-	BodyCreationSettings::GroupFilterToIDMap group_filter_to_id;
-	SoftBodyCreationSettings::SharedSettingsToIDMap settings_to_id;
+	BodyCreationSettings::ShapeToIDMap shape_to_id(/*empty key=*/nullptr);
+	BodyCreationSettings::MaterialToIDMap material_to_id(/*empty key=*/nullptr);
+	BodyCreationSettings::GroupFilterToIDMap group_filter_to_id(/*empty key=*/nullptr);
+	SoftBodyCreationSettings::SharedSettingsToIDMap settings_to_id(/*empty key=*/nullptr);
 
 	// Save bodies
 	inStream.Write((uint32)mBodies.size());
@@ -210,7 +210,7 @@ void PhysicsScene::FromPhysicsSystem(const PhysicsSystem *inSystem)
 {
 	// This map will track where each body went in mBodies
 	using BodyIDToIdxMap = UnorderedMap<BodyID, uint32>;
-	BodyIDToIdxMap body_id_to_idx;
+	BodyIDToIdxMap body_id_to_idx(/*empty key=*/BodyID(BodyID::cInvalidBodyID - 1));
 
 	// Map invalid ID
 	body_id_to_idx[BodyID()] = cFixedToWorld;

--- a/Jolt/Physics/Ragdoll/Ragdoll.cpp
+++ b/Jolt/Physics/Ragdoll/Ragdoll.cpp
@@ -258,9 +258,9 @@ void RagdollSettings::DisableParentChildCollisions(const Mat44 *inJointMatrices,
 
 void RagdollSettings::SaveBinaryState(StreamOut &inStream, bool inSaveShapes, bool inSaveGroupFilter) const
 {
-	BodyCreationSettings::ShapeToIDMap shape_to_id;
-	BodyCreationSettings::MaterialToIDMap material_to_id;
-	BodyCreationSettings::GroupFilterToIDMap group_filter_to_id;
+	BodyCreationSettings::ShapeToIDMap shape_to_id(/*empty key=*/nullptr);
+	BodyCreationSettings::MaterialToIDMap material_to_id(/*empty key=*/nullptr);
+	BodyCreationSettings::GroupFilterToIDMap group_filter_to_id(/*empty key=*/nullptr);
 
 	// Save skeleton
 	mSkeleton->SaveBinaryState(inStream);

--- a/Jolt/TriangleSplitter/TriangleSplitterBinning.cpp
+++ b/Jolt/TriangleSplitter/TriangleSplitterBinning.cpp
@@ -14,7 +14,7 @@ TriangleSplitterBinning::TriangleSplitterBinning(const VertexList &inVertices, c
 	mMaxNumBins(inMaxNumBins),
 	mNumTrianglesPerBin(inNumTrianglesPerBin)
 {
-	mBins.resize(mMaxNumBins);
+	mBins.resize(mMaxNumBins * 3); // mMaxNumBins per dimension
 }
 
 bool TriangleSplitterBinning::Split(const Range &inTriangles, Range &outLeft, Range &outRight)
@@ -30,45 +30,76 @@ bool TriangleSplitterBinning::Split(const Range &inTriangles, Range &outLeft, Ra
 
 	// Bin in all dimensions
 	uint num_bins = Clamp(inTriangles.Count() / mNumTrianglesPerBin, mMinNumBins, mMaxNumBins);
+
+	// Initialize bins
+	Vec3 bounds_min = centroid_bounds.mMin;
+	Vec3 bounds_size = centroid_bounds.mMax - bounds_min;
 	for (uint dim = 0; dim < 3; ++dim)
 	{
-		float bounds_min = centroid_bounds.mMin[dim];
-		float bounds_size = centroid_bounds.mMax[dim] - bounds_min;
-
-		// Skip axis if too small
-		if (bounds_size < 1.0e-5f)
-			continue;
-
-		// Initialize bins
 		for (uint b = 0; b < num_bins; ++b)
 		{
-			Bin &bin = mBins[b];
+			Bin &bin = mBins[num_bins * dim + b];
 			bin.mBounds.SetEmpty();
-			bin.mMinCentroid = bounds_min + bounds_size * (b + 1) / num_bins;
+			bin.mMinCentroid = bounds_min + bounds_size * (float)(b + 1) / (float)num_bins;
 			bin.mNumTriangles = 0;
 		}
+	}
 
-		// Bin all triangles
-		for (uint t = inTriangles.mBegin; t < inTriangles.mEnd; ++t)
+	// Bin all triangles in all dimensions at once
+	for (uint t = inTriangles.mBegin; t < inTriangles.mEnd; ++t)
+	{
+		AABox tri_t_bounds;
+		tri_t_bounds.Encapsulate(mVertices, GetTriangle(t));
+
+		Vec3 tri_t_centroid = Vec3(mCentroids[mSortedTriangleIdx[t]]);
+
+		Vec3 bin_vec = ((tri_t_centroid - bounds_min) / bounds_size) * (float)num_bins;
+
+		// Dimension 0:
 		{
-			float centroid_pos = mCentroids[mSortedTriangleIdx[t]][dim];
-
 			// Select bin
-			uint bin_no = min(uint((centroid_pos - bounds_min) / bounds_size * num_bins), num_bins - 1);
+			uint bin_no = min(uint(bin_vec.GetX()), num_bins - 1);
 			Bin &bin = mBins[bin_no];
 
 			// Accumulate triangle in bin
-			bin.mBounds.Encapsulate(mVertices, GetTriangle(t));
-			bin.mMinCentroid = min(bin.mMinCentroid, centroid_pos);
+			bin.mBounds.Encapsulate(tri_t_bounds);
+			bin.mMinCentroid = Vec3::sMin(bin.mMinCentroid, tri_t_centroid);
 			bin.mNumTriangles++;
 		}
 
+		// Dimension 1:
+		{
+			// Select bin
+			uint bin_no = num_bins + min(uint(bin_vec.GetY()), num_bins - 1);
+			Bin &bin = mBins[bin_no];
+
+			// Accumulate triangle in bin
+			bin.mBounds.Encapsulate(tri_t_bounds);
+			bin.mMinCentroid = Vec3::sMin(bin.mMinCentroid, tri_t_centroid);
+			bin.mNumTriangles++;
+		}
+
+		// Dimension 2:
+		{
+			// Select bin
+			uint bin_no = num_bins * 2 + min(uint(bin_vec.GetZ()), num_bins - 1);
+			Bin &bin = mBins[bin_no];
+
+			// Accumulate triangle in bin
+			bin.mBounds.Encapsulate(tri_t_bounds);
+			bin.mMinCentroid = Vec3::sMin(bin.mMinCentroid, tri_t_centroid);
+			bin.mNumTriangles++;
+		}
+	}
+
+	for (uint dim = 0; dim < 3; ++dim)
+	{
 		// Calculate totals left to right
 		AABox prev_bounds;
 		int prev_triangles = 0;
 		for (uint b = 0; b < num_bins; ++b)
 		{
-			Bin &bin = mBins[b];
+			Bin &bin = mBins[num_bins * dim + b];
 			bin.mBoundsAccumulatedLeft = prev_bounds; // Don't include this node as we'll take a split on the left side of the bin
 			bin.mNumTrianglesAccumulatedLeft = prev_triangles;
 			prev_bounds.Encapsulate(bin.mBounds);
@@ -80,7 +111,7 @@ bool TriangleSplitterBinning::Split(const Range &inTriangles, Range &outLeft, Ra
 		prev_triangles = 0;
 		for (int b = num_bins - 1; b >= 0; --b)
 		{
-			Bin &bin = mBins[b];
+			Bin &bin = mBins[num_bins * dim + b];
 			prev_bounds.Encapsulate(bin.mBounds);
 			prev_triangles += bin.mNumTriangles;
 			bin.mBoundsAccumulatedRight = prev_bounds;
@@ -91,13 +122,13 @@ bool TriangleSplitterBinning::Split(const Range &inTriangles, Range &outLeft, Ra
 		for (uint b = 1; b < num_bins; ++b) // Start at 1 since selecting bin 0 would result in everything ending up on the right side
 		{
 			// Calculate surface area heuristic and see if it is better than the current best
-			const Bin &bin = mBins[b];
+			const Bin &bin = mBins[num_bins * dim + b];
 			float cp = bin.mBoundsAccumulatedLeft.GetSurfaceArea() * bin.mNumTrianglesAccumulatedLeft + bin.mBoundsAccumulatedRight.GetSurfaceArea() * bin.mNumTrianglesAccumulatedRight;
 			if (cp < best_cp)
 			{
 				best_cp = cp;
 				best_dim = dim;
-				best_split = bin.mMinCentroid;
+				best_split = bin.mMinCentroid[dim];
 			}
 		}
 	}

--- a/Jolt/TriangleSplitter/TriangleSplitterBinning.h
+++ b/Jolt/TriangleSplitter/TriangleSplitterBinning.h
@@ -35,7 +35,7 @@ private:
 	{
 		// Properties of this bin
 		AABox				mBounds;
-		float				mMinCentroid;
+		Vec3				mMinCentroid;
 		uint				mNumTriangles;
 
 		// Accumulated data from left most / right most bin to current (including this bin)


### PR DESCRIPTION
Hi Jorrit,
MeshShape building is a bit of a bottleneck in Substrata, since as the 3d models consist of user-generated content, I can't really build them ahead of time.
As such I wanted to reduce the number of memory allocations Jolt does, and also speed up BVH building a bit.   The large number of memory allocations Jolt was doing was impacting multi-threaded computation quite a lot due to global allocator contention.

Results building a MeshShape with 152350 triangles:

```
Results before these optimisations are applied
---------------------------------------------------
createJoltShapeForBatchedMesh took 0.1375 s, num_allocs: 463825, min time so far: 0.1293 s

Results after optimisations are applied:
----------------------------------------------
createJoltShapeForBatchedMesh took 0.0872 s, num_allocs: 64, min time so far: 85.4597 ms
```

As you can see the number of allocations is decreased rather a lot :)

The code is not throughly tested, I mostly banged it out this evening, apart from using my existing HashMap and HashSet code.  I'm not wedded to the HashMap and HashSet implementation, we just need something better than the standard library trash.
