### PR TITLE
improve temp alloc a bit (non aligned allocs)

### DIFF
--- a/Jolt/Core/TempAllocator.h
+++ b/Jolt/Core/TempAllocator.h
@@ -17,7 +17,8 @@ class JPH_EXPORT TempAllocator : public NonCopyable
 public:
 	JPH_OVERRIDE_NEW_DELETE
 
-	static constexpr bool	needs_aligned_allocate = JPH_RVECTOR_ALIGNMENT > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16);
+	/// If this allocator needs to fall back to aligned allocations because JPH_RVECTOR_ALIGNMENT is bigger than the platform default
+	static constexpr bool			needs_aligned_allocate = JPH_RVECTOR_ALIGNMENT > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16);
 
 	/// Destructor
 	virtual							~TempAllocator() = default;


### PR DESCRIPTION
If JPH_RVECTOR_ALIGNMENT is small enough we could use simpler/less overhead Allocate/Free code path instead of aligned one.

Basically same logic as in
https://github.com/jrouwe/JoltPhysics/commit/ff05612c89b1ba0a9c9fca7bcc3bacd34b08dfc9#diff-88beae258ce8db547ebd0dfb2bad98ad6c995b211dd368316a4a816d4bffd796R47