### PR TITLE
README.md: update weblink to the Jolt-JNI project (Java/Kotlin bindings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you're interested in how Jolt scales with multiple CPUs and compares to other
 
 * C [here](https://github.com/amerkoleci/joltc), [here](https://github.com/zig-gamedev/zphysics/tree/main/libs/JoltC) and [here](https://github.com/SecondHalfGames/JoltC/)
 * [C#](https://github.com/amerkoleci/JoltPhysicsSharp)
-* [Java](https://github.com/stephengold/jolt-jni)
+* [Java or Kotlin](https://stephengold.github.io/jolt-jni-docs)
 * [JavaScript](https://github.com/jrouwe/JoltPhysics.js)
 * [Rust](https://github.com/SecondHalfGames/jolt-rust)
 * [Zig](https://github.com/zig-gamedev/zphysics)


### PR DESCRIPTION
I created a documentation website for the Jolt-JNI project,
and I'd like for the new site to become the main entry point into the project.
So I'm requesting a change to the weblink in your project's README.

I'm also adding mention of Kotlin. Jolt JNI works equally well with Java and Kotlin, so it's a nice freebie.
Presumably Jolt JNI will also work with Scala, Groovy, and Clojure.

I've made good progress on Jolt JNI since September, when the weblink was created.
Vehicles and soft bodies work great, and there's an OpenGL-based visualization add-on that works
equally well on Windows, Linux, and macOS.

I'm happy to answer any questions you have about the project.