### PR TITLE
Export IslandBuilder class by adding JPH_EXPORT

### DIFF
--- a/Jolt/Physics/IslandBuilder.h
+++ b/Jolt/Physics/IslandBuilder.h
@@ -15,7 +15,7 @@ class TempAllocator;
 //#define JPH_VALIDATE_ISLAND_BUILDER
 
 /// Keeps track of connected bodies and builds islands for multithreaded velocity/position update
-class IslandBuilder : public NonCopyable
+class JPH_EXPORT IslandBuilder : public NonCopyable
 {
 public:
 	/// Destructor


### PR DESCRIPTION
This is so that I can create new island-affecting constraints similar to what VehicleConstraint::BuildIslands does when using Jolt as a DLL!

There might be more non-exported classes but I haven't encountered any besides this so far in my project. Big thanks to JRouwe and other contributors for their time and effort put into this repo and answering questions/PRs.
