### PR TITLE
Use vfsqrt in place of sqrt libm in RVV code.

### DIFF
--- a/Jolt/Core/RISCVVector.h
+++ b/Jolt/Core/RISCVVector.h
@@ -92,7 +92,7 @@ JPH_INLINE vfloat32m1_t RVVShuffleFloat32x4<1, 3, 5, 7>(vfloat32m1_t inV0, vfloa
 }
 
 /// Given inV = (a, b, c, d), calculates (a + b) + (c + d) when cross platform determinism is on, otherwise calculates a + b + c + d (order undefined)
-JPH_INLINE float RVVSumElementsFloat32x4(vfloat32m1_t inV)
+JPH_INLINE vfloat32m1_t RVVSumElementsFloat32x4(vfloat32m1_t inV)
 {
 #ifdef JPH_CROSS_PLATFORM_DETERMINISTIC
 	const vfloat32m1_t shift1 = __riscv_vslidedown_vx_f32m1(inV, 1, 4);
@@ -103,7 +103,7 @@ JPH_INLINE float RVVSumElementsFloat32x4(vfloat32m1_t inV)
 	const vfloat32m1_t zeros = __riscv_vfmv_v_f_f32m1(0.0f, 4);
 	const vfloat32m1_t sum = __riscv_vfredusum_vs_f32m1_f32m1(inV, zeros, 4);
 #endif
-	return __riscv_vfmv_f_s_f32m1_f32(sum);
+	return sum;
 }
 
 #endif // JPH_USE_RVV

--- a/Jolt/Math/Mat44.inl
+++ b/Jolt/Math/Mat44.inl
@@ -899,8 +899,9 @@ Mat44 Mat44::Inversed() const
 	minor3 = __riscv_vfadd_vv_f32m1(__riscv_vfmul_vv_f32m1(row1, tmp1, 4), minor3, 4);
 
 	const vfloat32m1_t v_det = __riscv_vfmul_vv_f32m1(row0, minor0, 4);
-	const float s_det = RVVSumElementsFloat32x4(v_det);
-	const vfloat32m1_t det_inv = __riscv_vfmv_v_f_f32m1(1.0f / s_det, 4);
+	const vfloat32m1_t s_det = RVVSumElementsFloat32x4(v_det);
+	const vfloat32m1_t det_splat = __riscv_vrgather_vx_f32m1(s_det, 0, 4);
+	const vfloat32m1_t det_inv = __riscv_vfrdiv_vf_f32m1(det_splat, 1.0f, 4);
 
 	minor0 = __riscv_vfmul_vv_f32m1(det_inv, minor0, 4);
 	minor1 = __riscv_vfmul_vv_f32m1(det_inv, minor1, 4);

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -1017,8 +1017,8 @@ float Vec3::Length() const
 	const vfloat32m1_t v = __riscv_vle32_v_f32m1(mF32, 3);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v, v, 3);
 	const vfloat32m1_t sum = __riscv_vfredosum_vs_f32m1_f32m1(mul, zeros, 3);
-	const float dot = __riscv_vfmv_f_s_f32m1_f32(sum);
-	return sqrt(dot);
+	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(sum, 1);
+	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
 	return sqrt(LengthSq());
 #endif
@@ -1061,9 +1061,9 @@ Vec3 Vec3::Normalized() const
 	const vfloat32m1_t v = __riscv_vle32_v_f32m1(mF32, 3);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v, v, 3);
 	const vfloat32m1_t sum = __riscv_vfredosum_vs_f32m1_f32m1(mul, zeros, 3);
-	const float dot = __riscv_vfmv_f_s_f32m1_f32(sum);
-	const float magnitude = sqrt(dot);
-	const vfloat32m1_t norm_v = __riscv_vfdiv_vf_f32m1(v, magnitude, 3);
+	const vfloat32m1_t splat = __riscv_vrgather_vx_f32m1(sum, 0, 3);
+	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(splat, 3);
+	const vfloat32m1_t norm_v = __riscv_vfdiv_vv_f32m1(v, sqrt, 3);
 
 	Vec3 res;
 	__riscv_vse32_v_f32m1(res.mF32, norm_v, 3);
@@ -1110,10 +1110,11 @@ Vec3 Vec3::NormalizedOr(Vec3Arg inZeroValue) const
 	if (dot <= FLT_MIN)
 		return inZeroValue;
 
