### PR TITLE
Performance improvement for kinematic bodies

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -18,15 +18,19 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * Increased maximum value of HeightFieldShape::mBitsPerSample to 16 to be able to create height fields that more closely match the uncompressed height values.
 * Made tolerance that's used in the internal edge removal algorithm configurable in `CollideShapeSettings::mInternalEdgeRemovalVertexToleranceSq` and `PhysicsSettings::mInternalEdgeRemovalVertexToleranceSq`.
 * Added support for RISC-V RVV, the SIMD extension for RISC-V.
+* Added JPH_BUILD_SHARED_LIBS cmake variable to determine whether to build static or shared libraries (it defaults to BUILD_SHARED_LIBS). This allows embedding Jolt as a static library within a shared library.
+* Simulation stats: Added tracking of collision steps. This way we can know by how many steps we need to divide the numbers to get averages per step.
+* Various performance and memory optimizations.
 
 ### Bug Fixes
 
 * Made it possible to make a class outside the `JPH` namespace serializable.
 * `VehicleConstraint`s are automatically disabled when the vehicle body is not in the `PhysicsSystem`.
 * Fixed an issue where a character could get stuck. If the character was teleported inside an area surrounded by slopes that are steeper than `mMaxSlopeAngle`, the code to stop the constraint solver from ping ponging between two planes didn't work properly.
-* Fixed an issue where collide/cast shape against a triangle would return a hit result with `mShape2Face` in incorrect winding order. This caused an incorrect normal in the enhanced internal edge removal algorithm. This in turn resulted in objects not settling properly on dense triangle grids.
+* Fixed an issue where collide/cast shape against a triangle that was scaled inside out would return a hit result with `mShape2Face` in incorrect winding order. This caused an incorrect normal in the enhanced internal edge removal algorithm. This in turn resulted in objects not settling properly on dense triangle grids.
 * When using `Body::AddForce` to apply gravity, bodies could gain extra energy during elastic collisions. We now cancel added forces in the direction of the contact normal if the body starts in collision to negate this energy gain.
 * Made `MoveKinematic` more accurate when rotating a body by a very small angle.
+* Kinematic bodies were assigned to the same island as bodies that were constrained to / in contact with them. This led to larger simulation islands and impacted performance.
 
 ## v5.5.0
 

--- a/Jolt/Physics/Body/MotionProperties.h
+++ b/Jolt/Physics/Body/MotionProperties.h
@@ -215,12 +215,27 @@ public:
 
 	///@name Update linear and angular velocity (used during constraint solving)
 	///@{
-	inline void				AddLinearVelocityStep(Vec3Arg inLinearVelocityChange)			{ JPH_DET_LOG("AddLinearVelocityStep: " << inLinearVelocityChange); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); mLinearVelocity = LockTranslation(mLinearVelocity + inLinearVelocityChange); JPH_ASSERT(!mLinearVelocity.IsNaN()); }
-	inline void				SubLinearVelocityStep(Vec3Arg inLinearVelocityChange)			{ JPH_DET_LOG("SubLinearVelocityStep: " << inLinearVelocityChange); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); mLinearVelocity = LockTranslation(mLinearVelocity - inLinearVelocityChange); JPH_ASSERT(!mLinearVelocity.IsNaN()); }
-	inline void				ApplyLinearVelocityStep(Vec3Arg inLinearVelocity)				{ JPH_DET_LOG("ApplyLinearVelocityStep: " << inLinearVelocity); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); JPH_ASSERT(!inLinearVelocity.IsNaN()); mLinearVelocity = LockTranslation(inLinearVelocity); }
-	inline void				AddAngularVelocityStep(Vec3Arg inAngularVelocityChange)			{ JPH_DET_LOG("AddAngularVelocityStep: " << inAngularVelocityChange); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); mAngularVelocity += inAngularVelocityChange; JPH_ASSERT(!mAngularVelocity.IsNaN()); }
-	inline void				SubAngularVelocityStep(Vec3Arg inAngularVelocityChange)			{ JPH_DET_LOG("SubAngularVelocityStep: " << inAngularVelocityChange); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); mAngularVelocity -= inAngularVelocityChange; JPH_ASSERT(!mAngularVelocity.IsNaN()); }
-	inline void				ApplyAngularVelocityStep(Vec3Arg inAngularVelocity)				{ JPH_DET_LOG("ApplyAngularVelocityStep: " << inAngularVelocity); JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite)); JPH_ASSERT(!inAngularVelocity.IsNaN()); mAngularVelocity = inAngularVelocity; }
+	inline void				ApplyLinearVelocityStep(Vec3Arg inLinearVelocity)
+	{
+		JPH_DET_LOG("ApplyLinearVelocityStep: " << inLinearVelocity);
+		JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite));
+		JPH_ASSERT(mCachedMotionType == EMotionType::Dynamic);
+		JPH_ASSERT(!inLinearVelocity.IsNaN());
+		mLinearVelocity = LockTranslation(inLinearVelocity);
+	}
+	inline void				AddLinearVelocityStep(Vec3Arg inLinearVelocityChange)			{ ApplyLinearVelocityStep(mLinearVelocity + inLinearVelocityChange); }
+	inline void				SubLinearVelocityStep(Vec3Arg inLinearVelocityChange)			{ ApplyLinearVelocityStep(mLinearVelocity - inLinearVelocityChange); }
+
+	inline void				ApplyAngularVelocityStep(Vec3Arg inAngularVelocity)
+	{
+		JPH_DET_LOG("ApplyAngularVelocityStep: " << inAngularVelocity);
+		JPH_ASSERT(BodyAccess::sCheckRights(BodyAccess::sVelocityAccess(), BodyAccess::EAccess::ReadWrite));
+		JPH_ASSERT(mCachedMotionType == EMotionType::Dynamic);
+		JPH_ASSERT(!inAngularVelocity.IsNaN());
+		mAngularVelocity = inAngularVelocity;
+	}
+	inline void				AddAngularVelocityStep(Vec3Arg inAngularVelocityChange)			{ ApplyAngularVelocityStep(mAngularVelocity + inAngularVelocityChange); }
+	inline void				SubAngularVelocityStep(Vec3Arg inAngularVelocityChange)			{ ApplyAngularVelocityStep(mAngularVelocity - inAngularVelocityChange); }
 	///@}
 
 	/// Apply the gyroscopic force (aka Dzhanibekov effect, see https://en.wikipedia.org/wiki/Tennis_racket_theorem)

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -952,7 +952,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 
 void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled)
 {
-	// Start with no constraint and not handled
+	// Start with not handled
 	outPairHandled = false;
 
 	// Swap bodies so that body 1 id < body 2 id

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -33,46 +33,6 @@ bool ContactConstraintManager::sDrawContactManifolds = false;
 //#define JPH_MANIFOLD_CACHE_DEBUG
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-// ContactLinker
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void ContactLinker::LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2)
-{
-	bool body1_dynamic = inBody1.IsDynamic();
-	bool body2_dynamic = inBody2.IsDynamic();
-
-	if (mLinkBodies)
-	{
-		// Do this only once
-		mLinkBodies = false;
-
-		// Wake up sleeping bodies
-		BodyID body_ids[2];
-		int num_bodies = 0;
-		if (body1_dynamic && !inBody1.IsActive())
-			body_ids[num_bodies++] = inBody1.GetID();
-		if (body2_dynamic && !inBody2.IsActive())
-			body_ids[num_bodies++] = inBody2.GetID();
-		if (num_bodies > 0)
-			mBodyManager.ActivateBodies(body_ids, num_bodies);
-
-		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
-		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
-		if (body1_dynamic && body2_dynamic)
-			mIslandBuilder.LinkBodies(inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
-	}
-
-	// Link the contact to the first dynamic body
-	if (body1_dynamic)
-		mIslandBuilder.LinkContact(inConstraintIdx, inBody1.GetIndexInActiveBodiesInternal());
-	else
-	{
-		JPH_ASSERT(body2_dynamic);
-		mIslandBuilder.LinkContact(inConstraintIdx, inBody2.GetIndexInActiveBodiesInternal());
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ContactConstraintManager::WorldContactPoint
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -761,7 +721,7 @@ void ContactConstraintManager::PrepareConstraintBuffer(PhysicsUpdateContext *inC
 }
 
 template <EMotionType Type1, EMotionType Type2>
-JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactConstraintManager::CreateConstraint(ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints)
+JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactConstraintManager::CreateConstraint(bool &ioActivateAndLinkBodies, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints)
 {
 	// Calculate the size of this constraint
 	uint32 constraint_size = sizeof(ContactConstraint<Type1, Type2>) + (inNumContactPoints - 1) * sizeof(WorldContactPoint<Type1, Type2>);
@@ -773,8 +733,38 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 	if (constraint_idx >= mMaxConstraints)
 		return nullptr;
 
-	// Activate the bodies and link the constraint to the body
-	ioContactLinker.LinkContact(constraint_idx, inBody1, inBody2);
+	bool body1_dynamic = inBody1.IsDynamic();
+	bool body2_dynamic = inBody2.IsDynamic();
+
+	if (ioActivateAndLinkBodies)
+	{
+		// Do this only once
+		ioActivateAndLinkBodies = false;
+
+		// Wake up sleeping bodies
+		BodyID body_ids[2];
+		int num_bodies = 0;
+		if (body1_dynamic && !inBody1.IsActive())
+			body_ids[num_bodies++] = inBody1.GetID();
+		if (body2_dynamic && !inBody2.IsActive())
+			body_ids[num_bodies++] = inBody2.GetID();
+		if (num_bodies > 0)
+			mUpdateContext->mBodyManager->ActivateBodies(body_ids, num_bodies);
+
+		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
+		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
+		if (body1_dynamic && body2_dynamic)
+			mUpdateContext->mIslandBuilder->LinkBodies(inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
+	}
+
+	// Link the contact to the first dynamic body
+	if (body1_dynamic)
+		mUpdateContext->mIslandBuilder->LinkContact(constraint_idx, inBody1.GetIndexInActiveBodiesInternal());
+	else
+	{
+		JPH_ASSERT(body2_dynamic);
+		mUpdateContext->mIslandBuilder->LinkContact(constraint_idx, inBody2.GetIndexInActiveBodiesInternal());
+	}
 
 	// Store offset for constraint
 	uint32 constraint_offset = uint32(constraint_idx_and_constraint_offset >> 32);
@@ -805,7 +795,7 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 }
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair)
+void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair)
 {
 	// Get body transforms
 	RMat44 transform_body1 = inBody1.GetCenterOfMassTransform();
@@ -821,6 +811,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 	// Copy manifolds
 	uint32 output_handle = ManifoldMap::cInvalidHandle;
 	uint32 input_handle = inCachedBodyPair.mFirstCachedManifold;
+	bool link_bodies = true;
 	do
 	{
 		JPH_PROFILE("Add Constraint From Cached Manifold");
@@ -884,7 +875,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 				|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 		{
 			// Create a new constraint
-			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(ioContactLinker, inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints);
+			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(link_bodies, inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints);
 			if (constraint == nullptr)
 			{
 				ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
@@ -959,7 +950,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 	outCachedBodyPair.mFirstCachedManifold = output_handle;
 }
 
-void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, bool &outPairHandled)
+void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled)
 {
 	// Start with no constraint and not handled
 	outPairHandled = false;
@@ -1027,7 +1018,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, ContactLinker &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1047,7 +1038,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, ioContactLinker, *body1, *body2, input_cbp, *output_cbp);
+	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, *body1, *body2, input_cbp, *output_cbp);
 }
 
 ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2)
