### PR TITLE
Fixed compilation error when using Jolt in conjunction with the _CRTDBG_MAP_ALLOC define on Windows

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -10,7 +10,9 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 
 ### Bug Fixes
 
-* A 6DOF constraint that constrains all rotation axis in combination with a body that has some of its rotation axis locked would not constrain the rotation in the unlocked axis
+* A 6DOF constraint that constrains all rotation axis in combination with a body that has some of its rotation axis locked would not constrain the rotation in the unlocked axis.
+* Added include <type_traits> for std::is_trivial to avoid compile error on macOS with clang 21.
+* Fixed compilation error when using Jolt in conjunction with the `_CRTDBG_MAP_ALLOC` define on Windows.
 
 ## v5.4.0
 

--- a/Jolt/Core/Array.h
+++ b/Jolt/Core/Array.h
@@ -238,7 +238,7 @@ private:
 	}
 
 	/// Free memory
-	inline void				free()
+	inline void				deallocate()
 	{
 		get_allocator().deallocate(mElements, mCapacity);
 		mElements = nullptr;
@@ -251,7 +251,7 @@ private:
 		if (mElements != nullptr)
 		{
 			clear();
-			free();
+			deallocate();
 		}
 	}
 
@@ -411,7 +411,7 @@ public:
 		if (mElements != nullptr)
 		{
 			if (mSize == 0)
-				free();
+				deallocate();
 			else if (mCapacity > mSize)
 				reallocate(mSize);
 		}


### PR DESCRIPTION
Fixes #1781