### PR TITLE
Support for compiling on x64 with 32 bit pointers

### DIFF
--- a/Jolt/ConfigurationString.h
+++ b/Jolt/ConfigurationString.h
@@ -32,9 +32,9 @@ inline const char *GetConfigurationString()
 #else
 	#error Unknown CPU architecture
 #endif
-#if JPH_CPU_ADDRESS_BITS == 64
+#if JPH_CPU_ARCH_BITS == 64
 		"64-bit "
-#elif JPH_CPU_ADDRESS_BITS == 32
+#elif JPH_CPU_ARCH_BITS == 32
 		"32-bit "
 #endif
 		"with instructions: "

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -121,9 +121,9 @@
 	// X86 CPU architecture
 	#define JPH_CPU_X86
 	#if defined(__x86_64__) || defined(_M_X64)
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 	#endif
 	#define JPH_USE_SSE
 	#define JPH_VECTOR_ALIGNMENT 16
@@ -171,12 +171,12 @@
 	// ARM CPU architecture
 	#define JPH_CPU_ARM
 	#if defined(__aarch64__) || defined(_M_ARM64)
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 		#define JPH_USE_NEON
 		#define JPH_VECTOR_ALIGNMENT 16
 		#define JPH_DVECTOR_ALIGNMENT 32
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 		#define JPH_VECTOR_ALIGNMENT 8 // 32-bit ARM does not support aligning on the stack on 16 byte boundaries
 		#define JPH_DVECTOR_ALIGNMENT 8
 	#endif
@@ -184,11 +184,11 @@
 	// RISC-V CPU architecture
 	#define JPH_CPU_RISCV
 	#if __riscv_xlen == 64
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 		#define JPH_VECTOR_ALIGNMENT 16
 		#define JPH_DVECTOR_ALIGNMENT 32
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 		#define JPH_VECTOR_ALIGNMENT 16
 		#define JPH_DVECTOR_ALIGNMENT 8
 	#endif
@@ -196,9 +196,9 @@
 	// WebAssembly CPU architecture
 	#define JPH_CPU_WASM
 	#if defined(__wasm64__)
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 	#endif
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 32
@@ -211,9 +211,9 @@
 	// PowerPC CPU architecture
 	#define JPH_CPU_PPC
 	#if defined(__powerpc64__)
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 	#endif
 	#ifdef _BIG_ENDIAN
 		#define JPH_CPU_BIG_ENDIAN
@@ -224,16 +224,16 @@
 	// LoongArch CPU architecture
 	#define JPH_CPU_LOONGARCH
 	#if defined(__loongarch64)
-		#define JPH_CPU_ADDRESS_BITS 64
+		#define JPH_CPU_ARCH_BITS 64
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 	#endif
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 8
 #elif defined(__e2k__)
 	// E2K CPU architecture (MCST Elbrus 2000)
 	#define JPH_CPU_E2K
-	#define JPH_CPU_ADDRESS_BITS 64
+	#define JPH_CPU_ARCH_BITS 64
 	#define JPH_VECTOR_ALIGNMENT 16
 	#define JPH_DVECTOR_ALIGNMENT 32
 
@@ -453,6 +453,7 @@ JPH_SUPPRESS_WARNINGS_STD_BEGIN
 #include <float.h>
 #include <limits.h>
 #include <string.h>
+#include <new>
 #include <utility>
 #include <cmath>
 #include <sstream>
@@ -508,7 +509,6 @@ static_assert(sizeof(uint8) == 1, "Invalid size of uint8");
 static_assert(sizeof(uint16) == 2, "Invalid size of uint16");
 static_assert(sizeof(uint32) == 4, "Invalid size of uint32");
 static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
-static_assert(sizeof(void *) == (JPH_CPU_ADDRESS_BITS == 64? 8 : 4), "Invalid size of pointer" );
 
 // Determine if we want extra debugging code to be active
 #if !defined(NDEBUG) && !defined(JPH_NO_DEBUG)

--- a/Jolt/Core/HashTable.h
+++ b/Jolt/Core/HashTable.h
@@ -842,7 +842,7 @@ public:
 
 private:
 	/// If this allocator needs to fall back to aligned allocations because the type requires it
-	static constexpr bool	cNeedsAlignedAllocate = alignof(KeyValue) > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16);
+	static constexpr bool	cNeedsAlignedAllocate = alignof(KeyValue) > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 
 	/// Max load factor is cMaxLoadFactorNumerator / cMaxLoadFactorDenominator
 	static constexpr uint64	cMaxLoadFactorNumerator = 7;

--- a/Jolt/Core/Memory.h
+++ b/Jolt/Core/Memory.h
@@ -37,7 +37,7 @@ JPH_EXPORT void RegisterDefaultAllocator();
 // It uses the non-aligned version, which on 32 bit platforms usually returns an 8 byte aligned block.
 // We therefore default to 16 byte aligned allocations when the regular new operator is used.
 // See: https://github.com/godotengine/godot/issues/105455#issuecomment-2824311547