@@ -1091,7 +1082,7 @@ ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(C
 }
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
+void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, bool &ioActivateAndLinkBodies, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
 {
 	// Calculate hash
 	SubShapeIDPair key { inBody1.GetID(), inManifold.mSubShapeID1, inBody2.GetID(), inManifold.mSubShapeID2 };
@@ -1161,7 +1152,7 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 	{
 		// Create a new constraint
-		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(ioContactLinker, inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points);
+		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(ioActivateAndLinkBodies, inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points);
 		if (constraint == nullptr)
 		{
 			ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
@@ -1283,7 +1274,7 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 	cbp->mFirstCachedManifold = write_cache.ToHandle(new_manifold_kv);
 }
 
-void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
+void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, bool &ioActivateAndLinkBodies, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
 {
 	JPH_PROFILE_FUNCTION();
 
@@ -1313,7 +1304,7 @@ void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, ContactLinker &, BodyPairHandle, Body &, Body &, const ContactManifold &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, bool &, BodyPairHandle, Body &, Body &, const ContactManifold &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1333,7 +1324,7 @@ void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, ioContactLinker, inBodyPairHandle, *body1, *body2, *manifold);
+	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, ioActivateAndLinkBodies, inBodyPairHandle, *body1, *body2, *manifold);
 }
 
 void ContactConstraintManager::OnCCDContactAdded(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &outSettings)

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -729,14 +729,15 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 
 	// Reserve space for constraint
 	uint64 constraint_idx_and_constraint_offset = mNumConstraintsAndNextConstraintOffset.fetch_add((uint64(constraint_size) << 32) + 1, memory_order_relaxed);
-	outConstraintIdx = uint32(constraint_idx_and_constraint_offset);
-	if (outConstraintIdx >= mMaxConstraints)
+	uint32 constraint_idx = uint32(constraint_idx_and_constraint_offset);
+	if (constraint_idx >= mMaxConstraints)
 		return nullptr;
+	outConstraintIdx = constraint_idx;
 
 	// Store offset for constraint
 	uint32 constraint_offset = uint32(constraint_idx_and_constraint_offset >> 32);
 	JPH_ASSERT(constraint_offset + constraint_size < mMaxConstraints * cMaxConstraintSize);
-	mConstraintIdxToOffset[outConstraintIdx] = constraint_offset;
+	mConstraintIdxToOffset[constraint_idx] = constraint_offset;
 
 	// Construct constraint
 	ContactConstraint<Type1, Type2> *constraint = reinterpret_cast<ContactConstraint<Type1, Type2> *>(mConstraints + constraint_offset);
@@ -762,7 +763,7 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 }
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, bool &outConstraintCreated)
+void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, uint32 &outConstraintIdx)
 {
 	// Get body transforms
 	RMat44 transform_body1 = inBody1.GetCenterOfMassTransform();
@@ -841,19 +842,14 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 				|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 		{
 			// Create a new constraint
-			uint32 constraint_idx;
-			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints, constraint_idx);
+			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints, outConstraintIdx);
 			if (constraint == nullptr)
 			{
 				ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
 				break;
 			}
-			outConstraintCreated = true;
 
 			JPH_DET_LOG("GetContactsFromCache: id1: " << inBody1.GetID() << " id2: " << inBody2.GetID() << " key: " << constraint->mSortKey);
-
-			// Notify island builder
-			mUpdateContext->mIslandBuilder->LinkContact(constraint_idx, inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
 
 			// Calculate scaled mass and inertia
 			Mat44 inv_i1;
@@ -921,10 +917,10 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 	outCachedBodyPair.mFirstCachedManifold = output_handle;
 }
 
-void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, bool &outConstraintCreated)
+void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, uint32 &outConstraintIdx)
 {
-	// Start with nothing found and not handled
-	outConstraintCreated = false;
+	// Start with no constraint and not handled
+	outConstraintIdx = ~uint32(0);
 	outPairHandled = false;
 
 	// Swap bodies so that body 1 id < body 2 id
@@ -990,7 +986,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &, bool &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &, uint32 &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1010,7 +1006,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, *body1, *body2, input_cbp, *output_cbp, outConstraintCreated);
+	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, *body1, *body2, input_cbp, *output_cbp, outConstraintIdx);
 }
 
 ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2)
@@ -1054,8 +1050,11 @@ ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(C
 }
 
 template <EMotionType Type1, EMotionType Type2>
-bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
+void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx)
 {
+	// Start with no constraint added
+	outConstraintIdx = ~uint(0);
+
 	// Calculate hash
 	SubShapeIDPair key { inBody1.GetID(), inManifold.mSubShapeID1, inBody2.GetID(), inManifold.mSubShapeID2 };
 	uint64 key_hash = key.GetHash();
@@ -1071,7 +1070,7 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 	ManifoldCache &write_cache = mCache[mCacheWriteIdx];
 	MKeyValue *new_manifold_kv = write_cache.Create(ioContactAllocator, key, key_hash, num_contact_points);
 	if (new_manifold_kv == nullptr)
-		return false; // Out of cache space
+		return; // Out of cache space
 	CachedManifold *new_manifold = &new_manifold_kv->GetValue();
 
 	// Transform the world space normal to the space of body 2 (this is usually the static body)
@@ -1117,8 +1116,6 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 	// Get inverse transform for body 1
 	RMat44 inverse_transform_body1 = inBody1.GetInverseCenterOfMassTransform();
 
-	bool contact_constraint_created = false;
-
 	// If one of the bodies is a sensor, don't actually create the constraint
 	JPH_ASSERT(settings.mIsSensor || !(inBody1.IsSensor() || inBody2.IsSensor()), "Sensors cannot be converted into regular bodies by a contact callback!");
 	if (!settings.mIsSensor
@@ -1126,8 +1123,7 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 	{
 		// Create a new constraint
-		uint32 constraint_idx;
-		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points, constraint_idx);
+		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points, outConstraintIdx);
 		if (constraint == nullptr)
 		{
 			ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
@@ -1135,14 +1131,10 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			// Manifold has been created already, we're not filling it in, so we need to reset the contact number of points.
 			// Note that we don't hook it up to the body pair cache so that it won't be used as a cache during the next simulation.
 			new_manifold->mNumContactPoints = 0;
-			return false;
+			return;
 		}
-		contact_constraint_created = true;
 
 		JPH_DET_LOG("AddContactConstraint: id1: " << constraint->mBody1->GetID() << " id2: " << constraint->mBody2->GetID() << " key: " << constraint->mSortKey);
-
-		// Notify island builder
-		mUpdateContext->mIslandBuilder->LinkContact(constraint_idx, inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
 
 		// Get time step and gravity
 		float delta_time = mUpdateContext->mStepDeltaTime;
@@ -1251,12 +1243,9 @@ bool ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 	CachedBodyPair *cbp = reinterpret_cast<CachedBodyPair *>(inBodyPairHandle);
 	new_manifold->mNextWithSameBodyPair = cbp->mFirstCachedManifold;
 	cbp->mFirstCachedManifold = write_cache.ToHandle(new_manifold_kv);
-
-	// A contact constraint was added
-	return contact_constraint_created;
 }
 
-bool ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
+void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx)
 {
 	JPH_PROFILE_FUNCTION();
 
@@ -1265,6 +1254,8 @@ bool ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 		<< " normal: " << inManifold.mWorldSpaceNormal << " pendepth: " << inManifold.mPenetrationDepth);
 
 	JPH_ASSERT(inManifold.mWorldSpaceNormal.IsNormalized());
+
+	outConstraintIdx = ~uint32(0);
 
 	// Swap bodies so that body 1 id < body 2 id
 	const ContactManifold *manifold;
