### PR TITLE
Added support for a ShapeFilter during simulation

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -11,6 +11,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * Added MotionProperties::ScaleToMass. This lets you easily change the mass and inertia tensor of a body after creation.
 * Split up Body::ApplyBuoyancyImpulse into Body::GetSubmergedVolume and Body::ApplyBuoyancyImpulse. This allows you to use the calculated submerged volume for other purposes.
 * Fixed a number of issues when creating very large MeshShapes. MeshShapes of up to 110M triangles are possible now, but the actual maximum is very dependent on how the triangles in the mesh are connected.
+* Added PhysicsSystem::SetSimulationShapeFilter. This allows filtering out collisions between sub shapes within a body and can for example be used to have a single body that contains a low detail simulation shape an a high detail collision query shape.
 
 ### Bug fixes
 

--- a/Jolt/Physics/Collision/ShapeFilter.h
+++ b/Jolt/Physics/Collision/ShapeFilter.h
@@ -33,7 +33,7 @@ public:
 	/// It is called at each level of the shape hierarchy, so if you have a compound shape with a box, this function will be called twice.
 	/// It will not be called on triangles that are part of another shape, i.e a mesh shape will not trigger a callback per triangle. You can filter out individual triangles in the CollisionCollector::AddHit function by their sub shape ID.
 	/// @param inShape1 1st shape that is colliding
-	/// @param inSubShapeIDOfShape1 The sub shape ID that will lead from the root shape to inShape1 (i.e. the shape that is used to collide or cast against shape 2)
+	/// @param inSubShapeIDOfShape1 The sub shape ID that will lead from the root shape to inShape1 (i.e. the shape that is used to collide or cast against shape 2 or the shape of mBodyID1)
 	/// @param inShape2 2nd shape that is colliding
 	/// @param inSubShapeIDOfShape2 The sub shape ID that will lead from the root shape to inShape2 (i.e. the shape of mBodyID2)
 	virtual bool			ShouldCollide([[maybe_unused]] const Shape *inShape1, [[maybe_unused]] const SubShapeID &inSubShapeIDOfShape1, [[maybe_unused]] const Shape *inShape2, [[maybe_unused]] const SubShapeID &inSubShapeIDOfShape2) const
@@ -41,7 +41,12 @@ public:
 		return true;
 	}
 
-	/// Set by the collision detection functions to the body ID of the body that we're colliding against before calling the ShouldCollide function
+	/// Used during PhysicsSystem::Update only. Set to the body ID of inShape1 before calling ShouldCollide.
+	/// Provides context to the filter to indicate which body is colliding.
+	mutable BodyID			mBodyID1;
+
+	/// Used during PhysicsSystem::Update, NarrowPhase queries and TransformedShape queries. Set to the body ID of inShape2 before calling ShouldCollide.
+	/// Provides context to the filter to indicate which body is colliding.
 	mutable BodyID			mBodyID2;
 };
 