-#if defined(JPH_COMPILER_MINGW) && JPH_CPU_ADDRESS_BITS == 32
+#if defined(JPH_COMPILER_MINGW) && JPH_CPU_ARCH_BITS == 32
 	#define JPH_INTERNAL_DEFAULT_ALLOCATE(size) JPH::AlignedAllocate(size, 16)
 	#define JPH_INTERNAL_DEFAULT_FREE(pointer) JPH::AlignedFree(pointer)
 #else

--- a/Jolt/Core/STLAllocator.h
+++ b/Jolt/Core/STLAllocator.h
@@ -44,7 +44,7 @@ public:
 	inline					STLAllocator(const STLAllocator<T2> &) { }
 
 	/// If this allocator needs to fall back to aligned allocations because the type requires it
-	static constexpr bool	needs_aligned_allocate = alignof(T) > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16);
+	static constexpr bool	needs_aligned_allocate = alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 
 	/// Allocate memory
 	inline pointer			allocate(size_type inN)

--- a/Jolt/Core/TempAllocator.h
+++ b/Jolt/Core/TempAllocator.h
@@ -18,7 +18,7 @@ public:
 	JPH_OVERRIDE_NEW_DELETE
 
 	/// If this allocator needs to fall back to aligned allocations because JPH_RVECTOR_ALIGNMENT is bigger than the platform default
-	static constexpr bool			needs_aligned_allocate = JPH_RVECTOR_ALIGNMENT > (JPH_CPU_ADDRESS_BITS == 32? 8 : 16);
+	static constexpr bool			needs_aligned_allocate = JPH_RVECTOR_ALIGNMENT > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
 
 	/// Destructor
 	virtual							~TempAllocator() = default;

--- a/Jolt/Core/TickCounter.h
+++ b/Jolt/Core/TickCounter.h
@@ -38,7 +38,7 @@ JPH_INLINE uint64 GetProcessorTickCount()
 	asm volatile("mrs %0, cntvct_el0" : "=r" (val));
 	return val;
 #elif defined(JPH_CPU_LOONGARCH)
-	#if JPH_CPU_ADDRESS_BITS == 64
+	#if JPH_CPU_ARCH_BITS == 64
 		__drdtime_t t = __rdtime_d();
 		return t.dvalue;
 	#else

--- a/Jolt/Physics/Body/Body.h
+++ b/Jolt/Physics/Body/Body.h
@@ -444,7 +444,7 @@ private:
 	// 122 bytes up to here (64-bit mode, single precision, 16-bit ObjectLayer)
 };
 
-static_assert(JPH_CPU_ADDRESS_BITS != 64 || JPH_RVECTOR_ALIGNMENT < 16 || sizeof(Body) == JPH_IF_SINGLE_PRECISION_ELSE(128, 160), "Body size is incorrect");
+static_assert(sizeof(void *) != 8 || JPH_RVECTOR_ALIGNMENT < 16 || sizeof(Body) == JPH_IF_SINGLE_PRECISION_ELSE(128, 160), "Body size is incorrect");
 static_assert(alignof(Body) == max(JPH_VECTOR_ALIGNMENT, JPH_RVECTOR_ALIGNMENT), "Body should properly align");
 
 JPH_NAMESPACE_END

--- a/Jolt/Physics/Collision/Shape/CompoundShape.h
+++ b/Jolt/Physics/Collision/Shape/CompoundShape.h
@@ -243,7 +243,7 @@ public:
 		// 3 padding bytes left
 	};
 
-	static_assert(sizeof(SubShape) == (JPH_CPU_ADDRESS_BITS == 64? 40 : 36), "Compiler added unexpected padding");
+	static_assert(sizeof(SubShape) == (sizeof(void *) == 8? 40 : 36), "Compiler added unexpected padding");
 
 	using SubShapes = Array<SubShape>;
 

--- a/Jolt/Physics/Collision/TransformedShape.h
+++ b/Jolt/Physics/Collision/TransformedShape.h
@@ -188,7 +188,7 @@ public:
 	SubShapeIDCreator			mSubShapeIDCreator;							///< Optional sub shape ID creator for the shape (can be used when expanding compound shapes into multiple transformed shapes)
 };
 
-static_assert(JPH_CPU_ADDRESS_BITS != 64 || JPH_RVECTOR_ALIGNMENT < 16 || sizeof(TransformedShape) == JPH_IF_SINGLE_PRECISION_ELSE(64, 96), "Not properly packed");
+static_assert(sizeof(void *) != 8 || JPH_RVECTOR_ALIGNMENT < 16 || sizeof(TransformedShape) == JPH_IF_SINGLE_PRECISION_ELSE(64, 96), "Not properly packed");
 static_assert(alignof(TransformedShape) == max(JPH_VECTOR_ALIGNMENT, JPH_RVECTOR_ALIGNMENT), "Not properly aligned");
 
 JPH_NAMESPACE_END


### PR DESCRIPTION
* Renamed JPH_CPU_ADDRESS_BITS to JPH_CPU_ARCH_BITS to better represent what it is for.
* Use sizeof(void *) to determine pointer size where needed.
* Use __STDCPP_DEFAULT_NEW_ALIGNMENT__ to determine the default memory allocation alignment.