@@ -1286,7 +1277,7 @@ bool ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = bool (ContactConstraintManager::*)(ContactAllocator &, BodyPairHandle, Body &, Body &, const ContactManifold &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, BodyPairHandle, Body &, Body &, const ContactManifold &, uint32 &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1306,7 +1297,7 @@ bool ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, inBodyPairHandle, *body1, *body2, *manifold);
+	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, inBodyPairHandle, *body1, *body2, *manifold, outConstraintIdx);
 }
 
 void ContactConstraintManager::OnCCDContactAdded(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &outSettings)

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -33,6 +33,46 @@ bool ContactConstraintManager::sDrawContactManifolds = false;
 //#define JPH_MANIFOLD_CACHE_DEBUG
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ContactLinker
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void ContactLinker::LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2)
+{
+	bool body1_dynamic = inBody1.IsDynamic();
+	bool body2_dynamic = inBody2.IsDynamic();
+
+	if (mLinkBodies)
+	{
+		// Do this only once
+		mLinkBodies = false;
+
+		// Wake up sleeping bodies
+		BodyID body_ids[2];
+		int num_bodies = 0;
+		if (body1_dynamic && !inBody1.IsActive())
+			body_ids[num_bodies++] = inBody1.GetID();
+		if (body2_dynamic && !inBody2.IsActive())
+			body_ids[num_bodies++] = inBody2.GetID();
+		if (num_bodies > 0)
+			mBodyManager.ActivateBodies(body_ids, num_bodies);
+
+		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
+		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
+		if (body1_dynamic && body2_dynamic)
+			mIslandBuilder.LinkBodies(inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
+	}
+
+	// Link the contact to the first dynamic body
+	if (body1_dynamic)
+		mIslandBuilder.LinkContact(inConstraintIdx, inBody1.GetIndexInActiveBodiesInternal());
+	else
+	{
+		JPH_ASSERT(body2_dynamic);
+		mIslandBuilder.LinkContact(inConstraintIdx, inBody2.GetIndexInActiveBodiesInternal());
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ContactConstraintManager::WorldContactPoint
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -721,7 +761,7 @@ void ContactConstraintManager::PrepareConstraintBuffer(PhysicsUpdateContext *inC
 }
 
 template <EMotionType Type1, EMotionType Type2>
-JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactConstraintManager::CreateConstraint(Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints, uint32 &outConstraintIdx)
+JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactConstraintManager::CreateConstraint(ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints)
 {
 	// Calculate the size of this constraint
 	uint32 constraint_size = sizeof(ContactConstraint<Type1, Type2>) + (inNumContactPoints - 1) * sizeof(WorldContactPoint<Type1, Type2>);
@@ -732,7 +772,9 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 	uint32 constraint_idx = uint32(constraint_idx_and_constraint_offset);
 	if (constraint_idx >= mMaxConstraints)
 		return nullptr;
-	outConstraintIdx = constraint_idx;
+
+	// Activate the bodies and link the constraint to the body
+	ioContactLinker.LinkContact(constraint_idx, inBody1, inBody2);
 
 	// Store offset for constraint
 	uint32 constraint_offset = uint32(constraint_idx_and_constraint_offset >> 32);
@@ -763,7 +805,7 @@ JPH_INLINE ContactConstraintManager::ContactConstraint<Type1, Type2> *ContactCon
 }
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, uint32 &outConstraintIdx)
+void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair)
 {
 	// Get body transforms
 	RMat44 transform_body1 = inBody1.GetCenterOfMassTransform();
@@ -842,7 +884,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 				|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 		{
 			// Create a new constraint
-			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints, outConstraintIdx);
+			ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(ioContactLinker, inBody1, inBody2, input_hash, world_space_normal, settings, output_cm->mNumContactPoints);
 			if (constraint == nullptr)
 			{
 				ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
@@ -917,10 +959,9 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 	outCachedBodyPair.mFirstCachedManifold = output_handle;
 }
 
-void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, uint32 &outConstraintIdx)
+void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, bool &outPairHandled)
 {
 	// Start with no constraint and not handled
-	outConstraintIdx = ~uint32(0);
 	outPairHandled = false;
 
 	// Swap bodies so that body 1 id < body 2 id
@@ -986,7 +1027,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &, uint32 &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, ContactLinker &, Body &, Body &, const CachedBodyPair &, CachedBodyPair &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1006,7 +1047,7 @@ void ContactConstraintManager::GetContactsFromCache(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, *body1, *body2, input_cbp, *output_cbp, outConstraintIdx);
+	(this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, ioContactLinker, *body1, *body2, input_cbp, *output_cbp);
 }
 
 ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2)
@@ -1050,11 +1091,8 @@ ContactConstraintManager::BodyPairHandle ContactConstraintManager::AddBodyPair(C
 }
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx)
+void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
 {
-	// Start with no constraint added
-	outConstraintIdx = ~uint(0);
-
 	// Calculate hash
 	SubShapeIDPair key { inBody1.GetID(), inManifold.mSubShapeID1, inBody2.GetID(), inManifold.mSubShapeID2 };
 	uint64 key_hash = key.GetHash();
@@ -1123,7 +1161,7 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			|| (Type2 == EMotionType::Dynamic && settings.mInvMassScale2 != 0.0f)))
 	{
 		// Create a new constraint
-		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points, outConstraintIdx);
+		ContactConstraint<Type1, Type2> *constraint = CreateConstraint<Type1, Type2>(ioContactLinker, inBody1, inBody2, key_hash, inManifold.mWorldSpaceNormal, settings, num_contact_points);
 		if (constraint == nullptr)
 		{
 			ioContactAllocator.mErrors |= EPhysicsUpdateError::ContactConstraintsFull;
@@ -1245,7 +1283,7 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 	cbp->mFirstCachedManifold = write_cache.ToHandle(new_manifold_kv);
 }
 
-void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx)
+void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold)
 {
 	JPH_PROFILE_FUNCTION();
 
@@ -1254,8 +1292,6 @@ void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 		<< " normal: " << inManifold.mWorldSpaceNormal << " pendepth: " << inManifold.mPenetrationDepth);
 
 	JPH_ASSERT(inManifold.mWorldSpaceNormal.IsNormalized());
-
-	outConstraintIdx = ~uint32(0);
 
 	// Swap bodies so that body 1 id < body 2 id
 	const ContactManifold *manifold;
@@ -1277,7 +1313,7 @@ void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 
 	// Build dispatch table
 	// Note: Non-dynamic vs non-dynamic can happen in this case due to one body being a sensor, so we need to have an extended table here
-	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, BodyPairHandle, Body &, Body &, const ContactManifold &, uint32 &);
+	using DispatchFunc = void (ContactConstraintManager::*)(ContactAllocator &, ContactLinker &, BodyPairHandle, Body &, Body &, const ContactManifold &);
 	static const DispatchFunc table[3][3] = {
 		{
 			nullptr, // Static vs static doesn't exist
@@ -1297,7 +1333,7 @@ void ContactConstraintManager::AddContactConstraint(ContactAllocator &ioContactA
 	};
 
 	// Dispatch to the correct templated form
-	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, inBodyPairHandle, *body1, *body2, *manifold, outConstraintIdx);
+	return (this->*table[(int)body1->GetMotionType()][(int)body2->GetMotionType()])(ioContactAllocator, ioContactLinker, inBodyPairHandle, *body1, *body2, *manifold);
 }
 
 void ContactConstraintManager::OnCCDContactAdded(ContactAllocator &ioContactAllocator, const Body &inBody1, const Body &inBody2, const ContactManifold &inManifold, ContactSettings &outSettings)

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -95,8 +95,8 @@ public:
 
 	/// Check if the contact points from the previous frame are reusable and if so copy them.
 	/// When the cache was usable and the pair has been handled: outPairHandled = true.
-	/// When a contact constraint was produced: outConstraintCreated = true.
-	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, bool &outConstraintCreated);
+	/// When a contact constraint was produced: outConstraintIdx will be the index in the constraint list, 0xffffffff otherwise.
+	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, uint32 &outConstraintIdx);
 
 	/// Handle used to keep track of the current body pair
 	using BodyPairHandle = void *;
@@ -146,7 +146,7 @@ public:
 	/// r1, r2 = contact point relative to center of mass of body 1 and body 2 (r1 = p1 - x1, r2 = p2 - x2).
 	/// v1, v2 = (linear velocity, angular velocity): 6 vectors containing linear and angular velocity for body 1 and 2.
 	/// M = mass matrix, a diagonal matrix of the mass and inertia with diagonal [m1, I1, m2, I2].
-	bool						AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
+	void						AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx);
 
 	/// Finalizes the contact cache, the contact cache that was generated during the calls to AddContactConstraint in this update
 	/// will be used from now on to read from. After finalizing the contact cache, the contact removed callbacks will be called.
@@ -502,11 +502,11 @@ private:
 
 	/// Internal helper function to add a contact constraint from the cache. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, bool &outConstraintCreated);
+	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, uint32 &outConstraintIdx);
 
 	/// Internal helper function to add a contact constraint. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	bool						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
+	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx);
 
 	/// Read the velocities from the motion properties
 	template <EMotionType Type1, EMotionType Type2>

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -95,7 +95,6 @@ public:
 
 	/// Check if the contact points from the previous frame are reusable and if so copy them.
 	/// When the cache was usable and the pair has been handled: outPairHandled = true.
-	/// When a contact constraint was produced: outConstraintIdx will be the index in the constraint list, 0xffffffff otherwise.
 	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled);
 
 	/// Handle used to keep track of the current body pair

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -24,6 +24,24 @@ JPH_NAMESPACE_BEGIN
 
 struct PhysicsSettings;
 class PhysicsUpdateContext;
+class IslandBuilder;
+class BodyManager;
+
+/// Activates bodies and links a contact to a body so that we can build simulation islands
+class ContactLinker
+{
+public:
+	/// Constructor
+								ContactLinker(BodyManager &inBodyManager, IslandBuilder &inIslandBuilder) : mBodyManager(inBodyManager), mIslandBuilder(inIslandBuilder) { }
+
+	/// Link a contact to two bodies
+	void						LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2);
+
+private:
+	BodyManager &				mBodyManager;
+	IslandBuilder &				mIslandBuilder;
+	bool						mLinkBodies = true;													// If we still need to activate and link these 2 bodies together
+};
 
 /// A contact constraint manager manages all contacts between two bodies
 ///
