### PR TITLE
Treat AABBTree memory sizes with size_t

### DIFF
--- a/Jolt/AABBTree/AABBTreeToBuffer.h
+++ b/Jolt/AABBTree/AABBTreeToBuffer.h
@@ -39,8 +39,8 @@ public:
 		// Estimate the amount of memory required
 		uint tri_count = inRoot->GetTriangleCountInTree(inNodes);
 		uint node_count = inRoot->GetNodeCount(inNodes);
-		uint nodes_size = node_ctx.GetPessimisticMemoryEstimate(node_count);
-		uint total_size = HeaderSize + TriangleHeaderSize + nodes_size + tri_ctx.GetPessimisticMemoryEstimate(tri_count, inStoreUserData);
+		size_t nodes_size = node_ctx.GetPessimisticMemoryEstimate(node_count);
+		size_t total_size = HeaderSize + TriangleHeaderSize + nodes_size + tri_ctx.GetPessimisticMemoryEstimate(tri_count, inStoreUserData);
 		mTree.reserve(total_size);
 
 		// Reset counters

--- a/Jolt/AABBTree/NodeCodec/NodeCodecQuadTreeHalfFloat.h
+++ b/Jolt/AABBTree/NodeCodec/NodeCodecQuadTreeHalfFloat.h
@@ -62,7 +62,7 @@ public:
 	{
 	public:
 		/// Get an upper bound on the amount of bytes needed for a node tree with inNodeCount nodes
-		uint							GetPessimisticMemoryEstimate(uint inNodeCount) const
+		size_t							GetPessimisticMemoryEstimate(uint inNodeCount) const
 		{
 			return inNodeCount * (sizeof(Node) + Alignment - 1);
 		}

--- a/Jolt/AABBTree/TriangleCodec/TriangleCodecIndexed8BitPackSOA4Flags.h
+++ b/Jolt/AABBTree/TriangleCodec/TriangleCodecIndexed8BitPackSOA4Flags.h
@@ -141,7 +141,7 @@ public:
 		}
 
 		/// Get an upper bound on the amount of bytes needed to store inTriangleCount triangles
-		uint						GetPessimisticMemoryEstimate(uint inTriangleCount, bool inStoreUserData) const
+		size_t						GetPessimisticMemoryEstimate(uint inTriangleCount, bool inStoreUserData) const
 		{
 			// Worst case each triangle is alone in a block, none of the vertices are shared and we need to add 3 bytes to align the vertices
 			return inTriangleCount * (sizeof(TriangleBlockHeader) + sizeof(TriangleBlock) + (inStoreUserData? sizeof(uint32) : 0) + 3 * sizeof(VertexData)) + 3;


### PR DESCRIPTION
It's easy to hit the overlow of `uint32_t` when dealing with memory sizes