### PR TITLE
Build perf: speed up JoltPhysics build by adding PCH

### DIFF
--- a/TestFramework/TestFramework.h
+++ b/TestFramework/TestFramework.h
@@ -40,6 +40,19 @@ JPH_MSVC_SUPPRESS_WARNING(4062) // enumerator 'X' in switch of enum 'X' is not h
 
 #endif
 
+// Precompile frequently used Jolt Physics headers for better build performance
+#include <Jolt/Physics/PhysicsSystem.h>
+#include <Jolt/Physics/Body/Body.h>
+#include <Jolt/Physics/Body/BodyLock.h>
+#include <Jolt/Physics/Body/BodyLockInterface.h>
+#include <Jolt/Physics/Body/BodyManager.h>
+#include <Jolt/Physics/Collision/NarrowPhaseQuery.h>
+#include <Jolt/Physics/Collision/Shape/Shape.h>
+#include <Jolt/Physics/Constraints/ContactConstraintManager.h>
+#include <Jolt/Core/Mutex.h>
+#include <Jolt/Core/Profiler.h>
+#include <Jolt/Skeleton/SkeletonPose.h>
+
 using namespace JPH;
 using namespace JPH::literals;
 using namespace std;


### PR DESCRIPTION
Hi JoltPhysics maintainers

I am a software engineer at Microsoft in the Visual C++ group. As part of our efforts, we've investigated OSS repositories for build throughput opportunities, and we work with the project maintainers to make OSS builds faster.

We've identified an opportunity in JoltPhysics, which improves the Build Throughput by 26.6%, saving 8 seconds of build time.

We believe this contribution would be a net positive for JoltPhysics, and we'd love to work with you to shape it as appropriate for the project. 

We've done these measurements on an AMD EPYC 7763 machine on Windows and ran the build 5 times.

Thank you!
-Eve