@@ -96,7 +114,7 @@ public:
 	/// Check if the contact points from the previous frame are reusable and if so copy them.
 	/// When the cache was usable and the pair has been handled: outPairHandled = true.
 	/// When a contact constraint was produced: outConstraintIdx will be the index in the constraint list, 0xffffffff otherwise.
-	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled, uint32 &outConstraintIdx);
+	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, bool &outPairHandled);
 
 	/// Handle used to keep track of the current body pair
 	using BodyPairHandle = void *;
@@ -146,7 +164,7 @@ public:
 	/// r1, r2 = contact point relative to center of mass of body 1 and body 2 (r1 = p1 - x1, r2 = p2 - x2).
 	/// v1, v2 = (linear velocity, angular velocity): 6 vectors containing linear and angular velocity for body 1 and 2.
 	/// M = mass matrix, a diagonal matrix of the mass and inertia with diagonal [m1, I1, m2, I2].
-	void						AddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx);
+	void						AddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
 
 	/// Finalizes the contact cache, the contact cache that was generated during the calls to AddContactConstraint in this update
 	/// will be used from now on to read from. After finalizing the contact cache, the contact removed callbacks will be called.
@@ -498,15 +516,15 @@ public:
 private:
 	/// Create a new contact constraint
 	template <EMotionType Type1, EMotionType Type2>
-	JPH_INLINE ContactConstraint<Type1, Type2> *CreateConstraint(Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints, uint32 &outConstraintIdx);
+	JPH_INLINE ContactConstraint<Type1, Type2> *CreateConstraint(ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints);
 
 	/// Internal helper function to add a contact constraint from the cache. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair, uint32 &outConstraintIdx);
+	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair);
 
 	/// Internal helper function to add a contact constraint. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold, uint32 &outConstraintIdx);
+	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
 
 	/// Read the velocities from the motion properties
 	template <EMotionType Type1, EMotionType Type2>

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -24,24 +24,6 @@ JPH_NAMESPACE_BEGIN
 
 struct PhysicsSettings;
 class PhysicsUpdateContext;
-class IslandBuilder;
-class BodyManager;
-
-/// Activates bodies and links a contact to a body so that we can build simulation islands
-class ContactLinker
-{
-public:
-	/// Constructor
-								ContactLinker(BodyManager &inBodyManager, IslandBuilder &inIslandBuilder) : mBodyManager(inBodyManager), mIslandBuilder(inIslandBuilder) { }
-
-	/// Link a contact to two bodies
-	void						LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2);
-
-private:
-	BodyManager &				mBodyManager;
-	IslandBuilder &				mIslandBuilder;
-	bool						mLinkBodies = true;													// If we still need to activate and link these 2 bodies together
-};
 
 /// A contact constraint manager manages all contacts between two bodies
 ///
@@ -114,7 +96,7 @@ public:
 	/// Check if the contact points from the previous frame are reusable and if so copy them.
 	/// When the cache was usable and the pair has been handled: outPairHandled = true.
 	/// When a contact constraint was produced: outConstraintIdx will be the index in the constraint list, 0xffffffff otherwise.
-	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, bool &outPairHandled);
+	void						GetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, bool &outPairHandled);
 
 	/// Handle used to keep track of the current body pair
 	using BodyPairHandle = void *;
@@ -164,7 +146,7 @@ public:
 	/// r1, r2 = contact point relative to center of mass of body 1 and body 2 (r1 = p1 - x1, r2 = p2 - x2).
 	/// v1, v2 = (linear velocity, angular velocity): 6 vectors containing linear and angular velocity for body 1 and 2.
 	/// M = mass matrix, a diagonal matrix of the mass and inertia with diagonal [m1, I1, m2, I2].
-	void						AddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
+	void						AddContactConstraint(ContactAllocator &ioContactAllocator, bool &ioActivateAndLinkBodies, BodyPairHandle inBodyPair, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
 
 	/// Finalizes the contact cache, the contact cache that was generated during the calls to AddContactConstraint in this update
 	/// will be used from now on to read from. After finalizing the contact cache, the contact removed callbacks will be called.
@@ -516,15 +498,15 @@ public:
 private:
 	/// Create a new contact constraint
 	template <EMotionType Type1, EMotionType Type2>
-	JPH_INLINE ContactConstraint<Type1, Type2> *CreateConstraint(ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints);
+	JPH_INLINE ContactConstraint<Type1, Type2> *CreateConstraint(bool &ioActivateAndLinkBodies, Body &inBody1, Body &inBody2, uint64 inSortKey, Vec3Arg inWorldSpaceNormal, const ContactSettings &inSettings, uint32 inNumContactPoints);
 
 	/// Internal helper function to add a contact constraint from the cache. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair);
+	void						TemplatedGetContactsFromCache(ContactAllocator &ioContactAllocator, Body &inBody1, Body &inBody2, const CachedBodyPair &inCachedBodyPair, CachedBodyPair &outCachedBodyPair);
 
 	/// Internal helper function to add a contact constraint. Templated to the motion type to reduce the amount of branches and calculations.
 	template <EMotionType Type1, EMotionType Type2>
-	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
+	void						TemplatedAddContactConstraint(ContactAllocator &ioContactAllocator, bool &ioActivateAndLinkBodies, BodyPairHandle inBodyPairHandle, Body &inBody1, Body &inBody2, const ContactManifold &inManifold);
 
 	/// Read the velocities from the motion properties
 	template <EMotionType Type1, EMotionType Type2>

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -107,11 +107,11 @@ public:
 	/// Add a contact constraint for this frame.
 	///
 	/// @param ioContactAllocator The allocator that reserves memory for the contacts
+	/// @param ioActivateAndLinkBodies When true, this function attempts to activate and link the bodies and then sets ioActivateAndLinkBodies to false so that it only happens once
 	/// @param inBodyPair The handle for the contact cache for this body pair
 	/// @param inBody1 The first body that is colliding
 	/// @param inBody2 The second body that is colliding
 	/// @param inManifold The manifold that describes the collision
-	/// @return true if a contact constraint was created (can be false in the case of a sensor)
 	///
 	/// This is using the approach described in 'Modeling and Solving Constraints' by Erin Catto presented at GDC 2009 (and later years with slight modifications).
 	/// We're using the formulas from slide 50 - 53 combined.

--- a/Jolt/Physics/Constraints/TwoBodyConstraint.cpp
+++ b/Jolt/Physics/Constraints/TwoBodyConstraint.cpp
@@ -22,18 +22,32 @@ JPH_IMPLEMENT_SERIALIZABLE_ABSTRACT(TwoBodyConstraintSettings)
 
 void TwoBodyConstraint::BuildIslands(uint32 inConstraintIndex, IslandBuilder &ioBuilder, BodyManager &inBodyManager)
 {
+	bool body1_dynamic = mBody1->IsDynamic();
+	bool body2_dynamic = mBody2->IsDynamic();
+
 	// Activate bodies
 	BodyID body_ids[2];
 	int num_bodies = 0;
-	if (mBody1->IsDynamic() && !mBody1->IsActive())
+	if (body1_dynamic && !mBody1->IsActive())
 		body_ids[num_bodies++] = mBody1->GetID();
-	if (mBody2->IsDynamic() && !mBody2->IsActive())
+	if (body2_dynamic && !mBody2->IsActive())
 		body_ids[num_bodies++] = mBody2->GetID();
 	if (num_bodies > 0)
 		inBodyManager.ActivateBodies(body_ids, num_bodies);
 
-	// Link the bodies into the same island
-	ioBuilder.LinkConstraint(inConstraintIndex, mBody1->GetIndexInActiveBodiesInternal(), mBody2->GetIndexInActiveBodiesInternal());
+	// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
+	// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
+	if (body1_dynamic && body2_dynamic)
+		ioBuilder.LinkBodies(mBody1->GetIndexInActiveBodiesInternal(), mBody2->GetIndexInActiveBodiesInternal());
+
+	// Link the constraint to the first dynamic body
+	if (body1_dynamic)
+		ioBuilder.LinkConstraint(inConstraintIndex, mBody1->GetIndexInActiveBodiesInternal());
+	else
+	{
+		JPH_ASSERT(body2_dynamic);
+		ioBuilder.LinkConstraint(inConstraintIndex, mBody2->GetIndexInActiveBodiesInternal());
+	}
 }
 
 uint TwoBodyConstraint::BuildIslandSplits(LargeIslandSplitter &ioSplitter) const

--- a/Jolt/Physics/IslandBuilder.cpp
+++ b/Jolt/Physics/IslandBuilder.cpp
@@ -154,20 +154,18 @@ void IslandBuilder::LinkBodies(uint32 inFirst, uint32 inSecond)
 	}
 }
 
-void IslandBuilder::LinkConstraint(uint32 inConstraintIndex, uint32 inFirst, uint32 inSecond)
+void IslandBuilder::LinkConstraint(uint32 inConstraintIndex, uint32 inIndexInActiveBodyList)
 {
-	LinkBodies(inFirst, inSecond);
-
 	JPH_ASSERT(inConstraintIndex < mNumConstraints);
-	uint32 min_value = min(inFirst, inSecond); // Use fact that invalid index is 0xffffffff, we want the active body of two
-	JPH_ASSERT(min_value != Body::cInactiveIndex); // At least one of the bodies must be active
-	mConstraintLinks[inConstraintIndex] = min_value;
+	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active
+
+	mConstraintLinks[inConstraintIndex] = inIndexInActiveBodyList;
 }
 
 void IslandBuilder::LinkContact(uint32 inContactIndex, uint32 inIndexInActiveBodyList)
 {
 	JPH_ASSERT(inContactIndex < mMaxContacts);
-	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active by now
+	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active
 
 	mContactLinks[inContactIndex] = inIndexInActiveBodyList;
 }

