### PR TITLE
Adds CMake option to use External Profiler

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -92,10 +92,9 @@ option(PROFILER_IN_DEBUG_AND_RELEASE "Enable the profiler in Debug and Release b
 # Note that enabling this reduces the performance of the library.
 option(PROFILER_IN_DISTRIBUTION "Enable the profiler in all builds" OFF)
 
-# Ability to use the external profiler using CMake config.
 # Use external profiler set using ProfileStartMeasurement and ProfileEndMeasurement to profile.
 # Option is available only when profiling is enabled using PROFILER_IN_DEBUG_AND_RELEASE or PROFILER_IN_DISTRIBUTION.
-option(JPH_USE_EXTERNAL_PROFILER "Use external profiler when profiling is enabled" OFF)
+option(JPH_USE_EXTERNAL_PROFILE "Use external profiler when profiling is enabled" OFF)
 
 # Setting this option will force the library to use malloc/free instead of allowing the user to override the memory allocator
 option(DISABLE_CUSTOM_ALLOCATOR "Disable support for a custom memory allocator" OFF)

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -92,6 +92,7 @@ option(PROFILER_IN_DEBUG_AND_RELEASE "Enable the profiler in Debug and Release b
 # Note that enabling this reduces the performance of the library.
 option(PROFILER_IN_DISTRIBUTION "Enable the profiler in all builds" OFF)
 
+# Ability to use the external profiler using CMake config. Defines preprocessor JPH_EXTERNAL_PROFILE.
 # Use external profiler set using ProfileStartMeasurement and ProfileEndMeasurement to profile.
 # Option is available only when profiling is enabled using PROFILER_IN_DEBUG_AND_RELEASE or PROFILER_IN_DISTRIBUTION.
 option(JPH_USE_EXTERNAL_PROFILE "Use external profiler when profiling is enabled" OFF)

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -92,6 +92,11 @@ option(PROFILER_IN_DEBUG_AND_RELEASE "Enable the profiler in Debug and Release b
 # Note that enabling this reduces the performance of the library.
 option(PROFILER_IN_DISTRIBUTION "Enable the profiler in all builds" OFF)
 
+# Ability to use the external profiler using CMake config.
+# Use external profiler set using ProfileStartMeasurement and ProfileEndMeasurement to profile.
+# Option is available only when profiling is enabled using PROFILER_IN_DEBUG_AND_RELEASE or PROFILER_IN_DISTRIBUTION.
+option(JPH_USE_EXTERNAL_PROFILER "Use external profiler when profiling is enabled" OFF)
+
 # Setting this option will force the library to use malloc/free instead of allowing the user to override the memory allocator
 option(DISABLE_CUSTOM_ALLOCATOR "Disable support for a custom memory allocator" OFF)
 

--- a/Build/README.md
+++ b/Build/README.md
@@ -25,7 +25,7 @@ There are a number of user configurable defines that turn on/off certain feature
 	<ul>
 		<li>JPH_SHARED_LIBRARY - Use the Jolt library as a shared library. Use JPH_BUILD_SHARED_LIBRARY to build Jolt as a shared library.</li>
 		<li>JPH_PROFILE_ENABLED - Turns on the internal profiler.</li>
-		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h). Use JPH_USE_EXTERNAL_PROFILER when profiler is enabled to use external profiler.</li>
+		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h). Use JPH_USE_EXTERNAL_PROFILE when profiler is enabled to use external profiler.</li>
 		<li>JPH_DEBUG_RENDERER - Adds support to draw lines and triangles, used to be able to debug draw the state of the world.</li>
 		<li>JPH_DISABLE_TEMP_ALLOCATOR - Disables the temporary memory allocator, used mainly to allow ASAN to do its job.</li>
 		<li>JPH_DISABLE_CUSTOM_ALLOCATOR - Disables the ability to override the memory allocator.</li>

--- a/Build/README.md
+++ b/Build/README.md
@@ -25,7 +25,7 @@ There are a number of user configurable defines that turn on/off certain feature
 	<ul>
 		<li>JPH_SHARED_LIBRARY - Use the Jolt library as a shared library. Use JPH_BUILD_SHARED_LIBRARY to build Jolt as a shared library.</li>
 		<li>JPH_PROFILE_ENABLED - Turns on the internal profiler.</li>
-		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h).</li>
+		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h). Use JPH_USE_EXTERNAL_PROFILER when profiler is enabled to use external profiler.</li>
 		<li>JPH_DEBUG_RENDERER - Adds support to draw lines and triangles, used to be able to debug draw the state of the world.</li>
 		<li>JPH_DISABLE_TEMP_ALLOCATOR - Disables the temporary memory allocator, used mainly to allow ASAN to do its job.</li>
 		<li>JPH_DISABLE_CUSTOM_ALLOCATOR - Disables the ability to override the memory allocator.</li>

