### PR TITLE
Improved mouse, keyboard, and resize handling for macOS

### DIFF
--- a/TestFramework/Input/MacOS/KeyboardMacOS.mm
+++ b/TestFramework/Input/MacOS/KeyboardMacOS.mm
@@ -75,6 +75,16 @@ static EKey sToKey(GCKeyCode inValue)
 - (KeyboardDelegate *)init:(KeyboardMacOS *)Keyboard
 {
 	mKeyboard = Keyboard;
+
+    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown handler:^NSEvent *(NSEvent *event) {
+        // Ignore all keystrokes except Command-Q (Quit).
+        if ((event.modifierFlags & NSEventModifierFlagCommand) && [event.charactersIgnoringModifiers isEqual:@"q"]) {
+            return event;
+        } else {
+            return nil;
+        }
+    }];
+
 	return self;
 }
 

--- a/TestFramework/Window/ApplicationWindow.h
+++ b/TestFramework/Window/ApplicationWindow.h
@@ -29,7 +29,7 @@ public:
 	virtual void					MainLoop(RenderCallback inRenderCallback) = 0;
 	
 	/// Function that will trigger the callback
-	void							OnWindowResized(int inWidth, int inHeight) { mWindowWidth = inWidth; mWindowHeight = inHeight; mWindowResizeListener(); }
+	void							OnWindowResized(int inWidth, int inHeight) { mWindowWidth = inWidth; mWindowHeight = inHeight; if (mWindowResizeListener) { mWindowResizeListener(); } }
 
 protected:
 	int								mWindowWidth = 1920;

--- a/TestFramework/Window/ApplicationWindowMacOS.mm
+++ b/TestFramework/Window/ApplicationWindowMacOS.mm
@@ -38,10 +38,15 @@
 	return YES;
 }
 
+- (BOOL)isFlipped {
+    return YES;
+}
+
 - (void)mouseMoved:(NSEvent *)event
 {
-	NSPoint location = [event locationInWindow];
-	mWindow->OnMouseMoved(location.x, mWindow->GetWindowHeight() - location.y);	
+    NSPoint locationInView = [self convertPoint:event.locationInWindow fromView:nil];
+    NSPoint locationInBacking = [self convertPointToBacking:locationInView];
+	mWindow->OnMouseMoved(locationInBacking.x, -locationInBacking.y);
 }
 
 - (void)drawInMTKView:(MTKView *)view


### PR DESCRIPTION
This PR introduces a few small changes improving the newly added support for macOS in the test framework:

 - `GCKeyboard` operates outside of the Cocoa event loop, and the application window does not handle key events itself, resulting in an annoying beep on every key-down or key repeat event. Introducing a local event monitor and explicitly ignoring key-down events (excluding Command-Q, which is the Quit menu accelerator key) prevents this.

 - Because of the Cocoa view lifecycle, it is possible for a resize event to occur before the window resize handler is installed by the renderer, leading to a crash (on macOS Sequoia 15.2 at least). Adding a null check (i.e. checking whether the callback function is empty) prevents this.

 - Finally, the code currently assumes that window coordinates match backing layer coordinates, meaning the menu doesn't respond correctly to mouse hover or mouse click events. Refining the mouse event handling code to convert into the expected coordinate space restores menu functionality.