### PR TITLE
Vehicle serialization bugfixes

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -30,6 +30,8 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * Added an epsilon to the `CastRay` / `CastShape` early out condition to avoid dividing by a very small number and overflowing to INF. This can cause a float overflow exception.
 * Fixed Samples requiring Vulkan extension `VK_EXT_device_address_binding_report` without checking if it is available.
 * Fixed Vulkan warning in Samples: VkSemaphore is being signaled by VkQueue but it may still be in use by VkSwapchainKHR.
+* Fixed incorrect RTTI definition of MotorcycleControllerSettings which led to the members of WheeledVehicleControllerSettings not being serialized.
+* Implemented missing VehicleConstraint::GetConstraintSettings function.
 
 ## v5.3.0
 

--- a/Jolt/Physics/Vehicle/MotorcycleController.cpp
+++ b/Jolt/Physics/Vehicle/MotorcycleController.cpp
@@ -17,7 +17,7 @@ JPH_NAMESPACE_BEGIN
 
 JPH_IMPLEMENT_SERIALIZABLE_VIRTUAL(MotorcycleControllerSettings)
 {
-	JPH_ADD_BASE_CLASS(MotorcycleControllerSettings, VehicleControllerSettings)
+	JPH_ADD_BASE_CLASS(MotorcycleControllerSettings, WheeledVehicleControllerSettings)
 
 	JPH_ADD_ATTRIBUTE(MotorcycleControllerSettings, mMaxLeanAngle)
 	JPH_ADD_ATTRIBUTE(MotorcycleControllerSettings, mLeanSpringConstant)
@@ -289,5 +289,18 @@ void MotorcycleController::Draw(DebugRenderer *inRenderer) const
 }
 
 #endif // JPH_DEBUG_RENDERER
+
+Ref<VehicleControllerSettings> MotorcycleController::GetSettings() const
+{
+	MotorcycleControllerSettings *settings = new MotorcycleControllerSettings;
+	ToSettings(*settings);
+	settings->mMaxLeanAngle = mMaxLeanAngle;
+	settings->mLeanSpringConstant = mLeanSpringConstant;
+	settings->mLeanSpringDamping = settings->mLeanSpringDamping;
+	settings->mLeanSpringIntegrationCoefficient = mLeanSpringIntegrationCoefficient;
+	settings->mLeanSpringIntegrationCoefficientDecay = mLeanSpringIntegrationCoefficientDecay;
+	settings->mLeanSmoothingFactor = mLeanSmoothingFactor;
+	return settings;
+}
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Vehicle/MotorcycleController.h
+++ b/Jolt/Physics/Vehicle/MotorcycleController.h
@@ -83,6 +83,9 @@ public:
 	void						SetLeanSmoothingFactor(float inFactor)				{ mLeanSmoothingFactor = inFactor; }
 	float						GetLeanSmoothingFactor() const						{ return mLeanSmoothingFactor; }
 
+	// See: VehicleController
+	virtual Ref<VehicleControllerSettings> GetSettings() const override;
+
 protected:
 	// See: VehicleController
 	virtual void				PreCollide(float inDeltaTime, PhysicsSystem &inPhysicsSystem) override;

--- a/Jolt/Physics/Vehicle/TrackedVehicleController.cpp
+++ b/Jolt/Physics/Vehicle/TrackedVehicleController.cpp
@@ -534,4 +534,14 @@ void TrackedVehicleController::RestoreState(StateRecorder &inStream)
 		t.RestoreState(inStream);
 }
 
+Ref<VehicleControllerSettings> TrackedVehicleController::GetSettings() const
+{
+	TrackedVehicleControllerSettings *settings = new TrackedVehicleControllerSettings;
+	settings->mEngine = mEngine;
+	settings->mTransmission = mTransmission;
+	for (size_t i = 0; i < std::size(mTracks); ++i)
+		settings->mTracks[i] = mTracks[i];
+	return settings;
+}
+
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Vehicle/TrackedVehicleController.h
+++ b/Jolt/Physics/Vehicle/TrackedVehicleController.h
@@ -129,6 +129,9 @@ public:
 	void						SetRPMMeter(Vec3Arg inPosition, float inSize) { mRPMMeterPosition = inPosition; mRPMMeterSize = inSize; }
 #endif // JPH_DEBUG_RENDERER
 
