### PR TITLE
fix x32-ABI compilation (32-bit pointers on __x86_64__)

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -120,7 +120,9 @@
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 	// X86 CPU architecture
 	#define JPH_CPU_X86
-	#if defined(__x86_64__) || defined(_M_X64)
+	#ifdef __SIZEOF_POINTER__
+		#define JPH_CPU_ADDRESS_BITS (__SIZEOF_POINTER__ * 8)
+	#elif defined(__x86_64__) || defined(_M_X64)
 		#define JPH_CPU_ADDRESS_BITS 64
 	#else
 		#define JPH_CPU_ADDRESS_BITS 32


### PR DESCRIPTION
Not to be confused -m32/i386 ABI - https://en.wikipedia.org/wiki/X32_ABI
It's niche but nevertheless usefull ABI if your working set fits in
32-bit adress range.
See also
https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models

To consider: change `needs_aligned_allocate` to use of
`__STDCPP_DEFAULT_NEW_ALIGNMENT__` instead
(https://en.cppreference.com/w/cpp/memory/new/align_val_t.html)
because pointer size are not directly tied to address range
(e.g. on linux it's 16 regadless of ABI bitness)

Note: `__SIZEOF_POINTER__` defined (at least) by both gcc & clang, see below:
```
 :~$ grep -i prett /etc/os-release
 PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
 :~$ gcc -dumpfullversion
 14.2.0
 :~$ g++ -x c++ -E -dM - < /dev/null | grep -Pi "(x|3)86|size.*poin|lp\d\d|def.*new.*ali"
 #define __x86_64 1
 #define __SIZEOF_POINTER__ 8
 #define __LP64__ 1
 #define __x86_64__ 1
 #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16
 #define _LP64 1
 :~$ g++ -m32 -x c++ -E -dM - < /dev/null | grep -Pi "(x|3)86|size.*poin|lp\d\d|def.*new.*ali"
 #define __SIZEOF_POINTER__ 4
 #define __i386 1
 #define i386 1
 #define __i386__ 1
 #define __ILP32__ 1
 #define _ILP32 1
 #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16
 :~$ g++ -mx32 -x c++ -E -dM - < /dev/null | grep -Pi "(x|3)86|size.*poin|lp\d\d|def.*new.*ali"
 #define __x86_64 1
 #define __SIZEOF_POINTER__ 4
 #define __x86_64__ 1
 #define __ILP32__ 1
 #define _ILP32 1
 #define __STDCPP_DEFAULT_NEW_ALIGNMENT__ 16
```