--- a/Build/README.md
+++ b/Build/README.md
@@ -25,7 +25,7 @@ There are a number of user configurable defines that turn on/off certain feature
 	<ul>
 		<li>JPH_SHARED_LIBRARY - Use the Jolt library as a shared library. Use JPH_BUILD_SHARED_LIBRARY to build Jolt as a shared library.</li>
 		<li>JPH_PROFILE_ENABLED - Turns on the internal profiler.</li>
-		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h). Use JPH_USE_EXTERNAL_PROFILE when profiler is enabled to use external profiler.</li>
+		<li>JPH_EXTERNAL_PROFILE - Turns on the internal profiler but forwards the information to a user defined external system (see Profiler.h). Use JPH_USE_EXTERNAL_PROFILE option to enable this from CMake config.</li>
 		<li>JPH_DEBUG_RENDERER - Adds support to draw lines and triangles, used to be able to debug draw the state of the world.</li>
 		<li>JPH_DISABLE_TEMP_ALLOCATOR - Disables the temporary memory allocator, used mainly to allow ASAN to do its job.</li>
 		<li>JPH_DISABLE_CUSTOM_ALLOCATOR - Disables the ability to override the memory allocator.</li>

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -575,12 +575,15 @@ elseif (DEBUG_RENDERER_IN_DEBUG_AND_RELEASE)
 endif()
 
 # Enable the profiler
+if (JPH_USE_EXTERNAL_PROFILE)
+	set(JOLT_PROFILE_DEFINE JPH_EXTERNAL_PROFILE)
+else()
+	set(JOLT_PROFILE_DEFINE JPH_PROFILE_ENABLED)
+endif()
 if (PROFILER_IN_DISTRIBUTION)
-	target_compile_definitions(Jolt PUBLIC "JPH_PROFILE_ENABLED")
-	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILE}>:JPH_EXTERNAL_PROFILE>")
+	target_compile_definitions(Jolt PUBLIC "${JOLT_PROFILE_DEFINE}")
 elseif (PROFILER_IN_DEBUG_AND_RELEASE)
-	target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug,Release,ReleaseASAN,ReleaseUBSAN,ReleaseTSAN>:JPH_PROFILE_ENABLED>")
-	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILE}>:JPH_EXTERNAL_PROFILE>")
+	target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug,Release,ReleaseASAN,ReleaseUBSAN,ReleaseTSAN>:${JOLT_PROFILE_DEFINE}>")
 endif()
 
 # Compile the ObjectStream class and RTTI attribute information

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -577,10 +577,10 @@ endif()
 # Enable the profiler
 if (PROFILER_IN_DISTRIBUTION)
 	target_compile_definitions(Jolt PUBLIC "JPH_PROFILE_ENABLED")
-	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILER}>:JPH_EXTERNAL_PROFILE>")
+	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILE}>:JPH_EXTERNAL_PROFILE>")
 elseif (PROFILER_IN_DEBUG_AND_RELEASE)
 	target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug,Release,ReleaseASAN,ReleaseUBSAN,ReleaseTSAN>:JPH_PROFILE_ENABLED>")
-	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILER}>:JPH_EXTERNAL_PROFILE>")
+	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILE}>:JPH_EXTERNAL_PROFILE>")
 endif()
 
 # Compile the ObjectStream class and RTTI attribute information

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -577,8 +577,10 @@ endif()
 # Enable the profiler
 if (PROFILER_IN_DISTRIBUTION)
 	target_compile_definitions(Jolt PUBLIC "JPH_PROFILE_ENABLED")
+	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILER}>:JPH_EXTERNAL_PROFILE>")
 elseif (PROFILER_IN_DEBUG_AND_RELEASE)
 	target_compile_definitions(Jolt PUBLIC "$<$<CONFIG:Debug,Release,ReleaseASAN,ReleaseUBSAN,ReleaseTSAN>:JPH_PROFILE_ENABLED>")
+	target_compile_definitions(Jolt PUBLIC "$<$<BOOL:${JPH_USE_EXTERNAL_PROFILER}>:JPH_EXTERNAL_PROFILE>")
 endif()
 
 # Compile the ObjectStream class and RTTI attribute information


### PR DESCRIPTION
Ability to use the external profiler using CMake config. 
Use an external profiler set using ProfileStartMeasurement and ProfileEndMeasurement to profile. 
The option is available only when profiling is enabled using PROFILER_IN_DEBUG_AND_RELEASE or PROFILER_IN_DISTRIBUTION.

Exposes the preprocessor `JPH_EXTERNAL_PROFILE` as CMake option. Does not make any functionality changes.