-	const float length = sqrt(dot);
+	const vfloat32m1_t splat = __riscv_vrgather_vx_f32m1(sum, 0, 3);
+	const vfloat32m1_t length = __riscv_vfsqrt_v_f32m1(splat, 3);
 
 	Vec3 v;
-	const vfloat32m1_t norm = __riscv_vfdiv_vf_f32m1(src, length, 3);
+	const vfloat32m1_t norm = __riscv_vfdiv_vv_f32m1(src, length, 3);
 	__riscv_vse32_v_f32m1(v.mF32, norm, 3);
 	return v;
 #else

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -989,8 +989,8 @@ Vec4 Vec4::DotV(Vec4Arg inV2) const
 	const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(mF32, 4);
 	const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inV2.mF32, 4);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v1, v2, 4);
-	float dot = RVVSumElementsFloat32x4(mul);
-	const vfloat32m1_t splat = __riscv_vfmv_v_f_f32m1(dot, 4);
+	vfloat32m1_t dot = RVVSumElementsFloat32x4(mul);
+	const vfloat32m1_t splat = __riscv_vrgather_vx_f32m1(dot, 0, 4);
 	__riscv_vse32_v_f32m1(res.mF32, splat, 4);
 	return res;
 #else
@@ -1010,7 +1010,7 @@ float Vec4::Dot(Vec4Arg inV2) const
 	const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(mF32, 4);
 	const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inV2.mF32, 4);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v1, v2, 4);
-	return RVVSumElementsFloat32x4(mul);
+	return __riscv_vfmv_f_s_f32m1_f32(RVVSumElementsFloat32x4(mul));
 #else
 	// Brackets placed so that the order is consistent with the vectorized version
 	return (mF32[0] * inV2.mF32[0] + mF32[1] * inV2.mF32[1]) + (mF32[2] * inV2.mF32[2] + mF32[3] * inV2.mF32[3]);
@@ -1027,7 +1027,7 @@ float Vec4::LengthSq() const
 #elif defined(JPH_USE_RVV)
 	const vfloat32m1_t v = __riscv_vle32_v_f32m1(mF32, 4);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v, v, 4);
-	return RVVSumElementsFloat32x4(mul);
+	return __riscv_vfmv_f_s_f32m1_f32(RVVSumElementsFloat32x4(mul));
 #else
 	// Brackets placed so that the order is consistent with the vectorized version
 	return (mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]);
@@ -1045,7 +1045,9 @@ float Vec4::Length() const
 #elif defined(JPH_USE_RVV)
 	const vfloat32m1_t v = __riscv_vle32_v_f32m1(mF32, 4);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v, v, 4);
-	return sqrt(RVVSumElementsFloat32x4(mul));
+	const vfloat32m1_t sum = RVVSumElementsFloat32x4(mul);
+	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(sum, 1);
+	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
 	// Brackets placed so that the order is consistent with the vectorized version
 	return sqrt((mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]));
@@ -1119,8 +1121,11 @@ Vec4 Vec4::Normalized() const
 #elif defined(JPH_USE_RVV)
 	const vfloat32m1_t v = __riscv_vle32_v_f32m1(mF32, 4);
 	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v, v, 4);
-	const float length = sqrt(RVVSumElementsFloat32x4(mul));
-	const vfloat32m1_t norm_v = __riscv_vfdiv_vf_f32m1(v, length, 4);
+
+	const vfloat32m1_t sum = RVVSumElementsFloat32x4(mul);
+	const vfloat32m1_t sum_splat = __riscv_vrgather_vx_f32m1(sum, 0, 4);
+	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(sum_splat, 4);
+	const vfloat32m1_t norm_v = __riscv_vfdiv_vv_f32m1(v, sqrt, 4);
 
 	Vec4 vec;
 	__riscv_vse32_v_f32m1(vec.mF32, norm_v, 4);


### PR DESCRIPTION
The sqrt libm function requires errno to be set if the input is negative. For performance, clang and gcc partially inline the sqrt libcall by emitting a scalar sqrt instruction and a compre+branch to check for the error condition. If the error occurs, the sqrt function in libm will be called to set errno. For RVV, this call to sqrt requires the vector registers to be spilled and reloaded.

I suspect in most cases this error condition doesn't occur so this extra code just bloats the binary. The extra code can be disabled by passing -fno-math-errno, but I don't know if that's desirable for this library.

This patch instead uses the vfsqrt instrinsic in place of the library call. I've changed the interface to RVVSumElementsFloat32x4 to return the result in element 0 of a vector. The callers will move to a scalar register if necessary. If the scalar result needs to be splatted, I've used vrgather.vi.