### PR TITLE
ComputeSystemVKImpl.cpp:  add support for Android platforms

### DIFF
--- a/Jolt/Compute/VK/ComputeSystemVKImpl.cpp
+++ b/Jolt/Compute/VK/ComputeSystemVKImpl.cpp
@@ -9,7 +9,7 @@
 #include <Jolt/Compute/VK/ComputeSystemVKImpl.h>
 #include <Jolt/Core/QuickSort.h>
 #include <Jolt/Core/IncludeWindows.h>
-#if defined(JPH_PLATFORM_LINUX) || defined(JPH_PLATFORM_MACOS)
+#if defined(JPH_PLATFORM_LINUX) || defined(JPH_PLATFORM_ANDROID) ||defined(JPH_PLATFORM_MACOS)
 #include <dlfcn.h>
 #endif
 
@@ -58,7 +58,7 @@ bool ComputeSystemVKImpl::Initialize(ComputeSystemResult &outResult)
 		return false;
 	}
 	mVkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(reinterpret_cast<void *>(GetProcAddress(module, "vkGetInstanceProcAddr")));
-#elif defined(JPH_PLATFORM_LINUX)
+#elif defined(JPH_PLATFORM_LINUX) || defined(JPH_PLATFORM_ANDROID)
 	void *library = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
 	if (!library)
 		library = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
This PR adds support for Vulkan compute servers on Android platforms.
I tested this on an emulator, and it worked as expected.