### PR TITLE
Added new define JPH_TRACK_SIMULATION_STATS

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -78,6 +78,9 @@ option(TRACK_BROADPHASE_STATS "Track Broadphase Stats" OFF)
 # Setting to periodically trace narrowphase stats to help determine which collision queries could be optimized
 option(TRACK_NARROWPHASE_STATS "Track Narrowphase Stats" OFF)
 
+# Setting to track simulation timings per body
+option(JPH_TRACK_SIMULATION_STATS "Track Simulation Stats" OFF)
+
 # Enable the debug renderer in the Debug and Release builds. Note that DEBUG_RENDERER_IN_DISTRIBUTION will override this setting.
 option(DEBUG_RENDERER_IN_DEBUG_AND_RELEASE "Enable debug renderer in Debug and Release builds" ON)
 

--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -4,6 +4,10 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 
 ## Unreleased Changes
 
+### New functionality
+
+* Added new define `JPH_TRACK_SIMULATION_STATS` which tracks simulation statistics on a per body basis. This can be used to figure out bodies are the most expensive to simulate.
+
 ### Bug Fixes
 
 * A 6DOF constraint that constrains all rotation axis in combination with a body that has some of its rotation axis locked would not constrain the rotation in the unlocked axis

--- a/Jolt/Core/Profiler.h
+++ b/Jolt/Core/Profiler.h
@@ -113,6 +113,9 @@ public:
 	/// Remove a thread from being instrumented
 	void						RemoveThread(ProfileThread *inThread);
 
+	/// Get the amount of ticks per second, note that this number will never be fully accurate as the amount of ticks per second may vary with CPU load, so this number is only to be used to give an indication of time for profiling purposes
+	uint64						GetProcessorTicksPerSecond() const;
+
 	/// Singleton instance
 	static Profiler *			sInstance;
 
@@ -166,9 +169,6 @@ private:
 
 	/// We measure the amount of ticks per second, this function resets the reference time point
 	void						UpdateReferenceTime();
-
-	/// Get the amount of ticks per second, note that this number will never be fully accurate as the amount of ticks per second may vary with CPU load, so this number is only to be used to give an indication of time for profiling purposes
-	uint64						GetProcessorTicksPerSecond() const;
 
 	/// Dump profiling statistics
 	void						DumpInternal();

--- a/Jolt/Jolt.cmake
+++ b/Jolt/Jolt.cmake
@@ -562,6 +562,11 @@ if (TRACK_NARROWPHASE_STATS)
 	target_compile_definitions(Jolt PUBLIC JPH_TRACK_NARROWPHASE_STATS)
 endif()
 
+# Setting to track simulation timings per body
+if (JPH_TRACK_SIMULATION_STATS)
+	target_compile_definitions(Jolt PUBLIC JPH_TRACK_SIMULATION_STATS)
+endif()
+
 # Enable the debug renderer
 if (DEBUG_RENDERER_IN_DISTRIBUTION)
 	target_compile_definitions(Jolt PUBLIC "JPH_DEBUG_RENDERER")

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1189,7 +1189,7 @@ void BodyManager::ReportSimulationStats()
 {
 	UniqueLock lock(mActiveBodiesMutex JPH_IF_ENABLE_ASSERTS(, this, EPhysicsLockTypes::ActiveBodiesList));
 
-	Trace("BodyID, IslandIndex, NarrowPhaseUs, VelocityConstraintUs, PositionConstraintUS, CCDUs, NumContactConstraints, NumVelocitySteps, NumPositionSteps");
+	Trace("BodyID, IslandIndex, NarrowPhase (us), VelocityConstraint (us), PositionConstraint (us), CCD (us), NumContactConstraints, NumVelocitySteps, NumPositionSteps");
 
 	double us_per_tick = 1000000.0 / Profiler::sInstance->GetProcessorTicksPerSecond();
 

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1212,7 +1212,6 @@ void BodyManager::ReportSimulationStats()
 		}
 }
 #endif // JPH_PROFILE_ENABLED
