### PR TITLE
Add DropSample to simulate a falling cube

### DIFF
--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -112,6 +112,8 @@ JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, AllowedDOFsTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, ShapeFilterTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, SimShapeFilterTest)
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, GyroscopicForceTest)
+#include <Tests/General/DropSample.h> // Corrected placement for the include
+JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, DropSample)
 #ifdef JPH_OBJECT_STREAM
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, LoadSaveSceneTest)
 #endif // JPH_OBJECT_STREAM
@@ -159,6 +161,7 @@ static TestNameAndRTTI sGeneralTests[] =
 	{ "Shape Filter (Collision Detection)",	JPH_RTTI(ShapeFilterTest) },
 	{ "Shape Filter (Simulation)",			JPH_RTTI(SimShapeFilterTest) },
 	{ "Gyroscopic Force",					JPH_RTTI(GyroscopicForceTest) },
+	{ "Drop Sample",						JPH_RTTI(DropSample) },
 };
 
 JPH_DECLARE_RTTI_FOR_FACTORY(JPH_NO_EXPORT, DistanceConstraintTest)

--- a/Samples/Tests/General/DropSample.cpp
+++ b/Samples/Tests/General/DropSample.cpp
@@ -1,0 +1,47 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2023 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#include <TestFramework.h>
+
+#include <Tests/General/DropSample.h>
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Layers.h> // Assuming Layers.h is in the Samples directory or include path
+
+JPH_IMPLEMENT_RTTI_VIRTUAL(DropSample)
+{
+	JPH_ADD_BASE_CLASS(DropSample, Test)
+}
+
+const char *DropSample::GetDescription() const
+{
+	return "A sample that simulates a dropping cube.";
+}
+
+void DropSample::Initialize()
+{
+	// Floor
+	CreateFloor();
+
+	// Create a box shape
+	float box_half_extent = 2.0f;
+	BoxShapeSettings box_shape_settings(Vec3(box_half_extent, box_half_extent, box_half_extent));
+
+	// Create the shape
+	ShapeSettings::ShapeResult box_shape_result = box_shape_settings.Create();
+	ShapeRefC box_shape = box_shape_result.Get(); // We don't expect an error here, but you can check box_shape_result for HasError() / GetError()
+
+	// Create the settings for the body itself.
+	BodyCreationSettings box_settings(box_shape, RVec3(0.0_r, 20.0_r, 0.0_r), Quat::sIdentity(), EMotionType::Dynamic, Layers::MOVING);
+
+	// Create the actual rigid body
+	mBodyInterface->CreateAndAddBody(box_settings, EActivation::Activate);
+}
+
+void DropSample::GetInitialCamera(CameraState& ioState) const
+{
+	// Position the camera looking at the origin
+	ioState.mPos = RVec3(0, 25, 25);
+	ioState.mForward = Vec3(0, -0.5f, -1).Normalized();
+}

--- a/Samples/Tests/General/DropSample.h
+++ b/Samples/Tests/General/DropSample.h
@@ -1,0 +1,23 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2023 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Tests/Test.h>
+
+// Simple test that drops a box from a height.
+class DropSample : public Test
+{
+public:
+	JPH_DECLARE_RTTI_VIRTUAL(JPH_NO_EXPORT, DropSample)
+
+	// Get the description of this sample
+	virtual const char *	GetDescription() const override;
+
+	// Initialize the test
+	virtual void			Initialize() override;
+
+	// Override to specify the initial camera state (local to GetCameraPivot)
+	virtual void			GetInitialCamera(CameraState& ioState) const override;
+};


### PR DESCRIPTION
This commit introduces a new sample named `DropSample`.

Features:
- Creates a simple cube shape.
- Simulates the cube dropping onto a ground plane under gravity.
- Integrates into the existing SamplesApp framework for selection and viewing.

The `DropSample` class is implemented in `Samples/Tests/General/DropSample.h` and `Samples/Tests/General/DropSample.cpp`. It inherits from the `Test` base class and provides:
- A description for the sample menu.
- Initialization logic to create a floor and a dynamic box body.
- Initial camera setup for viewing the simulation.

The sample has been registered in `SamplesApp.cpp` by including its header, declaring its RTTI, and adding it to the list of general tests.

Compilation of `DropSample.cpp` and the modified `SamplesApp.cpp` was successful. Linking of the final `SamplesApp` executable was not possible in the environment due to missing Vulkan/DirectX SDKs, but the core code changes are complete.