### PR TITLE
Set JPH_DVECTOR_ALIGNMENT to 32 for LoongArch

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -229,7 +229,7 @@
 		#define JPH_CPU_ADDRESS_BITS 32
 	#endif
 	#define JPH_VECTOR_ALIGNMENT 16
-	#define JPH_DVECTOR_ALIGNMENT 8
+	#define JPH_DVECTOR_ALIGNMENT 32
 #elif defined(__e2k__)
 	// E2K CPU architecture (MCST Elbrus 2000)
 	#define JPH_CPU_E2K


### PR DESCRIPTION
original value only works for gcc with single precision, this change fix clang build and double precision build.

tested on my LoongArch machine with gcc 14, clang 18 and clang 20