### PR TITLE
fix missing malloc.h include in clang-cl mode (clang in msvc mode)

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -453,7 +453,7 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <functional>
 #include <algorithm>
 #include <cstdint>
-#ifdef JPH_COMPILER_MSVC
+#if defined(JPH_COMPILER_MSVC) || (defined(JPH_COMPILER_CLANG) && defined(_MSC_VER)) // MSVC or clang-cl
 	#include <malloc.h> // for alloca
 #endif
 #if defined(JPH_USE_SSE)


### PR DESCRIPTION
The issue manifest itself in windows-on-arm build (`--target=aarch64-pc-windows-msvc`)

Related
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/alloca?view=msvc-170