--- a/Jolt/Physics/IslandBuilder.cpp
+++ b/Jolt/Physics/IslandBuilder.cpp
@@ -157,7 +157,7 @@ void IslandBuilder::LinkBodies(uint32 inFirst, uint32 inSecond)
 void IslandBuilder::LinkConstraint(uint32 inConstraintIndex, uint32 inIndexInActiveBodyList)
 {
 	JPH_ASSERT(inConstraintIndex < mNumConstraints);
-	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active
+	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Body should be active
 
 	mConstraintLinks[inConstraintIndex] = inIndexInActiveBodyList;
 }
@@ -165,7 +165,7 @@ void IslandBuilder::LinkConstraint(uint32 inConstraintIndex, uint32 inIndexInAct
 void IslandBuilder::LinkContact(uint32 inContactIndex, uint32 inIndexInActiveBodyList)
 {
 	JPH_ASSERT(inContactIndex < mMaxContacts);
-	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active
+	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Body should be active
 
 	mContactLinks[inContactIndex] = inIndexInActiveBodyList;
 }

--- a/Jolt/Physics/IslandBuilder.cpp
+++ b/Jolt/Physics/IslandBuilder.cpp
@@ -164,10 +164,12 @@ void IslandBuilder::LinkConstraint(uint32 inConstraintIndex, uint32 inFirst, uin
 	mConstraintLinks[inConstraintIndex] = min_value;
 }
 
-void IslandBuilder::LinkContact(uint32 inContactIndex, uint32 inFirst, uint32 inSecond)
+void IslandBuilder::LinkContact(uint32 inContactIndex, uint32 inIndexInActiveBodyList)
 {
 	JPH_ASSERT(inContactIndex < mMaxContacts);
-	mContactLinks[inContactIndex] = min(inFirst, inSecond); // Use fact that invalid index is 0xffffffff, we want the active body of two
+	JPH_ASSERT(inIndexInActiveBodyList != MotionProperties::cInactiveIndex); // Bodies should be active by now
+
+	mContactLinks[inContactIndex] = inIndexInActiveBodyList;
 }
 
 #ifdef JPH_VALIDATE_ISLAND_BUILDER

--- a/Jolt/Physics/IslandBuilder.h
+++ b/Jolt/Physics/IslandBuilder.h
@@ -34,9 +34,9 @@ public:
 	void					LinkBodies(uint32 inFirst, uint32 inSecond);
 
 	/// Link a constraint to a body by their index in the BodyManager::mActiveBodies
-	void					LinkConstraint(uint32 inConstraintIndex, uint32 inFirst, uint32 inSecond);
+	void					LinkConstraint(uint32 inConstraintIndex, uint32 inIndexInActiveBodyList);
 
-	/// Link a contact to a body
+	/// Link a contact to a body by their index in the BodyManager::mActiveBodies
 	void					LinkContact(uint32 inContactIndex, uint32 inIndexInActiveBodyList);
 
 	/// Finalize the islands after all bodies have been Link()-ed

--- a/Jolt/Physics/IslandBuilder.h
+++ b/Jolt/Physics/IslandBuilder.h
@@ -36,8 +36,8 @@ public:
 	/// Link a constraint to a body by their index in the BodyManager::mActiveBodies
 	void					LinkConstraint(uint32 inConstraintIndex, uint32 inFirst, uint32 inSecond);
 
-	/// Link a contact to a body by their index in the BodyManager::mActiveBodies
-	void					LinkContact(uint32 inContactIndex, uint32 inFirst, uint32 inSecond);
+	/// Link a contact to a body
+	void					LinkContact(uint32 inContactIndex, uint32 inIndexInActiveBodyList);
 
 	/// Finalize the islands after all bodies have been Link()-ed
 	void					Finalize(const BodyID *inActiveBodies, uint32 inNumActiveBodies, uint32 inNumContacts, TempAllocator *inTempAllocator);

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -220,6 +220,7 @@ EPhysicsUpdateError PhysicsSystem::Update(float inDeltaTime, int inCollisionStep
 	context.mPhysicsSystem = this;
 	context.mJobSystem = inJobSystem;
 	context.mBarrier = inJobSystem->CreateBarrier();
+	context.mBodyManager = &mBodyManager;
 	context.mIslandBuilder = &mIslandBuilder;
 	context.mStepDeltaTime = step_delta_time;
 	context.mWarmStartImpulseRatio = warm_start_impulse_ratio;
@@ -1075,9 +1076,8 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 
 	// Check if the contact points from the previous frame are reusable and if so copy them
 	bool pair_handled = false;
-	ContactLinker linker(mBodyManager, mIslandBuilder);
 	if (mPhysicsSettings.mUseBodyPairContactCache && !(body1->IsCollisionCacheInvalid() || body2->IsCollisionCacheInvalid()))
-		mContactManager.GetContactsFromCache(ioContactAllocator, linker, *body1, *body2, pair_handled);
+		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled);
 
 	// If the cache hasn't handled this body pair do actual collision detection
 	if (!pair_handled)
@@ -1226,6 +1226,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());
 
 			// Add the contacts
+			bool link_and_activate_bodies = true;
 			for (ContactManifold &manifold : collector.mManifolds)
 			{
 				// Normalize the normal (is a sum of all normals from merged manifolds)
@@ -1236,7 +1237,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					PruneContactPoints(manifold.mWorldSpaceNormal, manifold.mRelativeContactPointsOn1, manifold.mRelativeContactPointsOn2 JPH_IF_DEBUG_RENDERER(, manifold.mBaseOffset));
 
 				// Actually add the contact points to the manager
-				mContactManager.AddContactConstraint(ioContactAllocator, linker, body_pair_handle, *body1, *body2, manifold);
+				mContactManager.AddContactConstraint(ioContactAllocator, link_and_activate_bodies, body_pair_handle, *body1, *body2, manifold);
 			}
 		}
 		else
@@ -1247,10 +1248,9 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			class NonReductionCollideShapeCollector : public CollideShapeCollector
 			{
 			public:
-								NonReductionCollideShapeCollector(PhysicsSystem *inSystem, ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body *inBody1, Body *inBody2, const ContactConstraintManager::BodyPairHandle &inPairHandle) :
+								NonReductionCollideShapeCollector(PhysicsSystem *inSystem, ContactAllocator &ioContactAllocator, Body *inBody1, Body *inBody2, const ContactConstraintManager::BodyPairHandle &inPairHandle) :
 					mSystem(inSystem),
 					mContactAllocator(ioContactAllocator),
-					mContactLinker(ioContactLinker),
 					mBody1(inBody1),
 					mBody2(inBody2),
 					mBodyPairHandle(inPairHandle)
@@ -1309,19 +1309,18 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					manifold.mSubShapeID2 = inResult.mSubShapeID2;
 
 					// Actually add the contact points to the manager
-					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mContactLinker, mBodyPairHandle, *mBody1, *mBody2, manifold);
+					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mLinkAndActivateBodies, mBodyPairHandle, *mBody1, *mBody2, manifold);
 				}
 
 				PhysicsSystem *		mSystem;
 				ContactAllocator &	mContactAllocator;
-				ContactLinker &		mContactLinker;
 				Body *				mBody1;
 				Body *				mBody2;
 				ContactConstraintManager::BodyPairHandle mBodyPairHandle;
 				bool				mValidateBodyPair = true;
-				bool				mLinkBodies = true;
+				bool				mLinkAndActivateBodies = true;
 			};
-			NonReductionCollideShapeCollector collector(this, ioContactAllocator, linker, body1, body2, body_pair_handle);
+			NonReductionCollideShapeCollector collector(this, ioContactAllocator, body1, body2, body_pair_handle);
 
 			// Perform collision detection between the two shapes
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -1343,7 +1343,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			body1->GetMotionProperties()->GetSimulationStats().mNarrowPhaseTicks.fetch_add(num_ticks, memory_order_relaxed);
 		}
 	#endif
-	}	
+	}
 }
 
 void PhysicsSystem::JobFinalizeIslands(PhysicsUpdateContext *ioContext)

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -1044,6 +1044,42 @@ void PhysicsSystem::sDefaultSimCollideBodyVsBody(const Body &inBody1, const Body
 	}
 }
 
+void PhysicsSystem::LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2, bool &ioLinkBodies)
+{
+	bool body1_dynamic = inBody1.IsDynamic();
+	bool body2_dynamic = inBody2.IsDynamic();
+
+	if (ioLinkBodies)
+	{
+		// Do this only once
+		ioLinkBodies = false;
+
+		// Wake up sleeping bodies
+		BodyID body_ids[2];
+		int num_bodies = 0;
+		if (body1_dynamic && !inBody1.IsActive())
+			body_ids[num_bodies++] = inBody1.GetID();
+		if (body2_dynamic && !inBody2.IsActive())
+			body_ids[num_bodies++] = inBody2.GetID();
+		if (num_bodies > 0)
+			mBodyManager.ActivateBodies(body_ids, num_bodies);
+
+		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
+		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
+		if (body1_dynamic && body2_dynamic)
+			mIslandBuilder.LinkBodies(inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
+	}
+
+	// Link the contact to the first dynamic body
+	if (body1_dynamic)
+		mIslandBuilder.LinkContact(inConstraintIdx, inBody1.GetIndexInActiveBodiesInternal());
+	else
+	{
+		JPH_ASSERT(body2_dynamic);
+		mIslandBuilder.LinkContact(inConstraintIdx, inBody2.GetIndexInActiveBodiesInternal());
+	}
+}
+
 void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const BodyPair &inBodyPair)
 {
 	JPH_PROFILE_FUNCTION();
@@ -1075,12 +1111,21 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 
 	// Check if the contact points from the previous frame are reusable and if so copy them
 	bool pair_handled = false;
-	uint32 constraint_idx = ~uint32(0);
+	uint32 constraint_idx_from_cache = ~uint32(0);
 	if (mPhysicsSettings.mUseBodyPairContactCache && !(body1->IsCollisionCacheInvalid() || body2->IsCollisionCacheInvalid()))
-		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled, constraint_idx);
+		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled, constraint_idx_from_cache);
 
 	// If the cache hasn't handled this body pair do actual collision detection
