### PR TITLE
Samples/Tests:  correct animation filenames

### DIFF
--- a/Samples/Tests/General/MultithreadedTest.cpp
+++ b/Samples/Tests/General/MultithreadedTest.cpp
@@ -151,7 +151,7 @@ void MultithreadedTest::RagdollSpawner()
 	{
 #ifdef JPH_OBJECT_STREAM
 		Ref<SkeletalAnimation> animation;
-		if (!ObjectStreamIn::sReadObject("Assets/Human/Dead_Pose1.tof", animation))
+		if (!ObjectStreamIn::sReadObject("Assets/Human/dead_pose1.tof", animation))
 			FatalError("Could not open animation");
 		animation->Sample(0.0f, ragdoll_pose);
 #else

--- a/Samples/Tests/General/SensorTest.cpp
+++ b/Samples/Tests/General/SensorTest.cpp
@@ -84,7 +84,7 @@ void SensorTest::Initialize()
 	{
 #ifdef JPH_OBJECT_STREAM
 		Ref<SkeletalAnimation> animation;
-		if (!ObjectStreamIn::sReadObject("Assets/Human/Dead_Pose1.tof", animation))
+		if (!ObjectStreamIn::sReadObject("Assets/Human/dead_pose1.tof", animation))
 			FatalError("Could not open animation");
 		animation->Sample(0.0f, ragdoll_pose);
 #else

--- a/Samples/Tests/Rig/BigWorldTest.cpp
+++ b/Samples/Tests/Rig/BigWorldTest.cpp
@@ -43,7 +43,7 @@ void BigWorldTest::Initialize()
 
 	// Load animation
 	Ref<SkeletalAnimation> animation;
-	if (!ObjectStreamIn::sReadObject("Assets/Human/Dead_Pose1.tof", animation))
+	if (!ObjectStreamIn::sReadObject("Assets/Human/dead_pose1.tof", animation))
 		FatalError("Could not open animation");
 	SkeletonPose pose;
 	pose.SetSkeleton(settings->GetSkeleton());

--- a/Samples/Tests/Rig/KinematicRigTest.cpp
+++ b/Samples/Tests/Rig/KinematicRigTest.cpp
@@ -19,16 +19,16 @@ JPH_IMPLEMENT_RTTI_VIRTUAL(KinematicRigTest)
 
 const char *KinematicRigTest::sAnimations[] =
 {
-	"Neutral",
-	"Walk",
-	"Sprint",
-	"Dead_Pose1",
-	"Dead_Pose2",
-	"Dead_Pose3",
-	"Dead_Pose4"
+	"neutral",
+	"walk",
+	"sprint",
+	"dead_pose1",
+	"dead_pose2",
+	"dead_pose3",
+	"dead_pose4"
 };
 
-const char *KinematicRigTest::sAnimationName = "Walk";
+const char *KinematicRigTest::sAnimationName = "walk";
 
 KinematicRigTest::~KinematicRigTest()
 {

--- a/Samples/Tests/Rig/PoweredRigTest.cpp
+++ b/Samples/Tests/Rig/PoweredRigTest.cpp
@@ -18,16 +18,16 @@ JPH_IMPLEMENT_RTTI_VIRTUAL(PoweredRigTest)
 
 const char *PoweredRigTest::sAnimations[] =
 {
-	"Neutral",
-	"Walk",
-	"Sprint",
-	"Dead_Pose1",
-	"Dead_Pose2",
-	"Dead_Pose3",
-	"Dead_Pose4"
+	"neutral",
+	"walk",
+	"sprint",
+	"dead_pose1",
+	"dead_pose2",
+	"dead_pose3",
+	"dead_pose4"
 };
 
-const char *PoweredRigTest::sAnimationName = "Sprint";
+const char *PoweredRigTest::sAnimationName = "sprint";
 
 PoweredRigTest::~PoweredRigTest()
 {

--- a/Samples/Tests/Rig/RigPileTest.cpp
+++ b/Samples/Tests/Rig/RigPileTest.cpp
@@ -80,7 +80,7 @@ void RigPileTest::Initialize()
 	Ref<SkeletalAnimation> animation[cAnimationCount];
 	for (int i = 0; i < cAnimationCount; ++i)
 	{
-		if (!ObjectStreamIn::sReadObject(StringFormat("Assets/Human/Dead_Pose%d.tof", i + 1).c_str(), animation[i]))
+		if (!ObjectStreamIn::sReadObject(StringFormat("Assets/Human/dead_pose%d.tof", i + 1).c_str(), animation[i]))
 			FatalError("Could not open animation");
 	}
 


### PR DESCRIPTION
The sample tests contain hard-coded filenames for animations, such as "Assets/Human/Dead_Pose1.tof".

On case-sensitive filesystems, the coded names do not match the actual filenames in the repository, in this instance "dead_pose1.tof".

Currently, the sample tests only run on Windows, so the mismatches do not cause failure. I discovered the mismatches because I am converting the tests to run on Linux.