### PR TITLE
Update docs to point to SetSimShapeFilter

### DIFF
--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -506,7 +506,7 @@ Bodies can only exist in a single layer. If you want a body with a low detail co
 The low detail body should be dynamic. The high detail body should be kinematic, or if it doesn't interact with other dynamic objects it can also be static.
 After calling PhysicsSystem::Update, you'll need to loop over these dynamic bodies and call BodyInterface::MoveKinematic in case the high detail body is kinematic, or BodyInterface::SetPositionAndRotation in case the high detail body is static.
 
-Alternatively, you can put a high detail and a low detail shape in a StaticCompoundShape and use PhysicsSystem::SetSimulationShapeFilter to filter out the high detail shape during simulation.
+Alternatively, you can put a high detail and a low detail shape in a StaticCompoundShape and use PhysicsSystem::SetSimShapeFilter to filter out the high detail shape during simulation.
 Another ShapeFilter would filter out the low detail shape during collision queries (e.g. through NarrowPhaseQuery).
 You can use Shape::GetUserData to determine if a shape is a high or a low detail shape.
 


### PR DESCRIPTION
In the original commit adding the simulation shape filter, the member was called `SetSimulationShapeFilter`, but then it was renamed to `SetSimShapeFilter` in a follow-up. This PR updates the docs to point to the new name.