-
 #endif // JPH_TRACK_SIMULATION_STATS
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -613,7 +613,7 @@ void BodyManager::DeactivateBodies(const BodyID *inBodyIDs, int inNumber)
 			#ifdef JPH_TRACK_SIMULATION_STATS
 				// Reset simulation stats
 				body.mMotionProperties->mSimulationStats.Reset();
-			#endif		
+			#endif
 
 				// Reset velocity
 				body.mMotionProperties->mLinearVelocity = Vec3::sZero();

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1183,6 +1183,36 @@ void BodyManager::ResetSimulationStats()
 			body->mMotionProperties->GetSimulationStats().Reset();
 		}
 }
+
+#ifdef JPH_PROFILE_ENABLED
+void BodyManager::ReportSimulationStats()
+{
+	UniqueLock lock(mActiveBodiesMutex JPH_IF_ENABLE_ASSERTS(, this, EPhysicsLockTypes::ActiveBodiesList));
+
+	Trace("BodyID, IslandIndex, NarrowPhaseUs, VelocityConstraintUs, PositionConstraintUS, CCDUs, NumContactConstraints, NumVelocitySteps, NumPositionSteps");
+
+	double us_per_tick = 1000000.0 / Profiler::sInstance->GetProcessorTicksPerSecond();
+
+	for (uint type = 0; type < cBodyTypeCount; ++type)
+		for (BodyID *id = mActiveBodies[type], *id_end = mActiveBodies[type] + mNumActiveBodies[type].load(memory_order_relaxed); id < id_end; ++id)
+		{
+			const Body *body = mBodies[id->GetIndex()];
+			const MotionProperties *mp = body->mMotionProperties;
+			const MotionProperties::SimulationStats &stats = mp->GetSimulationStats();
+			Trace("%u, %u, %.2f, %.2f, %.2f, %.2f, %u, %u, %u",
+				body->GetID().GetIndex(),
+				mp->GetIslandIndexInternal(),
+				double(stats.mNarrowPhaseTicks) * us_per_tick,
+				double(stats.mVelocityConstraintTicks) * us_per_tick,
+				double(stats.mPositionConstraintTicks) * us_per_tick,
+				double(stats.mCCDTicks) * us_per_tick,
+				stats.mNumContactConstraints.load(memory_order_relaxed),
+				stats.mNumVelocitySteps,
+				stats.mNumPositionSteps);
+		}
+}
+#endif // JPH_PROFILE_ENABLED
+
 #endif // JPH_TRACK_SIMULATION_STATS
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1172,6 +1172,8 @@ void BodyManager::ValidateActiveBodyBounds()
 #ifdef JPH_TRACK_SIMULATION_STATS
 void BodyManager::ResetSimulationStats()
 {
+	JPH_PROFILE_FUNCTION();
+
 	UniqueLock lock(mActiveBodiesMutex JPH_IF_ENABLE_ASSERTS(, this, EPhysicsLockTypes::ActiveBodiesList));
 
 	for (uint type = 0; type < cBodyTypeCount; ++type)

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -292,6 +292,10 @@ public:
 	void							ValidateActiveBodyBounds();
 #endif // JPH_DEBUG
 
+#ifdef JPH_TRACK_SIMULATION_STATS
+	void							ResetSimulationStats();
+#endif
+
 private:
 	/// Increment and get the sequence number of the body
 #ifdef JPH_COMPILER_CLANG

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -295,6 +295,11 @@ public:
 #ifdef JPH_TRACK_SIMULATION_STATS
 	/// Resets the per body simulation stats
 	void							ResetSimulationStats();
+
+#ifdef JPH_PROFILE_ENABLED
+	/// Dump the per body simulation stats to the TTY
+	void							ReportSimulationStats();
+#endif
 #endif
 
 private:

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -293,6 +293,7 @@ public:
 #endif // JPH_DEBUG
 
 #ifdef JPH_TRACK_SIMULATION_STATS
+	/// Resets the per body simulation stats
 	void							ResetSimulationStats();
 #endif
 

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -190,11 +190,12 @@ public:
 	/// Stats for this body. These are average for the simulation island the body was part of.
 	struct SimulationStats
 	{
-		void				Reset()															{ mNarrowPhaseTicks = 0; mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mNumContactConstraints = 0; mNumVelocitySteps = 0; mNumPositionSteps = 0; }
+		void				Reset()															{ mNarrowPhaseTicks.store(0, memory_order_relaxed); mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mCCDTicks.store(0, memory_order_relaxed); mNumContactConstraints.store(0, memory_order_relaxed); mNumVelocitySteps = 0; mNumPositionSteps = 0; }
 
 		atomic<uint64>		mNarrowPhaseTicks = 0;											///< Number of processor ticks spent doing narrow phase collision detection
 		uint64				mVelocityConstraintTicks = 0;									///< Number of ticks spent solving velocity constraints
 		uint64				mPositionConstraintTicks = 0;									///< Number of ticks spent solving position constraints
+		atomic<uint64>		mCCDTicks = 0;													///< Number of ticks spent doing CCD
 		atomic<uint32>		mNumContactConstraints = 0;										///< Number of contact constraints created for this body
 		uint8				mNumVelocitySteps = 0;											///< Number of velocity iterations performed
 		uint8				mNumPositionSteps = 0;											///< Number of position iterations performed

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -187,15 +187,17 @@ public:
 	uint					GetNumPositionStepsOverride() const								{ return mNumPositionStepsOverride; }
 
 #ifdef JPH_TRACK_SIMULATION_STATS
+	/// Stats for this body. These are average for the simulation island the body was part of.
 	struct SimulationStats
 	{
-		void				Reset()															{ mCollisionTicks = 0; mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mNumVelocitySteps = 0; mNumPositionSteps = 0; }
+		void				Reset()															{ mNarrowPhaseTicks = 0; mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mNumContactConstraints = 0; mNumVelocitySteps = 0; mNumPositionSteps = 0; }
 
-		atomic<uint64>		mCollisionTicks = 0;
-		atomic<uint64>		mVelocityConstraintTicks = 0;
-		atomic<uint64>		mPositionConstraintTicks = 0;
-		uint8				mNumVelocitySteps = 0;
-		uint8				mNumPositionSteps = 0;
+		atomic<uint64>		mNarrowPhaseTicks = 0;											///< Number of processor ticks spent doing narrow phase collision detection
+		uint64				mVelocityConstraintTicks = 0;									///< Number of ticks spent solving velocity constraints
+		uint64				mPositionConstraintTicks = 0;									///< Number of ticks spent solving position constraints
+		atomic<uint32>		mNumContactConstraints = 0;										///< Number of contact constraints created for this body
+		uint8				mNumVelocitySteps = 0;											///< Number of velocity iterations performed
+		uint8				mNumPositionSteps = 0;											///< Number of position iterations performed
 	};
 
 	const SimulationStats &	GetSimulationStats() const										{ return mSimulationStats; }

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -186,6 +186,22 @@ public:
 	void					SetNumPositionStepsOverride(uint inN)							{ JPH_ASSERT(inN < 256); mNumPositionStepsOverride = uint8(inN); }
 	uint					GetNumPositionStepsOverride() const								{ return mNumPositionStepsOverride; }
 
+#ifdef JPH_TRACK_SIMULATION_STATS
+	struct SimulationStats
+	{
+		void				Reset()															{ mCollisionTicks = 0; mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mNumVelocitySteps = 0; mNumPositionSteps = 0; }
+
+		atomic<uint64>		mCollisionTicks = 0;
+		atomic<uint64>		mVelocityConstraintTicks = 0;
+		atomic<uint64>		mPositionConstraintTicks = 0;
+		uint8				mNumVelocitySteps = 0;
+		uint8				mNumPositionSteps = 0;
+	};
+
+	const SimulationStats &	GetSimulationStats() const										{ return mSimulationStats; }
+	SimulationStats &		GetSimulationStats()											{ return mSimulationStats; }
+#endif // JPH_TRACK_SIMULATION_STATS
+
 	////////////////////////////////////////////////////////////
 	// FUNCTIONS BELOW THIS LINE ARE FOR INTERNAL USE ONLY
 	////////////////////////////////////////////////////////////
@@ -275,6 +291,10 @@ private:
 	EBodyType				mCachedBodyType;												///< Copied from Body::mBodyType and cached for asserting purposes
 	EMotionType				mCachedMotionType;												///< Copied from Body::mMotionType and cached for asserting purposes
 #endif
+
+#ifdef JPH_TRACK_SIMULATION_STATS
+	SimulationStats			mSimulationStats;
+#endif // JPH_TRACK_SIMULATION_STATS
 };
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -980,6 +980,14 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 			if (sDrawContactManifolds)
 				constraint.Draw(DebugRenderer::sInstance, Color::sYellow);
 		#endif // JPH_DEBUG_RENDERER
+
+		#ifdef JPH_TRACK_SIMULATION_STATS
+			// Track new contact constraints
+			if (!body1->IsStatic())
+				body1->GetMotionPropertiesUnchecked()->GetSimulationStats().mNumContactConstraints.fetch_add(1, memory_order_relaxed);
+			if (!body2->IsStatic())
+				body2->GetMotionPropertiesUnchecked()->GetSimulationStats().mNumContactConstraints.fetch_add(1, memory_order_relaxed);
+		#endif
 		}
 
 		// Mark contact as persisted so that we won't fire OnContactRemoved callbacks