-	if (!pair_handled)
+	if (pair_handled)
+	{
+		if (constraint_idx_from_cache != ~uint32(0))
+		{
+			// Activate bodies and link them to the constraint
+			bool link_bodies = true;
+			LinkContact(constraint_idx_from_cache, *body1, *body2, link_bodies);
+		}
+	}
+	else
 	{
 	#ifdef JPH_TRACK_SIMULATION_STATS
 		uint64 start_ticks = GetProcessorTickCount();
@@ -1226,6 +1271,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());
 
 			// Add the contacts
+			bool link_bodies = true;
 			for (ContactManifold &manifold : collector.mManifolds)
 			{
 				// Normalize the normal (is a sum of all normals from merged manifolds)
@@ -1236,8 +1282,12 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					PruneContactPoints(manifold.mWorldSpaceNormal, manifold.mRelativeContactPointsOn1, manifold.mRelativeContactPointsOn2 JPH_IF_DEBUG_RENDERER(, manifold.mBaseOffset));
 
 				// Actually add the contact points to the manager
+				uint32 constraint_idx = ~uint32(0);
 				mContactManager.AddContactConstraint(ioContactAllocator, body_pair_handle, *body1, *body2, manifold, constraint_idx);
-				// TODO link contact
+
+				// Activate bodies and link them to the constraint
+				if (constraint_idx != ~uint32(0))
+					LinkContact(constraint_idx, *body1, *body2, link_bodies);
 			}
 		}
 		else
@@ -1309,9 +1359,12 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					manifold.mSubShapeID2 = inResult.mSubShapeID2;
 
 					// Actually add the contact points to the manager
-					uint32 constraint_idx;
+					uint32 constraint_idx = ~uint32(0);
 					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mBodyPairHandle, *mBody1, *mBody2, manifold, constraint_idx);
-					// TODO link contact
+
+					// Activate bodies and link them to the constraint
+					if (constraint_idx != ~uint32(0))
+						mSystem->LinkContact(constraint_idx, *mBody1, *mBody2, mLinkBodies);
 				}
 
 				PhysicsSystem *		mSystem;
@@ -1320,6 +1373,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 				Body *				mBody2;
 				ContactConstraintManager::BodyPairHandle mBodyPairHandle;
 				bool				mValidateBodyPair = true;
+				bool				mLinkBodies = true;
 			};
 			NonReductionCollideShapeCollector collector(this, ioContactAllocator, body1, body2, body_pair_handle);
 
@@ -1344,37 +1398,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			body1->GetMotionProperties()->GetSimulationStats().mNarrowPhaseTicks.fetch_add(num_ticks, memory_order_relaxed);
 		}
 	#endif
-	}
-
-	// If a contact constraint was created, we need to do some extra work
-	if (constraint_idx != ~uint32(0))
-	{
-		// Wake up sleeping bodies
-		BodyID body_ids[2];
-		int num_bodies = 0;
-		bool body1_dynamic = body1->IsDynamic();
-		if (body1_dynamic && !body1->IsActive())
-			body_ids[num_bodies++] = body1->GetID();
-		bool body2_dynamic = body2->IsDynamic();
-		if (body2_dynamic && !body2->IsActive())
-			body_ids[num_bodies++] = body2->GetID();
-		if (num_bodies > 0)
-			mBodyManager.ActivateBodies(body_ids, num_bodies);
-
-		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
-		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
-		if (body1_dynamic)
-		{
-			if (body2_dynamic)
-				mIslandBuilder.LinkBodies(body1->GetIndexInActiveBodiesInternal(), body2->GetIndexInActiveBodiesInternal());
-			mIslandBuilder.LinkContact(constraint_idx, body1->GetIndexInActiveBodiesInternal());
-		}
-		else
-		{
-			JPH_ASSERT(body2_dynamic);
-			mIslandBuilder.LinkContact(constraint_idx, body2->GetIndexInActiveBodiesInternal());
-		}
-	}
+	}	
 }
 
 void PhysicsSystem::JobFinalizeIslands(PhysicsUpdateContext *ioContext)

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -1074,9 +1074,10 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 		std::swap(body1, body2);
 
 	// Check if the contact points from the previous frame are reusable and if so copy them
-	bool pair_handled = false, constraint_created = false;
+	bool pair_handled = false;
+	uint32 constraint_idx = ~uint32(0);
 	if (mPhysicsSettings.mUseBodyPairContactCache && !(body1->IsCollisionCacheInvalid() || body2->IsCollisionCacheInvalid()))
-		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled, constraint_created);
+		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled, constraint_idx);
 
 	// If the cache hasn't handled this body pair do actual collision detection
 	if (!pair_handled)
@@ -1235,7 +1236,8 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					PruneContactPoints(manifold.mWorldSpaceNormal, manifold.mRelativeContactPointsOn1, manifold.mRelativeContactPointsOn2 JPH_IF_DEBUG_RENDERER(, manifold.mBaseOffset));
 
 				// Actually add the contact points to the manager
-				constraint_created |= mContactManager.AddContactConstraint(ioContactAllocator, body_pair_handle, *body1, *body2, manifold);
+				mContactManager.AddContactConstraint(ioContactAllocator, body_pair_handle, *body1, *body2, manifold, constraint_idx);
+				// TODO link contact
 			}
 		}
 		else
@@ -1307,7 +1309,9 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					manifold.mSubShapeID2 = inResult.mSubShapeID2;
 
 					// Actually add the contact points to the manager
-					mConstraintCreated |= mSystem->mContactManager.AddContactConstraint(mContactAllocator, mBodyPairHandle, *mBody1, *mBody2, manifold);
+					uint32 constraint_idx;
+					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mBodyPairHandle, *mBody1, *mBody2, manifold, constraint_idx);
+					// TODO link contact
 				}
 
 				PhysicsSystem *		mSystem;
@@ -1316,14 +1320,11 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 				Body *				mBody2;
 				ContactConstraintManager::BodyPairHandle mBodyPairHandle;
 				bool				mValidateBodyPair = true;
-				bool				mConstraintCreated = false;
 			};
 			NonReductionCollideShapeCollector collector(this, ioContactAllocator, body1, body2, body_pair_handle);
 
 			// Perform collision detection between the two shapes
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());
-
-			constraint_created = collector.mConstraintCreated;
 		}
 
 	#ifdef JPH_TRACK_SIMULATION_STATS
@@ -1346,20 +1347,33 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 	}
 
 	// If a contact constraint was created, we need to do some extra work
-	if (constraint_created)
+	if (constraint_idx != ~uint32(0))
 	{
 		// Wake up sleeping bodies
 		BodyID body_ids[2];
 		int num_bodies = 0;
-		if (body1->IsDynamic() && !body1->IsActive())
+		bool body1_dynamic = body1->IsDynamic();
+		if (body1_dynamic && !body1->IsActive())
 			body_ids[num_bodies++] = body1->GetID();
-		if (body2->IsDynamic() && !body2->IsActive())
+		bool body2_dynamic = body2->IsDynamic();
+		if (body2_dynamic && !body2->IsActive())
 			body_ids[num_bodies++] = body2->GetID();
 		if (num_bodies > 0)
 			mBodyManager.ActivateBodies(body_ids, num_bodies);
 
-		// Link the two bodies
-		mIslandBuilder.LinkBodies(body1->GetIndexInActiveBodiesInternal(), body2->GetIndexInActiveBodiesInternal());
+		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
+		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
+		if (body1_dynamic)
+		{
+			if (body2_dynamic)
+				mIslandBuilder.LinkBodies(body1->GetIndexInActiveBodiesInternal(), body2->GetIndexInActiveBodiesInternal());
+			mIslandBuilder.LinkContact(constraint_idx, body1->GetIndexInActiveBodiesInternal());
+		}
+		else
+		{
+			JPH_ASSERT(body2_dynamic);
+			mIslandBuilder.LinkContact(constraint_idx, body2->GetIndexInActiveBodiesInternal());
+		}
 	}
 }
 

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -1044,42 +1044,6 @@ void PhysicsSystem::sDefaultSimCollideBodyVsBody(const Body &inBody1, const Body
 	}
 }
 
