### PR TITLE
Add parameter to shrink rest length of edge constraints

### DIFF
--- a/Jolt/Physics/SoftBody/SoftBodyCreationSettings.h
+++ b/Jolt/Physics/SoftBody/SoftBodyCreationSettings.h
@@ -65,6 +65,7 @@ public:
 	float				mFriction = 0.2f;					///< Friction coefficient when colliding
 	float				mPressure = 0.0f;					///< n * R * T, amount of substance * ideal gas constant * absolute temperature, see https://en.wikipedia.org/wiki/Pressure
 	float				mGravityFactor = 1.0f;				///< Value to multiply gravity with for this body
+	float				mEdgeRestLengthMultiplier = 1.0f;	///< Multiplier applied to Edge::mRestLength to allow shrinking of the edge constraints
 	bool				mUpdatePosition = true;				///< Update the position of the body while simulating (set to false for something that is attached to the static world)
 	bool				mMakeRotationIdentity = true;		///< Bake specified mRotation in the vertices and set the body rotation to identity (simulation is slightly more accurate if the rotation of a soft body is kept to identity)
 	bool				mAllowSleeping = true;				///< If this body can go to sleep or not

--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
@@ -568,7 +568,7 @@ void SoftBodyMotionProperties::ApplyEdgeConstraints(const SoftBodyUpdateContext 
 		float denom = length * (v0.mInvMass + v1.mInvMass + e->mCompliance * inv_dt_sq);
 		if (denom < 1.0e-12f)
 			continue;
-		Vec3 correction = delta * (length - e->mRestLength) / denom;
+		Vec3 correction = delta * (length - e->mRestLength * mEdgeRestLengthMultiplier) / denom;
 		v0.mPosition = x0 + v0.mInvMass * correction;
 		v1.mPosition = x1 - v1.mInvMass * correction;
 	}

--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
@@ -62,6 +62,7 @@ void SoftBodyMotionProperties::Initialize(const SoftBodyCreationSettings &inSett
 	mSettings = inSettings.mSettings;
 	mNumIterations = inSettings.mNumIterations;
 	mPressure = inSettings.mPressure;
+	mEdgeRestLengthMultiplier = inSettings.mEdgeRestLengthMultiplier;
 	mUpdatePosition = inSettings.mUpdatePosition;
 
 	// Initialize vertices

--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.h
@@ -289,6 +289,7 @@ private:
 	uint								mNumSensors;								///< Workaround for TSAN false positive: store mCollidingSensors.size() in a separate variable.
 	float								mPressure;									///< n * R * T, amount of substance * ideal gas constant * absolute temperature, see https://en.wikipedia.org/wiki/Pressure
 	float								mSkinnedMaxDistanceMultiplier = 1.0f;		///< Multiplier applied to Skinned::mMaxDistance to allow tightening or loosening of the skin constraints
+	float								mEdgeRestLengthMultiplier = 1.0f;			///< Multiplier applied to Edge::mRestLength to allow shrinking of the edge constraints
 	bool								mUpdatePosition;							///< Update the position of the body while simulating (set to false for something that is attached to the static world)
 	atomic<bool>						mNeedContactCallback = false;				///< True if the soft body has collided with anything in the last update
 	bool								mEnableSkinConstraints = true;				///< If skin constraints are enabled


### PR DESCRIPTION
Scaling down the rest lengths of edge constraints produces a shrinking effect that is useful for creating constantly tightened cloth, like sails or bat wings. This PR adds `mEdgeRestLengthMultiplier` parameter that can be set at the creation of the softbody and implemented as an adjustable parameter in Godot or other projects that uses Jolt, similar to Shrinking Factor in Blender's cloth simulation modifier.

ShapesTest with `mEdgeRestLengthMultiplier = 0.5`:
![image](https://github.com/user-attachments/assets/288d145a-7174-4204-bf54-a0934fa3c458)
