### PR TITLE
Support 64-bit WebAssembly

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -195,7 +195,11 @@
 #elif defined(JPH_PLATFORM_WASM)
 	// WebAssembly CPU architecture
 	#define JPH_CPU_WASM
-	#define JPH_CPU_ADDRESS_BITS 32
+	#if defined(__wasm64__)
+		#define JPH_CPU_ADDRESS_BITS 64
+	#else
+		#define JPH_CPU_ADDRESS_BITS 32
+	#endif
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 32
 	#ifdef __wasm_simd128__


### PR DESCRIPTION
Now that `MEMORY64` is [no longer experimental](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3172---111924), we'll probably be seeing more emscription builds targeting 64-bit in the coming months. This PR *should* be all that's needed to get it to compile