-void PhysicsSystem::LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2, bool &ioLinkBodies)
-{
-	bool body1_dynamic = inBody1.IsDynamic();
-	bool body2_dynamic = inBody2.IsDynamic();
-
-	if (ioLinkBodies)
-	{
-		// Do this only once
-		ioLinkBodies = false;
-
-		// Wake up sleeping bodies
-		BodyID body_ids[2];
-		int num_bodies = 0;
-		if (body1_dynamic && !inBody1.IsActive())
-			body_ids[num_bodies++] = inBody1.GetID();
-		if (body2_dynamic && !inBody2.IsActive())
-			body_ids[num_bodies++] = inBody2.GetID();
-		if (num_bodies > 0)
-			mBodyManager.ActivateBodies(body_ids, num_bodies);
-
-		// Link the two bodies only if both are dynamic. If one of them is static or kinematic they don't need to go into
-		// the same simulation island as a constraint cannot affect the velocity of a kinematic body.
-		if (body1_dynamic && body2_dynamic)
-			mIslandBuilder.LinkBodies(inBody1.GetIndexInActiveBodiesInternal(), inBody2.GetIndexInActiveBodiesInternal());
-	}
-
-	// Link the contact to the first dynamic body
-	if (body1_dynamic)
-		mIslandBuilder.LinkContact(inConstraintIdx, inBody1.GetIndexInActiveBodiesInternal());
-	else
-	{
-		JPH_ASSERT(body2_dynamic);
-		mIslandBuilder.LinkContact(inConstraintIdx, inBody2.GetIndexInActiveBodiesInternal());
-	}
-}
-
 void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const BodyPair &inBodyPair)
 {
 	JPH_PROFILE_FUNCTION();
@@ -1111,21 +1075,12 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 
 	// Check if the contact points from the previous frame are reusable and if so copy them
 	bool pair_handled = false;
-	uint32 constraint_idx_from_cache = ~uint32(0);
+	ContactLinker linker(mBodyManager, mIslandBuilder);
 	if (mPhysicsSettings.mUseBodyPairContactCache && !(body1->IsCollisionCacheInvalid() || body2->IsCollisionCacheInvalid()))
-		mContactManager.GetContactsFromCache(ioContactAllocator, *body1, *body2, pair_handled, constraint_idx_from_cache);
+		mContactManager.GetContactsFromCache(ioContactAllocator, linker, *body1, *body2, pair_handled);
 
 	// If the cache hasn't handled this body pair do actual collision detection
-	if (pair_handled)
-	{
-		if (constraint_idx_from_cache != ~uint32(0))
-		{
-			// Activate bodies and link them to the constraint
-			bool link_bodies = true;
-			LinkContact(constraint_idx_from_cache, *body1, *body2, link_bodies);
-		}
-	}
-	else
+	if (!pair_handled)
 	{
 	#ifdef JPH_TRACK_SIMULATION_STATS
 		uint64 start_ticks = GetProcessorTickCount();
@@ -1271,7 +1226,6 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());
 
 			// Add the contacts
-			bool link_bodies = true;
 			for (ContactManifold &manifold : collector.mManifolds)
 			{
 				// Normalize the normal (is a sum of all normals from merged manifolds)
@@ -1282,12 +1236,7 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					PruneContactPoints(manifold.mWorldSpaceNormal, manifold.mRelativeContactPointsOn1, manifold.mRelativeContactPointsOn2 JPH_IF_DEBUG_RENDERER(, manifold.mBaseOffset));
 
 				// Actually add the contact points to the manager
-				uint32 constraint_idx = ~uint32(0);
-				mContactManager.AddContactConstraint(ioContactAllocator, body_pair_handle, *body1, *body2, manifold, constraint_idx);
-
-				// Activate bodies and link them to the constraint
-				if (constraint_idx != ~uint32(0))
-					LinkContact(constraint_idx, *body1, *body2, link_bodies);
+				mContactManager.AddContactConstraint(ioContactAllocator, linker, body_pair_handle, *body1, *body2, manifold);
 			}
 		}
 		else
@@ -1298,9 +1247,10 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 			class NonReductionCollideShapeCollector : public CollideShapeCollector
 			{
 			public:
-								NonReductionCollideShapeCollector(PhysicsSystem *inSystem, ContactAllocator &ioContactAllocator, Body *inBody1, Body *inBody2, const ContactConstraintManager::BodyPairHandle &inPairHandle) :
+								NonReductionCollideShapeCollector(PhysicsSystem *inSystem, ContactAllocator &ioContactAllocator, ContactLinker &ioContactLinker, Body *inBody1, Body *inBody2, const ContactConstraintManager::BodyPairHandle &inPairHandle) :
 					mSystem(inSystem),
 					mContactAllocator(ioContactAllocator),
+					mContactLinker(ioContactLinker),
 					mBody1(inBody1),
 					mBody2(inBody2),
 					mBodyPairHandle(inPairHandle)
@@ -1359,23 +1309,19 @@ void PhysicsSystem::ProcessBodyPair(ContactAllocator &ioContactAllocator, const 
 					manifold.mSubShapeID2 = inResult.mSubShapeID2;
 
 					// Actually add the contact points to the manager
-					uint32 constraint_idx = ~uint32(0);
-					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mBodyPairHandle, *mBody1, *mBody2, manifold, constraint_idx);
-
-					// Activate bodies and link them to the constraint
-					if (constraint_idx != ~uint32(0))
-						mSystem->LinkContact(constraint_idx, *mBody1, *mBody2, mLinkBodies);
+					mSystem->mContactManager.AddContactConstraint(mContactAllocator, mContactLinker, mBodyPairHandle, *mBody1, *mBody2, manifold);
 				}
 
 				PhysicsSystem *		mSystem;
 				ContactAllocator &	mContactAllocator;
+				ContactLinker &		mContactLinker;
 				Body *				mBody1;
 				Body *				mBody2;
 				ContactConstraintManager::BodyPairHandle mBodyPairHandle;
 				bool				mValidateBodyPair = true;
 				bool				mLinkBodies = true;
 			};
-			NonReductionCollideShapeCollector collector(this, ioContactAllocator, body1, body2, body_pair_handle);
+			NonReductionCollideShapeCollector collector(this, ioContactAllocator, linker, body1, body2, body_pair_handle);
 
 			// Perform collision detection between the two shapes
 			mSimCollideBodyVsBody(*body1, *body2, transform1, transform2, settings, collector, shape_filter.GetFilter());

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -305,6 +305,9 @@ private:
 	/// Called at the end of JobSolveVelocityConstraints to check if bodies need to go to sleep and to update their bounding box in the broadphase
 	void						CheckSleepAndUpdateBounds(uint32 inIslandIndex, const PhysicsUpdateContext *ioContext, const PhysicsUpdateContext::Step *ioStep, BodiesToSleep &ioBodiesToSleep);
 
+	/// Link a contact constraint to one of the bodies so it's solved in the same island
+	void						LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2, bool &ioLinkBodies);
+
 	/// Number of constraints to process at once in JobDetermineActiveConstraints
 	static constexpr int		cDetermineActiveConstraintsBatchSize = 64;
 

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -305,9 +305,6 @@ private:
 	/// Called at the end of JobSolveVelocityConstraints to check if bodies need to go to sleep and to update their bounding box in the broadphase
 	void						CheckSleepAndUpdateBounds(uint32 inIslandIndex, const PhysicsUpdateContext *ioContext, const PhysicsUpdateContext::Step *ioStep, BodiesToSleep &ioBodiesToSleep);
 
-	/// Link a contact constraint to one of the bodies so it's solved in the same island
-	void						LinkContact(uint32 inConstraintIdx, const Body &inBody1, const Body &inBody2, bool &ioLinkBodies);
-
 	/// Number of constraints to process at once in JobDetermineActiveConstraints
 	static constexpr int		cDetermineActiveConstraintsBatchSize = 64;
 

--- a/Jolt/Physics/PhysicsUpdateContext.h
+++ b/Jolt/Physics/PhysicsUpdateContext.h
@@ -14,6 +14,7 @@
 JPH_NAMESPACE_BEGIN
 
 class PhysicsSystem;
+class BodyManager;
 class IslandBuilder;
 class Constraint;
 class TempAllocator;
@@ -163,6 +164,7 @@ public:
 
 	BodyPair *				mBodyPairs = nullptr;									///< A list of body pairs found by the broadphase
 
+	BodyManager *			mBodyManager;											///< Keeps track of all bodies in the simulation
 	IslandBuilder *			mIslandBuilder;											///< Keeps track of connected bodies and builds islands for multithreaded velocity/position update
 
 	Steps					mSteps;

--- a/Jolt/Physics/Vehicle/VehicleConstraint.cpp
+++ b/Jolt/Physics/Vehicle/VehicleConstraint.cpp
@@ -366,17 +366,16 @@ void VehicleConstraint::BuildIslands(uint32 inConstraintIndex, IslandBuilder &io
 		inBodyManager.ActivateBodies(body_ids, num_bodies);
 	}
 
-	// Link the bodies into the same island
-	uint32 min_active_index = Body::cInactiveIndex;
+	// Link dynamic bodies into the same island as the vehicle
 	for (int i = 0; i < num_bodies; ++i)
 	{
 		const Body &body = inBodyManager.GetBody(body_ids[i]);
-		min_active_index = min(min_active_index, body.GetIndexInActiveBodiesInternal());
-		ioBuilder.LinkBodies(mBody->GetIndexInActiveBodiesInternal(), body.GetIndexInActiveBodiesInternal());
+		if (body.IsDynamic())
+			ioBuilder.LinkBodies(mBody->GetIndexInActiveBodiesInternal(), body.GetIndexInActiveBodiesInternal());
 	}
 
-	// Link the constraint in the island
-	ioBuilder.LinkConstraint(inConstraintIndex, mBody->GetIndexInActiveBodiesInternal(), min_active_index);
+	// Link the vehicle constraint to the car body
+	ioBuilder.LinkConstraint(inConstraintIndex, mBody->GetIndexInActiveBodiesInternal());
 }
 
 uint VehicleConstraint::BuildIslandSplits(LargeIslandSplitter &ioSplitter) const

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -2262,7 +2262,8 @@ TEST_SUITE("PhysicsTests")
 		}
 	}
 
