### PR TITLE
Add CMake flag for Unreal Engine compatibility

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -111,7 +111,7 @@ option(ENABLE_INSTALL "Generate installation target"  ON)
 
 # Enable Unreal Engine integration
 # Primarily stops us from redefining _HAS_EXCEPTIONS which causes conflicts when building with Unreal
-option(WITH_UNREAL_ENGINE "Enable Unreal Engine integration" OFF)
+option(JPH_WITH_UNREAL_ENGINE "Enable Unreal Engine integration" OFF)
 
 include(CMakeDependentOption)
 

--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -109,6 +109,10 @@ option(ENABLE_OBJECT_STREAM "Compile the ObjectStream class and RTTI attribute i
 # Enable installation
 option(ENABLE_INSTALL "Generate installation target"  ON)
 
+# Enable Unreal Engine integration
+# Primarily stops us from redefining _HAS_EXCEPTIONS which causes conflicts when building with Unreal
+option(WITH_UNREAL_ENGINE "Enable Unreal Engine integration" OFF)
+
 include(CMakeDependentOption)
 
 # Ability to toggle between the static and DLL versions of the MSVC runtime library

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -511,8 +511,9 @@ else()
 	target_precompile_headers(Jolt PRIVATE "$<$<NOT:$<CONFIG:ReleaseCoverage>>:${JOLT_PHYSICS_ROOT}/Jolt.h>")
 endif()
 
-if (NOT CPP_EXCEPTIONS_ENABLED)
+if (NOT CPP_EXCEPTIONS_ENABLED AND NOT WITH_UNREAL_ENGINE)
 	# Disable use of exceptions in MSVC's STL
+	# We do not do this when using Unreal Engine because it conflicts with UE build settings
 	target_compile_definitions(Jolt PUBLIC $<$<BOOL:${MSVC}>:_HAS_EXCEPTIONS=0>)
 endif()
 

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -511,7 +511,7 @@ else()
 	target_precompile_headers(Jolt PRIVATE "$<$<NOT:$<CONFIG:ReleaseCoverage>>:${JOLT_PHYSICS_ROOT}/Jolt.h>")
 endif()
 
-if (NOT CPP_EXCEPTIONS_ENABLED AND NOT WITH_UNREAL_ENGINE)
+if (NOT CPP_EXCEPTIONS_ENABLED AND NOT JPH_WITH_UNREAL_ENGINE)
 	# Disable use of exceptions in MSVC's STL
 	# We do not do this when using Unreal Engine because it conflicts with UE build settings
 	target_compile_definitions(Jolt PUBLIC $<$<BOOL:${MSVC}>:_HAS_EXCEPTIONS=0>)


### PR DESCRIPTION
There has been growing interest in integrating Jolt physics with Unreal Engine. One small issue with this is that when building with MSVC, Jolt defines `_HAS_EXCEPTIONS = 0`  to disable exceptions in the STL for performance reasons. However this conflicts with Unreal Engine's build settings, causing compilation to fail. A full log of the errors this causes can be found in [this Gist.](https://gist.github.com/STIXTheMachine/126021ecf5e53da0b441a89c01186654)

This issue has been resistant to every solution I've tried from within Unreal Engine's build configuration options.

This PR introduces the CMake option ~~`WITH_UNREAL_ENGINE`~~ `JPH_WITH_UNREAL_ENGINE` which disables the `_HAS_EXCEPTIONS` redefinition when enabled. This option defaults to OFF, so existing builds are unaffected.

~~Unit tests pass successfully, note however that samples do not build build due to issue #1633 .~~
Unit tests and samples are confirmed to compile and pass.