### PR TITLE
Fix Vulkan descriptor pool count

### DIFF
--- a/TestFramework/Renderer/VK/RendererVK.cpp
+++ b/TestFramework/Renderer/VK/RendererVK.cpp
@@ -377,13 +377,16 @@ void RendererVK::Initialize()
 	FatalErrorIfFailed(vkCreatePipelineLayout(mDevice, &pipeline_layout, nullptr, &mPipelineLayout));
 
 	// Create descriptor pool
-	VkDescriptorPoolSize descriptor_pool_size = {};
-	descriptor_pool_size.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-	descriptor_pool_size.descriptorCount = cFrameCount;
+	VkDescriptorPoolSize descriptor_pool_sizes[] = {
+		// ubo_layout_binding * (Projection + Ortho)
+		VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, cFrameCount * (2 * 2)},
+		// texture_layout_binding * (Main Render Targets + DebugUI)
+		VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, cFrameCount * (1 * 2)},
+	};
 	VkDescriptorPoolCreateInfo descriptor_info = {};
 	descriptor_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-	descriptor_info.poolSizeCount = 1;
-	descriptor_info.pPoolSizes = &descriptor_pool_size;
+	descriptor_info.poolSizeCount = std::size(descriptor_pool_sizes);
+	descriptor_info.pPoolSizes = descriptor_pool_sizes;
 	descriptor_info.maxSets = 256;
 	FatalErrorIfFailed(vkCreateDescriptorPool(mDevice, &descriptor_info, nullptr, &mDescriptorPool));
 


### PR DESCRIPTION
Allocates the correct amount of UBOs and Image Samplers ahead of time.

Thank you for the Vulkan implementation. I did some testing and ran into a crash and validation error regarding the global descriptor-pool here not declaring enough descriptors of certain types ahead of time.

This addresses the issue directly, but a more robust solution might be needed here later on. This is enough to get all of the tests to run without any crashes on my system or validation _errors_ in particular, though I do get an allocation error involving the application reaching the maximum amount of allocations(4096 on this system) when running `FunnelTest` in particular. That will probably need a whole new allocation strategy though to sub-allocate out of a larger heap of VkDeviceMemory rather than allocating a new one for each DebugDraw TriangleBatch.

For reference, I tested on my ThinkPad X13S(Windows on ARM, Native Vulkan driver) and got valdation messages like this followed by a crash due to the global descriptor pool only allocating space for a `cFrameCount`-amount of uniform-buffers despite there being descriptor-layouts that want two uniform-buffers each descriptor set or one singular texture sampler per-set:

```
VK: Validation Error: [ VUID-VkDescriptorSetAllocateInfo-apiVersion-07896 ] Object 0: handle = 0x27d60e0000000019, type = VK_OBJECT_TYPE_DESCRIPTOR_POOL; | MessageID = 0x5584bd53 | vkAllocateDescriptorSets():  Unable to allocate 1 descriptors of type VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER from VkDescriptorPool 0x27d60e0000000019[]. This pool only has 0 descriptors of this type remaining. The Vulkan spec states: If the VK_KHR_maintenance1 extension is not enabled and VkPhysicalDeviceProperties::apiVersion is less than Vulkan 1.1, descriptorPool must have enough free descriptor capacity remaining to allocate the descriptor sets of the specified layouts (https://vulkan.lunarg.com/doc/view/1.3.290.0/mac/1.3-extensions/vkspec.html#VUID-VkDescriptorSetAllocateInfo-apiVersion-07896)
```