### PR TITLE
Allow SerializableObjects to be copy constructed only by derived classes

### DIFF
--- a/Jolt/ObjectStream/SerializableObject.h
+++ b/Jolt/ObjectStream/SerializableObject.h
@@ -152,13 +152,19 @@ public:																												\
 /// Classes must be derived from SerializableObject if you want to be able to save pointers or
 /// reference counting pointers to objects of this or derived classes. The type will automatically
 /// be determined during serialization and upon deserialization it will be restored correctly.
-class JPH_EXPORT SerializableObject : public NonCopyable
+class JPH_EXPORT SerializableObject
 {
 	JPH_DECLARE_SERIALIZABLE_ABSTRACT_BASE(JPH_EXPORT, SerializableObject)
 
 public:
-	/// Constructor
+	/// Destructor
 	virtual						~SerializableObject() = default;
+
+protected:
+	/// Don't allow (copy) constructing this base class, but allow derived classes to (copy) construct themselves
+								SerializableObject() = default;
+								SerializableObject(const SerializableObject &) = default;
+	SerializableObject &		operator = (const SerializableObject &) = default;
 };
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Collision/GroupFilter.h
+++ b/Jolt/Physics/Collision/GroupFilter.h
@@ -34,6 +34,11 @@ public:
 	static GroupFilterResult	sRestoreFromBinaryState(StreamIn &inStream);
 
 protected:
+	/// Don't allow (copy) constructing this base class, but allow derived classes to (copy) construct themselves
+								GroupFilter() = default;
+								GroupFilter(const GroupFilter &) = default;
+	GroupFilter &				operator = (const GroupFilter &) = default;
+
 	/// This function should not be called directly, it is used by sRestoreFromBinaryState.
 	virtual void				RestoreBinaryState(StreamIn &inStream);
 };

--- a/Jolt/Physics/Collision/PhysicsMaterial.h
+++ b/Jolt/Physics/Collision/PhysicsMaterial.h
@@ -24,7 +24,8 @@ class JPH_EXPORT PhysicsMaterial : public SerializableObject, public RefTarget<P
 	JPH_DECLARE_SERIALIZABLE_VIRTUAL(JPH_EXPORT, PhysicsMaterial)
 
 public:
-	/// Virtual destructor
+	/// Constructor
+											PhysicsMaterial() = default;
 	virtual									~PhysicsMaterial() override = default;
 
 	/// Default material that is used when a shape has no materials defined
@@ -43,6 +44,10 @@ public:
 	static PhysicsMaterialResult			sRestoreFromBinaryState(StreamIn &inStream);
 
 protected:
+	/// Don't allow copy constructing this base class, but allow derived classes to copy themselves
+											PhysicsMaterial(const PhysicsMaterial &) = default;
+	PhysicsMaterial &						operator = (const PhysicsMaterial &) = default;
+
 	/// This function should not be called directly, it is used by sRestoreFromBinaryState.
 	virtual void							RestoreBinaryState(StreamIn &inStream);
 };

--- a/Jolt/Physics/Constraints/Constraint.h
+++ b/Jolt/Physics/Constraints/Constraint.h
@@ -94,6 +94,11 @@ public:
 	uint64						mUserData = 0;
 
 protected:
+	/// Don't allow (copy) constructing this base class, but allow derived classes to (copy) construct themselves
+								ConstraintSettings() = default;
+								ConstraintSettings(const ConstraintSettings &) = default;
+	ConstraintSettings &		operator = (const ConstraintSettings &) = default;
+
 	/// This function should not be called directly, it is used by sRestoreFromBinaryState.
 	virtual void				RestoreBinaryState(StreamIn &inStream);
 };

--- a/Jolt/Physics/Constraints/PathConstraintPath.h
+++ b/Jolt/Physics/Constraints/PathConstraintPath.h
@@ -60,6 +60,11 @@ public:
 	static PathResult	sRestoreFromBinaryState(StreamIn &inStream);
 
 protected:
+	/// Don't allow (copy) constructing this base class, but allow derived classes to (copy) construct themselves
+						PathConstraintPath() = default;
+						PathConstraintPath(const PathConstraintPath &) = default;
+	PathConstraintPath &operator = (const PathConstraintPath &) = default;
+
 	/// This function should not be called directly, it is used by sRestoreFromBinaryState.
 	virtual void		RestoreBinaryState(StreamIn &inStream);
 


### PR DESCRIPTION
Allow PhysicsMaterial to be copy constructed only by derived classes
Disallow ConstraintSettings to be (copy) constructed, it always needs a derived class

Fixes #1663