### PR TITLE
Remove emscripten stack and memory flags

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -327,6 +327,10 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 		target_include_directories(UnitTests PUBLIC ${UNIT_TESTS_ROOT})
 		target_link_libraries(UnitTests LINK_PUBLIC Jolt)
 
+		if (EMSCRIPTEN)
+			target_link_options(UnitTests PUBLIC -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728)
+		endif()
+
 		# Code coverage doesn't work when using precompiled headers
 		if (CMAKE_GENERATOR STREQUAL "Ninja Multi-Config" AND MSVC)
 			# The Ninja Multi-Config generator errors out when selectively disabling precompiled headers for certain configurations.
@@ -367,6 +371,9 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			if (MSVC)
 				target_link_options(HelloWorld PUBLIC "/SUBSYSTEM:CONSOLE")
 			endif()
+			if (EMSCRIPTEN)
+				target_link_options(HelloWorld PUBLIC -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728)
+			endif()
 		endif()
 
 		if (TARGET_PERFORMANCE_TEST)
@@ -383,6 +390,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 				target_link_options(PerformanceTest PUBLIC "SHELL:--preload-file ${PHYSICS_REPO_ROOT}/Assets/Human.tof@/Assets/Human.tof")
 				target_link_options(PerformanceTest PUBLIC "SHELL:--preload-file ${PHYSICS_REPO_ROOT}/Assets/Human/dead_pose1.tof@/Assets/Human/dead_pose1.tof")
 				target_link_options(PerformanceTest PUBLIC "SHELL:--preload-file ${PHYSICS_REPO_ROOT}/Assets/terrain2.bof@/Assets/terrain2.bof")
+				target_link_options(PerformanceTest PUBLIC -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728)
 			endif()
 			set_property(TARGET PerformanceTest PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PHYSICS_REPO_ROOT}")
 

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -690,6 +690,7 @@ endif()
 
 if (EMSCRIPTEN)
 	# We need more than the default 64KB stack and 16MB memory
+	# In your application, specify at least -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728
 	# Also disable warning: running limited binaryen optimizations because DWARF info requested (or indirectly required)
-	target_link_options(Jolt PUBLIC -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728 -Wno-limited-postlink-optimizations)
+	target_link_options(Jolt PUBLIC -Wno-limited-postlink-optimizations)
 endif()


### PR DESCRIPTION
Rationale is that these should be applied on the application, not the library.
Specifying these on the library level has the effect of it overriding the application settings, which is undesirable

Example from my project (where 2147483648 is specified but the jolt parameters are picked instead)
```
  LINK_FLAGS = -sASSERTIONS=2 -sDISABLE_EXCEPTION_CATCHING=0 -lembind -sUSE_PTHREADS=1 -pthread -sMODULARIZE=1 -sEXPORT_NAME=shards -sENVIRONMENT=web,worker -sEXPORT_ES6=1 -sMIN_FIREFOX_VERSION=125 -sMIN_CHROME_VERSION=113 -sMIN_SAFARI_VERSION=-1 -sPTHREAD_POOL_SIZE=12 "-sEXPORTED_RUNTIME_METHODS=['FS', 'FETCHFS', 'stringToNewUTF8', 'UTF8ToString', 'ccall', 'cwrap', 'gfxSetup']" "-sEXPORTED_FUNCTIONS=['_malloc','_free']" -sOFFSCREENCANVAS_SUPPORT=1 -sSTACK_SIZE=2097152 -sINITIAL_MEMORY=2147483648 -sWASMFS -lfetchfs.js -sFORCE_FILESYSTEM -gseparate-dwarf=shards-mt.debug.wasm -sSEPARATE_DWARF_URL=http://localhost:3000/bin/shards-mt.debug.wasm -sLLD_REPORT_UNDEFINED -sASYNCIFY=1 -sUSE_WEBGPU=1 -s FETCH=1 -sSTACK_SIZE=1048576 -sINITIAL_MEMORY=134217728 
```