-	TEST_CASE("TestMotionTypeVsSimulationIslands")
+	// Tests that colliding dynamic bodies are put in the same simulation island and that kinematic and static bodies are not
+	TEST_CASE("TestContactsVsSimulationIslands")
 	{
 		EMotionType motion_types[] = { EMotionType::Static, EMotionType::Kinematic, EMotionType::Dynamic };
 		for (EMotionType m1 : motion_types)
@@ -2287,25 +2288,15 @@ TEST_SUITE("PhysicsTests")
 					uint32 island_index2 = get_island_index(b2);
 					uint32 island_index3 = get_island_index(b3);
 
-					if (m1 == EMotionType::Dynamic)
+					if (m1 == EMotionType::Dynamic && m2 == EMotionType::Dynamic)
 					{
-						if (m2 == EMotionType::Dynamic)
-						{
-							// Two dynamic bodies should always be in the same island
-							CHECK(island_index1 != MotionProperties::cInactiveIndex);
-							CHECK(island_index1 == island_index2);
-						}
-						else
-						{
-							// A dynamic body should be in an island with any other dynamic bodies but not with kinematic or static bodies
-							CHECK(island_index1 != MotionProperties::cInactiveIndex);
-							CHECK(island_index1 != island_index2);
-							CHECK(island_index1 != island_index3);
-						}
+						// Two dynamic bodies should always be in the same island
+						CHECK(island_index1 != MotionProperties::cInactiveIndex);
+						CHECK(island_index1 == island_index2);
 					}
-					else if (m1 == EMotionType::Kinematic)
+					else if (m1 == EMotionType::Dynamic || m1 == EMotionType::Kinematic)
 					{
-						// A kinematic body should be in an island of its own
+						// A kinematic body or a dynamic body that is touching a kinematic/static body should be in an island of its own
 						CHECK(island_index1 != MotionProperties::cInactiveIndex);
 						CHECK(island_index1 != island_index2);
 						CHECK(island_index1 != island_index3);
@@ -2316,25 +2307,15 @@ TEST_SUITE("PhysicsTests")
 						CHECK(island_index1 == MotionProperties::cInactiveIndex);
 					}
 
-					if (m3 == EMotionType::Dynamic)
+					if (m3 == EMotionType::Dynamic && m2 == EMotionType::Dynamic)
 					{
-						if (m2 == EMotionType::Dynamic)
-						{
-							// Two dynamic bodies should always be in the same island
-							CHECK(island_index3 != MotionProperties::cInactiveIndex);
-							CHECK(island_index2 == island_index3);
-						}
-						else
-						{
-							// A dynamic body should be in an island with any other dynamic bodies but not with kinematic or static bodies
-							CHECK(island_index3 != MotionProperties::cInactiveIndex);
-							CHECK(island_index3 != island_index2);
-							CHECK(island_index3 != island_index1);
-						}
+						// Two dynamic bodies should always be in the same island
+						CHECK(island_index3 != MotionProperties::cInactiveIndex);
+						CHECK(island_index2 == island_index3);
 					}
-					else if (m3 == EMotionType::Kinematic)
+					else if (m3 == EMotionType::Dynamic || m3 == EMotionType::Kinematic)
 					{
-						// A kinematic body should be in an island of its own
+						// A kinematic body or a dynamic body that is touching a kinematic/static body should be in an island of its own
 						CHECK(island_index3 != MotionProperties::cInactiveIndex);
 						CHECK(island_index3 != island_index2);
 						CHECK(island_index3 != island_index1);

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -2261,4 +2261,89 @@ TEST_SUITE("PhysicsTests")
 			c.GetSystem()->OptimizeBroadPhase();
 		}
 	}
+
+	TEST_CASE("TestMotionTypeVsSimulationIslands")
+	{
+		EMotionType motion_types[] = { EMotionType::Static, EMotionType::Kinematic, EMotionType::Dynamic };
+		for (EMotionType m1 : motion_types)
+			for (EMotionType m2 : motion_types)
+				for (EMotionType m3 : motion_types)
+				{
+					// Create 3 boxes with different motion types that are all touching each other
+					PhysicsTestContext c;
+					Body &b1 = c.CreateBox(RVec3(0, 0, 0), Quat::sIdentity(), m1, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+					Body &b2 = c.CreateBox(RVec3(1.99f, 0, 0), Quat::sIdentity(), m2, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+					Body &b3 = c.CreateBox(RVec3(3.98f, 0, 0), Quat::sIdentity(), m3, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+
+					// Simulate a step to make sure we properly create simulation islands with different motion types in them
+					c.SimulateSingleStep();
+
+					auto get_island_index = [](const Body &inBody)
+					{
+						return inBody.IsStatic()? MotionProperties::cInactiveIndex : inBody.GetMotionProperties()->GetIslandIndexInternal();
+					};
+
+					uint32 island_index1 = get_island_index(b1);
+					uint32 island_index2 = get_island_index(b2);
+					uint32 island_index3 = get_island_index(b3);
+
+					if (m1 == EMotionType::Dynamic)
+					{
+						if (m2 == EMotionType::Dynamic)
+						{
+							// Two dynamic bodies should always be in the same island
+							CHECK(island_index1 != MotionProperties::cInactiveIndex);
+							CHECK(island_index1 == island_index2);
+						}
+						else
+						{
+							// A dynamic body should be in an island with any other dynamic bodies but not with kinematic or static bodies
+							CHECK(island_index1 != MotionProperties::cInactiveIndex);
+							CHECK(island_index1 != island_index2);
+							CHECK(island_index1 != island_index3);
+						}
+					}
+					else if (m1 == EMotionType::Kinematic)
+					{
+						// A kinematic body should be in an island of its own
+						CHECK(island_index1 != MotionProperties::cInactiveIndex);
+						CHECK(island_index1 != island_index2);
+						CHECK(island_index1 != island_index3);
+					}
+					else
+					{
+						// Static bodies should not be in an island
+						CHECK(island_index1 == MotionProperties::cInactiveIndex);
+					}
+
+					if (m3 == EMotionType::Dynamic)
+					{
+						if (m2 == EMotionType::Dynamic)
+						{
+							// Two dynamic bodies should always be in the same island
+							CHECK(island_index3 != MotionProperties::cInactiveIndex);
+							CHECK(island_index2 == island_index3);
+						}
+						else
+						{
+							// A dynamic body should be in an island with any other dynamic bodies but not with kinematic or static bodies
+							CHECK(island_index3 != MotionProperties::cInactiveIndex);
+							CHECK(island_index3 != island_index2);
+							CHECK(island_index3 != island_index1);
+						}
+					}
+					else if (m3 == EMotionType::Kinematic)
+					{
+						// A kinematic body should be in an island of its own
+						CHECK(island_index3 != MotionProperties::cInactiveIndex);
+						CHECK(island_index3 != island_index2);
+						CHECK(island_index3 != island_index1);
+					}
+					else
+					{
+						// Static bodies should not be in an island
+						CHECK(island_index3 == MotionProperties::cInactiveIndex);
+					}
+				}
+	}
 }

--- a/UnitTests/Physics/SliderConstraintTests.cpp
+++ b/UnitTests/Physics/SliderConstraintTests.cpp
@@ -7,6 +7,7 @@
 #include <Jolt/Physics/Constraints/SliderConstraint.h>
 #include <Jolt/Physics/Collision/GroupFilterTable.h>
 #include "Layers.h"
+#include "LoggingContactListener.h"
 
 TEST_SUITE("SliderConstraintTests")
 {
@@ -503,5 +504,83 @@ TEST_SUITE("SliderConstraintTests")
 				CHECK_APPROX_EQUAL(body.GetPosition().GetZ(), 0);
 			}
 		}
+	}
+
+	// Tests that constrained dynamic bodies are put in the same simulation island and that kinematic and static bodies are not
+	TEST_CASE("TestConstraintsVsSimulationIslands")
+	{
+		EMotionType motion_types[] = { EMotionType::Static, EMotionType::Kinematic, EMotionType::Dynamic };
+		for (EMotionType m1 : motion_types)
+			for (EMotionType m2 : motion_types)
+				for (EMotionType m3 : motion_types)
+				{
+					// Create 3 boxes with different motion types that are apart
+					PhysicsTestContext c;
+					Body &b1 = c.CreateBox(RVec3(0, 0, 0), Quat::sIdentity(), m1, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+					Body &b2 = c.CreateBox(RVec3(5, 0, 0), Quat::sIdentity(), m2, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+					Body &b3 = c.CreateBox(RVec3(10, 0, 0), Quat::sIdentity(), m3, EMotionQuality::Discrete, Layers::MOVING, Vec3::sOne(), EActivation::Activate);
+
+					// Constrain b1 to b2 and b2 to b3
+					SliderConstraintSettings s;
+					s.mAutoDetectPoint = true;
+					c.GetSystem()->AddConstraint(s.Create(b1, b2));
+					c.GetSystem()->AddConstraint(s.Create(b2, b3));
+
+					LoggingContactListener listener;
+					c.GetSystem()->SetContactListener(&listener);
+
+					// Simulate a step to make sure we properly create simulation islands with different motion types in them
+					c.SimulateSingleStep();
+
+					// Nothing should have collided
+					CHECK(listener.GetEntryCount() == 0);
+
+					auto get_island_index = [](const Body &inBody)
+					{
+						return inBody.IsStatic()? MotionProperties::cInactiveIndex : inBody.GetMotionProperties()->GetIslandIndexInternal();
+					};
+
+					uint32 island_index1 = get_island_index(b1);
+					uint32 island_index2 = get_island_index(b2);
+					uint32 island_index3 = get_island_index(b3);
+
+					if (m1 == EMotionType::Dynamic && m2 == EMotionType::Dynamic)
+					{
+						// Two dynamic bodies should always be in the same island
+						CHECK(island_index1 != MotionProperties::cInactiveIndex);
+						CHECK(island_index1 == island_index2);
+					}
+					else if (m1 == EMotionType::Dynamic || m1 == EMotionType::Kinematic)
+					{
+						// A kinematic body or a dynamic body that is touching a kinematic/static body should be in an island of its own
+						CHECK(island_index1 != MotionProperties::cInactiveIndex);
+						CHECK(island_index1 != island_index2);
+						CHECK(island_index1 != island_index3);
+					}
+					else
+					{
+						// Static bodies should not be in an island
+						CHECK(island_index1 == MotionProperties::cInactiveIndex);
+					}
+
+					if (m3 == EMotionType::Dynamic && m2 == EMotionType::Dynamic)
+					{
+						// Two dynamic bodies should always be in the same island
+						CHECK(island_index3 != MotionProperties::cInactiveIndex);
+						CHECK(island_index2 == island_index3);
+					}
+					else if (m3 == EMotionType::Dynamic || m3 == EMotionType::Kinematic)
+					{
+						// A kinematic body or a dynamic body that is touching a kinematic/static body should be in an island of its own
+						CHECK(island_index3 != MotionProperties::cInactiveIndex);
+						CHECK(island_index3 != island_index2);
+						CHECK(island_index3 != island_index1);
+					}
+					else
+					{
+						// Static bodies should not be in an island
+						CHECK(island_index3 == MotionProperties::cInactiveIndex);
+					}
+				}
 	}
 }


### PR DESCRIPTION
Kinematic bodies were assigned to the same island as bodies that were constrained to / in contact with them. This led to larger simulation islands and impacted performance.