### PR TITLE
Fixed bug in OptimizeBroadPhase

### DIFF
--- a/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/BroadPhaseQuadTree.cpp
@@ -73,6 +73,7 @@ void BroadPhaseQuadTree::Optimize()
 {
 	JPH_PROFILE_FUNCTION();
 
+	// Free the previous tree so we can create a new optimized tree
 	FrameSync();
 
 	LockModifications();
@@ -80,7 +81,7 @@ void BroadPhaseQuadTree::Optimize()
 	for (uint l = 0; l < mNumLayers; ++l)
 	{
 		QuadTree &tree = mLayers[l];
-		if (tree.HasBodies())
+		if (tree.HasBodies() || tree.IsDirty())
 		{
 			QuadTree::UpdateState update_state;
 			tree.UpdatePrepare(mBodyManager->GetBodies(), mTracking, update_state, true);
@@ -89,6 +90,9 @@ void BroadPhaseQuadTree::Optimize()
 	}
 
 	UnlockModifications();
+
+	// Free the tree from before we created a new optimized tree
+	FrameSync();
 
 	mNextLayerToUpdate = 0;
 }

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -301,7 +301,7 @@ void QuadTree::UpdatePrepare(const BodyVector &inBodies, TrackingVector &ioTrack
 #endif
 
 	// Create space for all body ID's
-	NodeID *node_ids = new NodeID [mNumBodies];
+	NodeID *node_ids = mNumBodies > 0? new NodeID [mNumBodies] : nullptr;
 	NodeID *cur_node_id = node_ids;
 
 	// Collect all bodies


### PR DESCRIPTION
- A tree that had all its bodies removed would never be optimized and never release its empty nodes
- Quad tree nodes were not released until the next PhysicsSystem::Update / OptimizeBroadPhase

See https://github.com/godotengine/godot/issues/107951