@@ -1222,6 +1230,14 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 		if (sDrawContactManifolds)
 			constraint.Draw(DebugRenderer::sInstance, Color::sOrange);
 	#endif // JPH_DEBUG_RENDERER
+
+	#ifdef JPH_TRACK_SIMULATION_STATS
+		// Track new contact constraints
+		if constexpr (Type1 != EMotionType::Static)
+			inBody1.GetMotionPropertiesUnchecked()->GetSimulationStats().mNumContactConstraints.fetch_add(1, memory_order_relaxed);
+		if constexpr (Type2 != EMotionType::Static)
+			inBody2.GetMotionPropertiesUnchecked()->GetSimulationStats().mNumContactConstraints.fetch_add(1, memory_order_relaxed);
+	#endif
 	}
 	else
 	{

--- a/Jolt/Physics/IslandBuilder.cpp
+++ b/Jolt/Physics/IslandBuilder.cpp
@@ -382,6 +382,12 @@ void IslandBuilder::Finalize(const BodyID *inActiveBodies, uint32 inNumActiveBod
 	SortIslands(inTempAllocator);
 
 	mNumPositionSteps = (uint8 *)inTempAllocator->Allocate(mNumIslands * sizeof(uint8));
+
+#ifdef JPH_TRACK_SIMULATION_STATS
+	mIslandStats = (IslandStats *)inTempAllocator->Allocate(mNumIslands * sizeof(IslandStats));
+	for (uint32 i = 0; i < mNumIslands; ++i)
+		new (&mIslandStats[i]) IslandStats();
+#endif
 }
 
 void IslandBuilder::GetBodiesInIsland(uint32 inIslandIndex, BodyID *&outBodiesBegin, BodyID *&outBodiesEnd) const
@@ -431,6 +437,10 @@ bool IslandBuilder::GetContactsInIsland(uint32 inIslandIndex, uint32 *&outContac
 void IslandBuilder::ResetIslands(TempAllocator *inTempAllocator)
 {
 	JPH_PROFILE_FUNCTION();
+
+#ifdef JPH_TRACK_SIMULATION_STATS
+	inTempAllocator->Free(mIslandStats, mNumIslands * sizeof(IslandStats));
+#endif
 
 	inTempAllocator->Free(mNumPositionSteps, mNumIslands * sizeof(uint8));
 

--- a/Jolt/Physics/IslandBuilder.h
+++ b/Jolt/Physics/IslandBuilder.h
@@ -54,6 +54,18 @@ public:
 	void					SetNumPositionSteps(uint32 inIslandIndex, uint inNumPositionSteps)	{ JPH_ASSERT(inIslandIndex < mNumIslands); JPH_ASSERT(inNumPositionSteps < 256); mNumPositionSteps[inIslandIndex] = uint8(inNumPositionSteps); }
 	uint					GetNumPositionSteps(uint32 inIslandIndex) const						{ JPH_ASSERT(inIslandIndex < mNumIslands); return mNumPositionSteps[inIslandIndex]; }
 
+#ifdef JPH_TRACK_SIMULATION_STATS
+	struct IslandStats
+	{
+		atomic<uint64>		mVelocityConstraintTicks = 0;
+		atomic<uint64>		mPositionConstraintTicks = 0;
+		uint8				mNumVelocitySteps = 0;
+	};
+
+	/// Tracks simulation stats per island
+	IslandStats &			GetIslandStats(uint32 inIslandIndex)								{ return mIslandStats[inIslandIndex]; }
+#endif
+
 	/// After you're done calling the three functions above, call this function to free associated data
 	void					ResetIslands(TempAllocator *inTempAllocator);
 
@@ -100,6 +112,10 @@ private:
 	uint32 *				mIslandsSorted = nullptr;						///< A list of island indices in order of most constraints first
 
 	uint8 *					mNumPositionSteps = nullptr;					///< Number of position steps for each island
+
+#ifdef JPH_TRACK_SIMULATION_STATS
+	IslandStats *			mIslandStats = nullptr;							///< Per island statistics
+#endif
 
 	// Counters
 	uint32					mMaxActiveBodies;								///< Maximum size of the active bodies list (see BodyManager::mActiveBodies)

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -1513,9 +1513,6 @@ void PhysicsSystem::JobSolveVelocityConstraints(PhysicsUpdateContext *ioContext,
 				mContactManager.WarmStartVelocityConstraints(contacts_begin, contacts_end, warm_start_impulse_ratio, steps_calculator);
 				steps_calculator.Finalize();
 
-				// Store the number of position steps for later
-				mIslandBuilder.SetNumPositionSteps(island_idx, steps_calculator.GetNumPositionSteps());
-
 				// Solve velocity constraints
 				for (uint velocity_step = 0; velocity_step < steps_calculator.GetNumVelocitySteps(); ++velocity_step)
 				{
@@ -1528,6 +1525,9 @@ void PhysicsSystem::JobSolveVelocityConstraints(PhysicsUpdateContext *ioContext,
 				// Save back the lambdas in the contact cache for the warm start of the next physics update
 				mContactManager.StoreAppliedImpulses(contacts_begin, contacts_end);
 			}
+
+			// Store the number of position steps for later
+			mIslandBuilder.SetNumPositionSteps(island_idx, steps_calculator.GetNumPositionSteps());
 
 		#ifdef JPH_TRACK_SIMULATION_STATS
 			uint64 num_ticks = GetProcessorTickCount() - start_tick;

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -133,11 +133,11 @@ void PhysicsSystem::RemoveStepListener(PhysicsStepListener *inListener)
 void PhysicsSystem::GatherIslandStats()
 {
 	JPH_PROFILE_FUNCTION();
-	
+
 	for (uint32 island_idx = 0; island_idx < mIslandBuilder.GetNumIslands(); ++island_idx)
 	{
 		BodyID *bodies_begin, *bodies_end;
-		mIslandBuilder.GetBodiesInIsland(island_idx, bodies_begin, bodies_end);		
+		mIslandBuilder.GetBodiesInIsland(island_idx, bodies_begin, bodies_end);
 		uint64 num_bodies = bodies_end - bodies_begin;
 
 		// Equally distribute the stats over all bodies
@@ -1070,7 +1070,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 	#ifdef JPH_TRACK_SIMULATION_STATS
 		uint64 start_ticks = GetProcessorTickCount();
 	#endif
-	
+
 		// Create entry in the cache for this body pair
 		// Needs to happen irrespective if we found a collision or not (we want to remember that no collision was found too)
 		ContactConstraintManager::BodyPairHandle body_pair_handle = mContactManager.AddBodyPair(ioContactAllocator, *body1, *body2);
@@ -1310,7 +1310,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 
 			constraint_created = collector.mConstraintCreated;
 		}
-		
+
 	#ifdef JPH_TRACK_SIMULATION_STATS
 		// Track time spent processing collision for this body pair
 		uint64 num_ticks = GetProcessorTickCount() - start_ticks;
@@ -1327,7 +1327,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			body1->GetMotionProperties()->GetSimulationStats().mNarrowPhaseTicks.fetch_add(num_ticks, memory_order_relaxed);
 			body1->GetMotionProperties()->GetSimulationStats().mNarrowPhaseTicks.fetch_add(num_ticks, memory_order_relaxed);
 		}
-	#endif	
+	#endif
 	}
 
 	// If a contact constraint was created, we need to do some extra work
@@ -1512,10 +1512,10 @@ void PhysicsSystem::JobSolveVelocityConstraints(PhysicsUpdateContext *ioContext,
 				ConstraintManager::sWarmStartVelocityConstraints(active_constraints, constraints_begin, constraints_end, warm_start_impulse_ratio, steps_calculator);
 				mContactManager.WarmStartVelocityConstraints(contacts_begin, contacts_end, warm_start_impulse_ratio, steps_calculator);
 				steps_calculator.Finalize();
-	
+
 				// Store the number of position steps for later
 				mIslandBuilder.SetNumPositionSteps(island_idx, steps_calculator.GetNumPositionSteps());
-	
+
 				// Solve velocity constraints
 				for (uint velocity_step = 0; velocity_step < steps_calculator.GetNumVelocitySteps(); ++velocity_step)
 				{
@@ -1524,7 +1524,7 @@ void PhysicsSystem::JobSolveVelocityConstraints(PhysicsUpdateContext *ioContext,
 					if (!applied_impulse)
 						break;
 				}
-	
+
 				// Save back the lambdas in the contact cache for the warm start of the next physics update
 				mContactManager.StoreAppliedImpulses(contacts_begin, contacts_end);
 			}

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -283,6 +283,11 @@ private:
 	/// Tries to spawn a new FindCollisions job if max concurrency hasn't been reached yet
 	void						TrySpawnJobFindCollisions(PhysicsUpdateContext::Step *ioStep) const;
 
+#ifdef JPH_TRACK_SIMULATION_STATS
+	/// Gather stats from the islands and distribute them over the bodies
+	void						GatherIslandStats();
+#endif
+
 	using ContactAllocator = ContactConstraintManager::ContactAllocator;
 
 	/// Process narrow phase for a single body pair

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -255,6 +255,11 @@ public:
 	void						ReportBroadphaseStats()										{ mBroadPhase->ReportStats(); }
 #endif // JPH_TRACK_BROADPHASE_STATS
 
+#if defined(JPH_TRACK_SIMULATION_STATS) && defined(JPH_PROFILE_ENABLED)
+	/// Dump the per body simulation stats to the TTY
+	void						ReportSimulationStats()										{ mBodyManager.ReportSimulationStats(); }
+#endif
+
 private:
 	using CCDBody = PhysicsUpdateContext::Step::CCDBody;
 

--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -2170,6 +2170,12 @@ bool SamplesApp::UpdateFrame(float inDeltaTime)
 				mPlaybackMode = shift? EPlaybackMode::FastForward : EPlaybackMode::StepForward;
 			}
 			break;
+
+	#if defined(JPH_TRACK_SIMULATION_STATS) && defined(JPH_PROFILE_ENABLED)
+		case EKey::Y:
+			mPhysicsSystem->ReportSimulationStats();
+			break;
+	#endif
 		}
 
 	// Stop recording if record state is turned off


### PR DESCRIPTION
This tracks simulation statistics on a per body basis. It can be used to figure out bodies are the most expensive to simulate.