@@ -52,7 +57,18 @@ public:
 	/// Constructor
 	explicit				ReversedShapeFilter(const ShapeFilter &inFilter) : mFilter(inFilter)
 	{
-		mBodyID2 = inFilter.mBodyID2;
+		if (inFilter.mBodyID1.IsInvalid())
+		{
+			// If body 1 is not set then we're coming from a regular query and we should not swap the bodies
+			// because conceptually we're still colliding a shape against a body and not a body against a body.
+			mBodyID2 = inFilter.mBodyID2;
+		}
+		else
+		{
+			// If both bodies have been filled in then we swap the bodies
+			mBodyID1 = inFilter.mBodyID2;
+			mBodyID2 = inFilter.mBodyID1;
+		}
 	}
 
 	virtual bool			ShouldCollide(const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const override

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -67,6 +67,14 @@ public:
 	void						SetCombineRestitution(ContactConstraintManager::CombineFunction inCombineRestition) { mContactManager.SetCombineRestitution(inCombineRestition); }
 	ContactConstraintManager::CombineFunction GetCombineRestitution() const					{ return mContactManager.GetCombineRestitution(); }
 
+	/// Set/get the shape filter that will be used during simulation. This can be used to exclude shapes within a body from colliding with each other.
+	/// E.g. if you have a high detail and a low detail collision model, you can attach them to the same body in a StaticCompoundShape and use the ShapeFilter
+	/// to exclude the high detail collision model when simulating and exclude the low detail collision model when casting rays. Note that in this case
+	/// you would need to pass the inverse of inShapeFilter to the CastRay function. Pass a nullptr to disable the shape filter.
+	/// The PhysicsSystem does not own the ShapeFilter, make sure it stays alive during the lifetime of the PhysicsSystem.
+	void						SetSimulationShapeFilter(const ShapeFilter *inShapeFilter)	{ mSimulationShapeFilter = inShapeFilter; }
+	const ShapeFilter *			GetSimulationShapeFilter() const							{ return mSimulationShapeFilter; }
+
 	/// Control the main constants of the physics simulation
 	void						SetPhysicsSettings(const PhysicsSettings &inSettings)		{ mPhysicsSettings = inSettings; }
 	const PhysicsSettings &		GetPhysicsSettings() const									{ return mPhysicsSettings; }
@@ -293,6 +301,9 @@ private:
 
 	/// The soft body contact listener
 	SoftBodyContactListener *	mSoftBodyContactListener = nullptr;
+
+	/// The shape filter that is used to filter out sub shapes during simulation
+	const ShapeFilter *			mSimulationShapeFilter = nullptr;
 
 	/// Simulation settings
 	PhysicsSettings				mPhysicsSettings;

--- a/Samples/Samples.cmake
+++ b/Samples/Samples.cmake
@@ -87,6 +87,8 @@ set(SAMPLES_SRC_FILES
 	${SAMPLES_ROOT}/Tests/General/EnhancedInternalEdgeRemovalTest.h
 	${SAMPLES_ROOT}/Tests/General/ShapeFilterTest.cpp
 	${SAMPLES_ROOT}/Tests/General/ShapeFilterTest.h
+	${SAMPLES_ROOT}/Tests/General/SimulationShapeFilterTest.cpp
+	${SAMPLES_ROOT}/Tests/General/SimulationShapeFilterTest.h
 	${SAMPLES_ROOT}/Tests/General/CenterOfMassTest.cpp
 	${SAMPLES_ROOT}/Tests/General/CenterOfMassTest.h
 	${SAMPLES_ROOT}/Tests/General/ChangeMotionQualityTest.cpp

--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -107,6 +107,7 @@ JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, DynamicMeshTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, TwoDFunnelTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, AllowedDOFsTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, ShapeFilterTest)
+JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, SimulationShapeFilterTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, GyroscopicForceTest)
 #ifdef JPH_OBJECT_STREAM
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, LoadSaveSceneTest)
@@ -151,7 +152,8 @@ static TestNameAndRTTI sGeneralTests[] =
 	{ "Sensor",								JPH_RTTI(SensorTest) },
 	{ "Dynamic Mesh",						JPH_RTTI(DynamicMeshTest) },
 	{ "Allowed Degrees of Freedom",			JPH_RTTI(AllowedDOFsTest) },
-	{ "Shape Filter",						JPH_RTTI(ShapeFilterTest) },
+	{ "Shape Filter (Collision Detection)",	JPH_RTTI(ShapeFilterTest) },
+	{ "Shape Filter (Simulation)",			JPH_RTTI(SimulationShapeFilterTest) },
 	{ "Gyroscopic Force",					JPH_RTTI(GyroscopicForceTest) },
 };
 

