### PR TITLE
Extended simulation stats

### DIFF
--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1189,7 +1189,7 @@ void BodyManager::ReportSimulationStats()
 {
 	UniqueLock lock(mActiveBodiesMutex JPH_IF_ENABLE_ASSERTS(, this, EPhysicsLockTypes::ActiveBodiesList));
 
-	Trace("BodyID, IslandIndex, NarrowPhase (us), VelocityConstraint (us), PositionConstraint (us), CCD (us), NumContactConstraints, NumVelocitySteps, NumPositionSteps");
+	Trace("BodyID, IslandIndex, LargeIsland, BroadPhase (us), NarrowPhase (us), VelocityConstraint (us), PositionConstraint (us), UpdateBounds (us), CCD (us), NumContactConstraints, NumVelocitySteps, NumPositionSteps");
 
 	double us_per_tick = 1000000.0 / Profiler::sInstance->GetProcessorTicksPerSecond();
 
@@ -1199,12 +1199,15 @@ void BodyManager::ReportSimulationStats()
 			const Body *body = mBodies[id->GetIndex()];
 			const MotionProperties *mp = body->mMotionProperties;
 			const MotionProperties::SimulationStats &stats = mp->GetSimulationStats();
-			Trace("%u, %u, %.2f, %.2f, %.2f, %.2f, %u, %u, %u",
+			Trace("%u, %u, %s, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %u, %u, %u",
 				body->GetID().GetIndex(),
 				mp->GetIslandIndexInternal(),
+				stats.mIsLargeIsland? "True" : "False",
+				double(stats.mBroadPhaseTicks) * us_per_tick,
 				double(stats.mNarrowPhaseTicks) * us_per_tick,
 				double(stats.mVelocityConstraintTicks) * us_per_tick,
 				double(stats.mPositionConstraintTicks) * us_per_tick,
+				double(stats.mUpdateBoundsTicks) * us_per_tick,
 				double(stats.mCCDTicks) * us_per_tick,
 				stats.mNumContactConstraints.load(memory_order_relaxed),
 				stats.mNumVelocitySteps,

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -190,15 +190,18 @@ public:
 	/// Stats for this body. These are average for the simulation island the body was part of.
 	struct SimulationStats
 	{
-		void				Reset()															{ mNarrowPhaseTicks.store(0, memory_order_relaxed); mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mCCDTicks.store(0, memory_order_relaxed); mNumContactConstraints.store(0, memory_order_relaxed); mNumVelocitySteps = 0; mNumPositionSteps = 0; }
+		void				Reset()															{ mBroadPhaseTicks = 0; mNarrowPhaseTicks.store(0, memory_order_relaxed); mVelocityConstraintTicks = 0; mPositionConstraintTicks = 0; mUpdateBoundsTicks = 0; mCCDTicks.store(0, memory_order_relaxed); mNumContactConstraints.store(0, memory_order_relaxed); mNumVelocitySteps = 0; mNumPositionSteps = 0; mIsLargeIsland = false; }
 
-		atomic<uint64>		mNarrowPhaseTicks = 0;											///< Number of processor ticks spent doing narrow phase collision detection
+		uint64				mBroadPhaseTicks = 0;											///< Number of processor ticks spent doing broad phase collision detection
+		atomic<uint64>		mNarrowPhaseTicks = 0;											///< Number of ticks spent doing narrow phase collision detection
 		uint64				mVelocityConstraintTicks = 0;									///< Number of ticks spent solving velocity constraints
 		uint64				mPositionConstraintTicks = 0;									///< Number of ticks spent solving position constraints
+		uint64				mUpdateBoundsTicks = 0;											///< Number of ticks spent updating the broadphase and checking if the body should go to sleep
 		atomic<uint64>		mCCDTicks = 0;													///< Number of ticks spent doing CCD
 		atomic<uint32>		mNumContactConstraints = 0;										///< Number of contact constraints created for this body
 		uint8				mNumVelocitySteps = 0;											///< Number of velocity iterations performed
 		uint8				mNumPositionSteps = 0;											///< Number of position iterations performed
+		bool				mIsLargeIsland = false;											///< If this body was part of a large island
 	};
 
 	const SimulationStats &	GetSimulationStats() const										{ return mSimulationStats; }

--- a/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
+++ b/Jolt/Physics/Collision/BroadPhase/QuadTree.cpp
@@ -1452,6 +1452,10 @@ void QuadTree::FindCollidingPairs(const BodyVector &inBodies, const BodyID *inAc
 		const Body &body1 = *inBodies[b1_id.GetIndex()];
 		JPH_ASSERT(!body1.IsStatic());
 
+	#ifdef JPH_TRACK_SIMULATION_STATS
+		uint64 start_tick = GetProcessorTickCount();
+	#endif
+
 		// Expand the bounding box by the speculative contact distance
 		AABox bounds1 = body1.GetWorldSpaceBounds();
 		bounds1.ExpandBy(Vec3::sReplicate(inSpeculativeContactDistance));
@@ -1521,6 +1525,11 @@ void QuadTree::FindCollidingPairs(const BodyVector &inBodies, const BodyID *inAc
 			--top;
 		}
 		while (top >= 0);
+
+	#ifdef JPH_TRACK_SIMULATION_STATS
+		uint64 num_ticks = GetProcessorTickCount() - start_tick;
+		const_cast<MotionProperties::SimulationStats &>(body1.GetMotionPropertiesUnchecked()->GetSimulationStats()).mBroadPhaseTicks += num_ticks;
+	#endif
 	}
 
 	// Test that the root node was not swapped while finding collision pairs.

--- a/Jolt/Physics/IslandBuilder.h
+++ b/Jolt/Physics/IslandBuilder.h
@@ -59,7 +59,10 @@ public:
 	{
 		atomic<uint64>		mVelocityConstraintTicks = 0;
 		atomic<uint64>		mPositionConstraintTicks = 0;
+		atomic<uint64>		mUpdateBoundsTicks = 0;
 		uint8				mNumVelocitySteps = 0;
+		uint8				mNumPositionSteps = 0;												///< Tracking this a 2nd time since IslandBuilder::mNumPositionSteps is not filled in when there are no constraints or for large islands.
+		bool				mIsLargeIsland = false;
 	};
 
 	/// Tracks simulation stats per island


### PR DESCRIPTION
- Added time spent in the broad phase
- If part of large island
- Separate solve position ticks from update bounds ticks
- Only dynamic objects get solve velocity/position ticks assigned now