### PR TITLE
Fixed cast shape possibly not returning a hit

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -14,6 +14,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * A 6DOF constraint that constrains all rotation axis in combination with a body that has some of its rotation axis locked would not constrain the rotation in the unlocked axis.
 * Added include `type_traits` for `std::is_trivial` to avoid compile error on macOS with clang 21.
 * Fixed compilation error when using Jolt in conjunction with the `_CRTDBG_MAP_ALLOC` define on Windows.
+* Fixed cast shape possibly not returning a hit when a shape cast starts touching (but not intersecting) another shape and requesting the deepest hit.
 
 ## v5.4.0
 

--- a/Jolt/Geometry/EPAPenetrationDepth.h
+++ b/Jolt/Geometry/EPAPenetrationDepth.h
@@ -542,7 +542,7 @@ public:
 			AddConvexRadius add_convex_b(inB, inConvexRadiusB);
 			TransformedConvexObject transformed_a(inStart, add_convex_a);
 			if (!GetPenetrationDepthStepEPA(transformed_a, add_convex_b, inPenetrationTolerance, outContactNormal, outPointA, outPointB))
-				return false;
+				outContactNormal = inDirection; // Failed to get the deepest point, use points returned by GJK and use cast direction as normal
 		}
 		else if (contact_normal_invalid)
 		{


### PR DESCRIPTION
when a shape cast starts touching (but not intersecting) another shape and requesting the deepest hit.

Fixes #1786