### PR TITLE
Configuration string contains (External Profile) if JPH_EXTERNAL_PROFILE is set

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -242,10 +242,8 @@ else()
 		if (CMAKE_CXX_COMPILER_VERSION LESS 14 OR CROSS_PLATFORM_DETERMINISTIC OR "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "loongarch")
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off")
 
-			# emcc complains with: warning: overriding '-ffp-model=precise' option with '-ffp-contract=off' [-Woverriding-option],
-			# clang > 19 also report this as an error,
-			# but this is exactly what we want.
-			if (EMSCRIPTEN OR CMAKE_CXX_COMPILER_VERSION GREATER 19)
+			# Clang 20 and later complain with: overriding '-ffp-model=precise' option with '-ffp-contract=off' [-Woverriding-option], but this is exactly what we want.
+			if (CMAKE_CXX_COMPILER_VERSION GREATER 19)
 				set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overriding-option")
 			endif()
 		endif()

--- a/Jolt/ConfigurationString.h
+++ b/Jolt/ConfigurationString.h
@@ -83,6 +83,9 @@ inline const char *GetConfigurationString()
 #ifdef JPH_PROFILE_ENABLED
 		"(Profile) "
 #endif
+#ifdef JPH_EXTERNAL_PROFILE
+		"(External Profile) "
+#endif
 #if defined(JPH_OBJECT_LAYER_BITS) && JPH_OBJECT_LAYER_BITS == 32
 		"(32-bit ObjectLayer) "
 #else


### PR DESCRIPTION
Also removed if EMSCRIPTEN condition as the clang version check covers it