### PR TITLE
Make ARM64EC build available with NEON intrinsics

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -297,6 +297,7 @@ function(SET_INTERPROCEDURAL_OPTIMIZATION)
 	# On ARM, whole program optimization triggers an internal compiler error during code gen, so we don't turn it on
 	# When compiling as a shared lib with MinGW, turning on LTO causes errors of the form 'ld.exe: cannot export symbol X wrong type (4 vs 3)'
 	if (INTERPROCEDURAL_OPTIMIZATION
+		AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM64EC")
 		AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM64")
 		AND NOT ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
 		AND (NOT CROSS_COMPILE_ARM OR ("${CROSS_COMPILE_ARM_TARGET}" STREQUAL "aarch64-linux-gnu"))

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -117,21 +117,16 @@
 #endif
 
 // Detect CPU architecture
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM) || defined(_ARM64EC_) || defined(_M_ARM64EC) 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64EC)
 	// ARM CPU architecture
 	#define JPH_CPU_ARM
-
-	#if defined(_M_ARM64EC) || defined(_ARM64EC_) 
-		#define JPH_ARM_EC
-	#endif
-
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC) 
-		#define JPH_CPU_ADDRESS_BITS 64
+	#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+		#define JPH_CPU_ARCH_BITS 64
 		#define JPH_USE_NEON
 		#define JPH_VECTOR_ALIGNMENT 16
 		#define JPH_DVECTOR_ALIGNMENT 32
 	#else
-		#define JPH_CPU_ADDRESS_BITS 32
+		#define JPH_CPU_ARCH_BITS 32
 		#define JPH_VECTOR_ALIGNMENT 8 // 32-bit ARM does not support aligning on the stack on 16 byte boundaries
 		#define JPH_DVECTOR_ALIGNMENT 8
 	#endif

--- a/Jolt/Geometry/AABox4.h
+++ b/Jolt/Geometry/AABox4.h
@@ -84,9 +84,6 @@ JPH_INLINE UVec4 AABox4VsPoint(Vec3Arg inPoint, Vec4Arg inBoxMinX, Vec4Arg inBox
 	return UVec4::sAnd(UVec4::sAnd(overlapx, overlapy), overlapz);
 }
 
-#if defined(JPH_ARM_EC)
-	#pragma optimize("g", off)
-#endif
 /// Test if 4 bounding boxes overlap with an oriented box
 JPH_INLINE UVec4 AABox4VsBox(Mat44Arg inOrientation, Vec3Arg inHalfExtents, Vec4Arg inBoxMinX, Vec4Arg inBoxMinY, Vec4Arg inBoxMinZ, Vec4Arg inBoxMaxX, Vec4Arg inBoxMaxY, Vec4Arg inBoxMaxZ, float inEpsilon = 1.0e-6f)
 {
@@ -191,12 +188,6 @@ JPH_INLINE UVec4 AABox4VsBox(const OrientedBox &inBox, Vec4Arg inBoxMinX, Vec4Ar
 {
 	return AABox4VsBox(inBox.mOrientation, inBox.mHalfExtents, inBoxMinX, inBoxMinY, inBoxMinZ, inBoxMaxX, inBoxMaxY, inBoxMaxZ, inEpsilon);
 }
-
-#if defined(JPH_ARM_EC)
-	#ifndef _DEBUG
-		#pragma optimize("g", on)
-	#endif 
-#endif
 
 /// Get the squared distance between 4 AABoxes and a point
 JPH_INLINE Vec4 AABox4DistanceSqToPoint(Vec4Arg inPointX, Vec4Arg inPointY, Vec4Arg inPointZ, Vec4Arg inBoxMinX, Vec4Arg inBoxMinY, Vec4Arg inBoxMinZ, Vec4Arg inBoxMaxX, Vec4Arg inBoxMaxY, Vec4Arg inBoxMaxZ)


### PR DESCRIPTION
1. A batch file to make ARM64EC project
2. Make use of NEON intrinsics for ARM64EC ABI.
3. MSVC compiler causes internal compiler error in AABox4VsBox functions. It gets mitigated only if 'g' optimisation is disabled. A separate complaint is raised for Microsoft team to look into this compiler error. Until Microsoft resolves this compiler error, it is handled.