+	// See: VehicleController
+	virtual Ref<VehicleControllerSettings> GetSettings() const override;
+
 protected:
 	/// Synchronize angular velocities of left and right tracks according to their ratios
 	void						SyncLeftRightTracks();

--- a/Jolt/Physics/Vehicle/VehicleConstraint.cpp
+++ b/Jolt/Physics/Vehicle/VehicleConstraint.cpp
@@ -687,8 +687,17 @@ void VehicleConstraint::RestoreState(StateRecorder &inStream)
 
 Ref<ConstraintSettings> VehicleConstraint::GetConstraintSettings() const
 {
-	JPH_ASSERT(false); // Not implemented yet
-	return nullptr;
+	VehicleConstraintSettings *settings = new VehicleConstraintSettings;
+	ToConstraintSettings(*settings);
+	settings->mUp = mUp;
+	settings->mForward = mForward;
+	settings->mMaxPitchRollAngle = ACos(mCosMaxPitchRollAngle);
+	settings->mWheels.resize(mWheels.size());
+	for (Wheels::size_type w = 0; w < mWheels.size(); ++w)
+		settings->mWheels[w] = const_cast<WheelSettings *>(mWheels[w]->mSettings.GetPtr());
+	settings->mAntiRollBars = mAntiRollBars;
+	settings->mController = mController->GetSettings();
+	return settings;
 }
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Vehicle/VehicleController.h
+++ b/Jolt/Physics/Vehicle/VehicleController.h
@@ -50,6 +50,9 @@ public:
 	VehicleConstraint &			GetConstraint()								{ return mConstraint; }
 	const VehicleConstraint &	GetConstraint() const						{ return mConstraint; }
 
+	/// Recreate the settings for this controller
+	virtual Ref<VehicleControllerSettings> GetSettings() const = 0;
+
 protected:
 	// The functions below are only for the VehicleConstraint
 	friend class VehicleConstraint;

--- a/Jolt/Physics/Vehicle/WheeledVehicleController.cpp
+++ b/Jolt/Physics/Vehicle/WheeledVehicleController.cpp
@@ -848,4 +848,19 @@ void WheeledVehicleController::RestoreState(StateRecorder &inStream)
 	mTransmission.RestoreState(inStream);
 }
 
+void WheeledVehicleController::ToSettings(WheeledVehicleControllerSettings &outSettings) const
+{
+	outSettings.mEngine = mEngine;
+	outSettings.mTransmission = mTransmission;
+	outSettings.mDifferentials = mDifferentials;
+	outSettings.mDifferentialLimitedSlipRatio = mDifferentialLimitedSlipRatio;
+}
+
+Ref<VehicleControllerSettings> WheeledVehicleController::GetSettings() const
+{
+	WheeledVehicleControllerSettings *settings = new WheeledVehicleControllerSettings;
+	ToSettings(*settings);
+	return settings;
+}
+
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Vehicle/WheeledVehicleController.h
+++ b/Jolt/Physics/Vehicle/WheeledVehicleController.h
@@ -155,7 +155,13 @@ public:
 	void						SetRPMMeter(Vec3Arg inPosition, float inSize) { mRPMMeterPosition = inPosition; mRPMMeterSize = inSize; }
 #endif // JPH_DEBUG_RENDERER
 
+	// See: VehicleController
+	virtual Ref<VehicleControllerSettings> GetSettings() const override;
+
 protected:
+	/// Convert controller back to settings
+	void						ToSettings(WheeledVehicleControllerSettings &outSettings) const;
+
 	// See: VehicleController
 	virtual Wheel *				ConstructWheel(const WheelSettings &inWheel) const override { JPH_ASSERT(IsKindOf(&inWheel, JPH_RTTI(WheelSettingsWV))); return new WheelWV(static_cast<const WheelSettingsWV &>(inWheel)); }
 	virtual bool				AllowSleep() const override;


### PR DESCRIPTION
* Fixed incorrect RTTI definition of MotorcycleControllerSettings which led to the members of WheeledVehicleControllerSettings not being serialized.
* Implemented missing VehicleConstraint::GetConstraintSettings function.

Fixes #1743