--- a/Samples/Tests/General/ShapeFilterTest.cpp
+++ b/Samples/Tests/General/ShapeFilterTest.cpp
@@ -49,16 +49,13 @@ void ShapeFilterTest::PostPhysicsUpdate(float inDeltaTime)
 	class MyShapeFilter : public ShapeFilter
 	{
 	public:
-		// Not used in this example
-		virtual bool	ShouldCollide(const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const override
-		{
-			return true;
-		}
-
 		virtual bool	ShouldCollide(const Shape *inShape1, const SubShapeID &inSubShapeID1, const Shape *inShape2, const SubShapeID &inSubShapeID2) const override
 		{
 			return inShape1->GetUserData() != mUserDataOfShapeToIgnore;
 		}
+
+		// We're not interested in the other overload as it is not used by ray casts
+		using ShapeFilter::ShouldCollide;
 
 		uint64			mUserDataOfShapeToIgnore = (uint64)ShapeIdentifier::Sphere;
 	};

--- a/Samples/Tests/General/SimulationShapeFilterTest.cpp
+++ b/Samples/Tests/General/SimulationShapeFilterTest.cpp
@@ -25,14 +25,14 @@ SimulationShapeFilterTest::~SimulationShapeFilterTest()
 
 void SimulationShapeFilterTest::Initialize()
 {
-	// Register activation listener
+	// Register shape filter
 	mPhysicsSystem->SetSimulationShapeFilter(&mShapeFilter);
 
 	// Floor
 	CreateFloor();
 
 	// Platform
-	mShapeFilter.mPlatformID = mBodyInterface->CreateAndAddBody(BodyCreationSettings(new BoxShape(Vec3(5.0f, 0.5f, 5.0f)), Vec3(0, 7.5f, 0), Quat::sRotation(Vec3::sAxisX(), 0.25f * JPH_PI), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
+	mShapeFilter.mPlatformID = mBodyInterface->CreateAndAddBody(BodyCreationSettings(new BoxShape(Vec3(5.0f, 0.5f, 5.0f)), RVec3(0, 7.5f, 0), Quat::sRotation(Vec3::sAxisX(), 0.25f * JPH_PI), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
 
 	// Compound shape
 	Ref<Shape> capsule = new CapsuleShape(2, 0.1f);

--- a/Samples/Tests/General/SimulationShapeFilterTest.cpp
+++ b/Samples/Tests/General/SimulationShapeFilterTest.cpp
@@ -1,0 +1,58 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2024 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#include <TestFramework.h>
+
+#include <Tests/General/SimulationShapeFilterTest.h>
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+#include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
+#include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Layers.h>
+
+JPH_IMPLEMENT_RTTI_VIRTUAL(SimulationShapeFilterTest)
+{
+	JPH_ADD_BASE_CLASS(SimulationShapeFilterTest, Test)
+}
+
+SimulationShapeFilterTest::~SimulationShapeFilterTest()
+{
+	// Unregister shape filter
+	mPhysicsSystem->SetSimulationShapeFilter(nullptr);
+}
+
+void SimulationShapeFilterTest::Initialize()
+{
+	// Register activation listener
+	mPhysicsSystem->SetSimulationShapeFilter(&mShapeFilter);
+
+	// Floor
+	CreateFloor();
+
+	// Platform
+	mShapeFilter.mPlatformID = mBodyInterface->CreateAndAddBody(BodyCreationSettings(new BoxShape(Vec3(5.0f, 0.5f, 5.0f)), Vec3(0, 7.5f, 0), Quat::sRotation(Vec3::sAxisX(), 0.25f * JPH_PI), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
+
+	// Compound shape
+	Ref<Shape> capsule = new CapsuleShape(2, 0.1f);
+	capsule->SetUserData(1); // Don't want the capsule to collide with the platform
+	Ref<Shape> sphere = new SphereShape(0.5f);
+	sphere->SetUserData(1); // Don't want the sphere to collide with the platform
+	Ref<Shape> box = new BoxShape(Vec3::sReplicate(0.5f));
+	Ref<StaticCompoundShapeSettings> compound = new StaticCompoundShapeSettings;
+	compound->AddShape(Vec3::sZero(), Quat::sIdentity(), capsule);
+	compound->AddShape(Vec3(0, -2, 0), Quat::sIdentity(), sphere);
+	compound->AddShape(Vec3(0, 2, 0), Quat::sIdentity(), box);
+	mShapeFilter.mCompoundID = mBodyInterface->CreateAndAddBody(BodyCreationSettings(compound, RVec3(0, 15, 0), Quat::sIdentity(), EMotionType::Dynamic, Layers::MOVING), EActivation::Activate);
+}
+
+bool SimulationShapeFilterTest::Filter::ShouldCollide(const Shape *inShape1, const SubShapeID &inSubShapeIDOfShape1, const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const
+{
+	// If the platform is colliding with the compound, filter out collisions where the shape has user data 1
+	if (mBodyID1 == mPlatformID && mBodyID2 == mCompoundID)
+		return inShape2->GetUserData() != 1;
+	else if (mBodyID1 == mCompoundID && mBodyID2 == mPlatformID)
+		return inShape1->GetUserData() != 1;
+	return true;
+}

--- a/Samples/Tests/General/SimulationShapeFilterTest.h
+++ b/Samples/Tests/General/SimulationShapeFilterTest.h
@@ -1,0 +1,37 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2024 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Tests/Test.h>
+#include <Jolt/Physics/Body/BodyActivationListener.h>
+
+// This test shows how to use a shape filter during the simulation to disable contacts between certain sub shapes
+class SimulationShapeFilterTest : public Test
+{
+public:
+	JPH_DECLARE_RTTI_VIRTUAL(JPH_NO_EXPORT, SimulationShapeFilterTest)
+
+	// Destructor
+	virtual				~SimulationShapeFilterTest() override;
+
+	// See: Test
+	virtual void		Initialize() override;
+
+private:
+	// A demo of the shape filter
+	class Filter : public ShapeFilter
+	{
+	public:
+		virtual bool	ShouldCollide(const Shape *inShape1, const SubShapeID &inSubShapeIDOfShape1, const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const override;
+
+		// We're not interested in the other overload as it is only used by collision queries and not by the simulation
+		using ShapeFilter::ShouldCollide;
+
+		BodyID			mPlatformID;
+		BodyID			mCompoundID;
+	};
+
+	Filter				mShapeFilter;
+};

--- a/Samples/Tests/General/SimulationShapeFilterTest.h
+++ b/Samples/Tests/General/SimulationShapeFilterTest.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <Tests/Test.h>
-#include <Jolt/Physics/Body/BodyActivationListener.h>
 
 // This test shows how to use a shape filter during the simulation to disable contacts between certain sub shapes
 class SimulationShapeFilterTest : public Test

--- a/UnitTests/Physics/ShapeFilterTests.cpp
+++ b/UnitTests/Physics/ShapeFilterTests.cpp
@@ -1,0 +1,95 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2024 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#include "UnitTestFramework.h"
+#include "PhysicsTestContext.h"
+#include "Layers.h"
+#include "LoggingContactListener.h"
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+#include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
+
+TEST_SUITE("ShapeFilterTests")
+{
+	// Tests two spheres in one simulated body, one collides with a static platform, the other doesn't
+	TEST_CASE("TestSimulationShapeFilter")
+	{
+		// Test once per motion quality type
+		for (int q = 0; q < 2; ++q)
+		{
+			PhysicsTestContext c;
+
+			// Log contacts
+			LoggingContactListener contact_listener;
+			c.GetSystem()->SetContactListener(&contact_listener);
+
+			// Install shape filter
+			class Filter : public ShapeFilter
+			{
+			public:
+				virtual bool	ShouldCollide(const Shape *inShape1, const SubShapeID &inSubShapeIDOfShape1, const Shape *inShape2, const SubShapeID &inSubShapeIDOfShape2) const override
+				{
+					// If the platform is colliding with the compound, filter out collisions where the shape has user data 1
+					if (mBodyID1 == mPlatformID && mBodyID2 == mCompoundID)
+						return inShape2->GetUserData() != 1;
+					else if (mBodyID1 == mCompoundID && mBodyID2 == mPlatformID)
+						return inShape1->GetUserData() != 1;
+					return true;
+				}
+
+				// We're not interested in the other overload as it is only used by collision queries and not by the simulation
+				using ShapeFilter::ShouldCollide;
+
+				BodyID			mPlatformID;
+				BodyID			mCompoundID;
+			};
+			Filter shape_filter;
+			c.GetSystem()->SetSimulationShapeFilter(&shape_filter);
+
+			// Floor
+			BodyID floor_id = c.CreateFloor().GetID();
+
+			// Platform
+			BodyInterface &bi = c.GetBodyInterface();
+			shape_filter.mPlatformID = bi.CreateAndAddBody(BodyCreationSettings(new BoxShape(Vec3(10, 0.5f, 10)), RVec3(0, 3.5f, 0), Quat::sIdentity(), EMotionType::Static, Layers::NON_MOVING), EActivation::DontActivate);
+
+			// Compound shape that starts above platform
+			Ref<Shape> sphere = new SphereShape(0.5f);
+			sphere->SetUserData(1); // Don't want sphere to collide with the platform
+			Ref<Shape> sphere2 = new SphereShape(0.5f);
+			Ref<StaticCompoundShapeSettings> compound_settings = new StaticCompoundShapeSettings;
+			compound_settings->AddShape(Vec3(0, -2, 0), Quat::sIdentity(), sphere);
+			compound_settings->AddShape(Vec3(0, 2, 0), Quat::sIdentity(), sphere2);
+			Ref<StaticCompoundShape> compound = StaticCast<StaticCompoundShape>(compound_settings->Create().Get());
+			BodyCreationSettings bcs(compound, RVec3(0, 7, 0), Quat::sIdentity(), EMotionType::Dynamic, Layers::MOVING);
+			if (q == 1)
+			{
+				// For the 2nd iteration activate CCD
+				bcs.mMotionQuality = EMotionQuality::LinearCast;
+				bcs.mLinearVelocity = Vec3(0, -50, 0);
+			}
+			shape_filter.mCompoundID = bi.CreateAndAddBody(bcs, EActivation::Activate);
+
+			// Get sub shape IDs
+			SubShapeID sphere_id = compound->GetSubShapeIDFromIndex(0, SubShapeIDCreator()).GetID();
+			SubShapeID sphere2_id = compound->GetSubShapeIDFromIndex(1, SubShapeIDCreator()).GetID();
+
+			// Simulate for 2 seconds
+			c.Simulate(2.0f);
+
+			// The compound should now be resting with sphere on the platform and the sphere2 on the floor
+			CHECK_APPROX_EQUAL(bi.GetPosition(shape_filter.mCompoundID), RVec3(0, 2.5f, 0), 1.01f * c.GetSystem()->GetPhysicsSettings().mPenetrationSlop);
+			CHECK_APPROX_EQUAL(bi.GetRotation(shape_filter.mCompoundID), Quat::sIdentity());
+
+			// Check that sphere2 collided with the platform but sphere did not
+			CHECK(contact_listener.Contains(LoggingContactListener::EType::Add, shape_filter.mPlatformID, SubShapeID(), shape_filter.mCompoundID, sphere2_id));
+			CHECK(!contact_listener.Contains(LoggingContactListener::EType::Add, shape_filter.mPlatformID, SubShapeID(), shape_filter.mCompoundID, sphere_id));
+
+			// Check that sphere2 didn't collide with the floor but that the sphere did
+			CHECK(contact_listener.Contains(LoggingContactListener::EType::Add, floor_id, SubShapeID(), shape_filter.mCompoundID, sphere_id));
+			CHECK(!contact_listener.Contains(LoggingContactListener::EType::Add, floor_id, SubShapeID(), shape_filter.mCompoundID, sphere2_id));
+		}
+	}
+}

--- a/UnitTests/UnitTests.cmake
+++ b/UnitTests/UnitTests.cmake
@@ -64,6 +64,7 @@ set(UNIT_TESTS_SRC_FILES
 	${UNIT_TESTS_ROOT}/Physics/PhysicsTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/RayShapeTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/SensorTests.cpp
+	${UNIT_TESTS_ROOT}/Physics/ShapeFilterTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/ShapeTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/SixDOFConstraintTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/SliderConstraintTests.cpp


### PR DESCRIPTION
Added PhysicsSystem::SetSimulationShapeFilter. This allows filtering out collisions between sub shapes within a body and can for example be used to have a single body that contains a low detail simulation shape an a high detail collision query shape.