### PR TITLE
Replace std::sqrt with Sqrt

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -487,7 +487,6 @@ JPH_NAMESPACE_BEGIN
 using std::min;
 using std::max;
 using std::abs;
-using std::sqrt;
 using std::ceil;
 using std::floor;
 using std::trunc;

--- a/Jolt/Geometry/ConvexHullBuilder.cpp
+++ b/Jolt/Geometry/ConvexHullBuilder.cpp
@@ -1351,7 +1351,7 @@ void ConvexHullBuilder::DetermineMaxError(Face *&outFaceWithMaxError, float &out
 		}
 
 		// If the minimum distance to an edge is further than our current max error, we use that as max error
-		float min_edge_dist = sqrt(min_edge_dist_sq);
+		float min_edge_dist = Sqrt(min_edge_dist_sq);
 		if (min_edge_dist_face != nullptr && min_edge_dist > max_error)
 		{
 			max_error = min_edge_dist;

--- a/Jolt/Geometry/EPAPenetrationDepth.h
+++ b/Jolt/Geometry/EPAPenetrationDepth.h
@@ -124,7 +124,7 @@ public:
 		if (closest_points_dist_sq > 0.0f)
 		{
 			// Collision within convex radius, adjust points for convex radius
-			float v_len = sqrt(closest_points_dist_sq); // GetClosestPoints function returns |ioV|^2 when return value < FLT_MAX
+			float v_len = Sqrt(closest_points_dist_sq); // GetClosestPoints function returns |ioV|^2 when return value < FLT_MAX
 			outPointA += ioV * (inConvexRadiusA / v_len);
 			outPointB -= ioV * (inConvexRadiusB / v_len);
 			return EStatus::Colliding;

--- a/Jolt/Geometry/Sphere.h
+++ b/Jolt/Geometry/Sphere.h
@@ -52,7 +52,7 @@ public:
 		{
 			// It is further away than radius, we need to widen the sphere
 			// The diameter of the new sphere is radius + d, so the new radius is half of that
-			float d = sqrt(d_sq);
+			float d = Sqrt(d_sq);
 			float radius = 0.5f * (mRadius + d);
 
 			// The center needs to shift by new radius - old radius in the direction of d

--- a/Jolt/Math/DVec3.inl
+++ b/Jolt/Math/DVec3.inl
@@ -1094,7 +1094,7 @@ DVec3 DVec3::Sqrt() const
 	__riscv_vse64_v_f64m2(res.mF64, rvv_sqrt, 3);
 	return res;
 #else
-	return DVec3(Sqrt(mF64[0]), Sqrt(mF64[1]), Sqrt(mF64[2]));
+	return DVec3(JPH::Sqrt(mF64[0]), JPH::Sqrt(mF64[1]), JPH::Sqrt(mF64[2]));
 #endif
 }
 

--- a/Jolt/Math/DVec3.inl
+++ b/Jolt/Math/DVec3.inl
@@ -1094,13 +1094,13 @@ DVec3 DVec3::Sqrt() const
 	__riscv_vse64_v_f64m2(res.mF64, rvv_sqrt, 3);
 	return res;
 #else
-	return DVec3(sqrt(mF64[0]), sqrt(mF64[1]), sqrt(mF64[2]));
+	return DVec3(Sqrt(mF64[0]), Sqrt(mF64[1]), Sqrt(mF64[2]));
 #endif
 }
 
 double DVec3::Length() const
 {
-	return sqrt(Dot(*this));
+	return JPH::Sqrt(Dot(*this));
 }
 
 DVec3 DVec3::Normalized() const

--- a/Jolt/Math/EigenValueSymmetric.h
+++ b/Jolt/Math/EigenValueSymmetric.h
@@ -127,11 +127,11 @@ bool EigenValueSymmetric(const Matrix &inMatrix, Matrix &outEigVec, Vector &outE
 					else
 					{
 						float theta = 0.5f * h / a_pq; // Warning: Can become infinite if a(ip, iq) is very small which may trigger an invalid float exception
-						t = 1.0f / (abs(theta) + sqrt(1.0f + theta * theta)); // If theta becomes inf, t will be 0 so the infinite is not a problem for the algorithm
+						t = 1.0f / (abs(theta) + Sqrt(1.0f + theta * theta)); // If theta becomes inf, t will be 0 so the infinite is not a problem for the algorithm
 						if (theta < 0.0f) t = -t;
 					}
 
-					float c = 1.0f / sqrt(1.0f + t * t);
+					float c = 1.0f / Sqrt(1.0f + t * t);
 					float s = t * c;
 					float tau = s / (1.0f + c);
 					h = t * a_pq;

--- a/Jolt/Math/FindRoot.h
+++ b/Jolt/Math/FindRoot.h
@@ -28,7 +28,7 @@ inline int FindRoot(const T inA, const T inB, const T inC, T &outX1, T &outX2)
 	T det = Square(inB) - T(4) * inA * inC;
 	if (det < T(0))
 		return 0;
-	T q = (inB + Sign(inB) * sqrt(det)) / T(-2);
+	T q = (inB + Sign(inB) * Sqrt(det)) / T(-2);
 	outX1 = q / inA;
 	if (q == T(0))
 	{

--- a/Jolt/Math/Mat44.inl
+++ b/Jolt/Math/Mat44.inl
@@ -1010,7 +1010,7 @@ Quat Mat44::GetQuaternion() const
 
 	if (tr >= 0.0f)
 	{
-		float s = sqrt(tr + 1.0f);
+		float s = Sqrt(tr + 1.0f);
 		float is = 0.5f / s;
 		return Quat(
 			(mCol[1].mF32[2] - mCol[2].mF32[1]) * is,
@@ -1026,7 +1026,7 @@ Quat Mat44::GetQuaternion() const
 
 		if (i == 0)
 		{
-			float s = sqrt(mCol[0].mF32[0] - (mCol[1].mF32[1] + mCol[2].mF32[2]) + 1);
+			float s = Sqrt(mCol[0].mF32[0] - (mCol[1].mF32[1] + mCol[2].mF32[2]) + 1);
 			float is = 0.5f / s;
 			return Quat(
 				0.5f * s,
@@ -1036,7 +1036,7 @@ Quat Mat44::GetQuaternion() const
 		}
 		else if (i == 1)
 		{
-			float s = sqrt(mCol[1].mF32[1] - (mCol[2].mF32[2] + mCol[0].mF32[0]) + 1);
+			float s = Sqrt(mCol[1].mF32[1] - (mCol[2].mF32[2] + mCol[0].mF32[0]) + 1);
 			float is = 0.5f / s;
 			return Quat(
 				(mCol[1].mF32[0] + mCol[0].mF32[1]) * is,
@@ -1048,7 +1048,7 @@ Quat Mat44::GetQuaternion() const
 		{
 			JPH_ASSERT(i == 2);
 
-			float s = sqrt(mCol[2].mF32[2] - (mCol[0].mF32[0] + mCol[1].mF32[1]) + 1);
+			float s = Sqrt(mCol[2].mF32[2] - (mCol[0].mF32[0] + mCol[1].mF32[1]) + 1);
 			float is = 0.5f / s;
 			return Quat(
 				(mCol[0].mF32[2] + mCol[2].mF32[0]) * is,

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -57,6 +57,34 @@ JPH_INLINE constexpr T Square(T inV)
 	return inV * inV;
 }
 
+/// Take the square root of a float value
+JPH_INLINE float Sqrt(float inV)
+{
+#ifdef JPH_USE_SSE
+	return _mm_cvtss_f32(_mm_sqrt_ss(_mm_set_ss(inV)));
+#elif defined(JPH_USE_NEON)
+	return vget_lane_f32(vsqrt_f32(vdup_n_f32(inV)), 0);
+#elif defined(JPH_USE_RVV)
+	return __riscv_vfmv_f_s_f32m1_f32(__riscv_vfsqrt_v_f32m1(__riscv_vfmv_v_f_f32m1(inV, 1), 1));
+#else
+	return std::sqrt(inV);
+#endif
+}
+
+/// Take the square root of a double value
+JPH_INLINE double Sqrt(double inV)
+{
+#ifdef JPH_USE_SSE
+	return _mm_cvtsd_f64(_mm_sqrt_sd(_mm_undefined_pd(), _mm_set_sd(inV)));
+#elif defined(JPH_USE_NEON)
+	return vget_lane_f64(vsqrt_f64(vdup_n_f64(inV)), 0);
+#elif defined(JPH_USE_RVV)
+	return __riscv_vfmv_f_s_f64m1_f64(__riscv_vfsqrt_v_f64m1(__riscv_vfmv_v_f_f64m1(inV, 1), 1));
+#else
+	return std::sqrt(inV);
+#endif
+}
+
 /// Returns \f$inV^3\f$.
 template <typename T>
 JPH_INLINE constexpr T Cubed(T inV)

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -64,8 +64,10 @@ JPH_INLINE float Sqrt(float inV)
 	return _mm_cvtss_f32(_mm_sqrt_ss(_mm_set_ss(inV)));
 #elif defined(JPH_USE_NEON)
 	return vget_lane_f32(vsqrt_f32(vdup_n_f32(inV)), 0);
-#elif defined(JPH_USE_RVV)
-	return __riscv_vfmv_f_s_f32m1_f32(__riscv_vfsqrt_v_f32m1(__riscv_vfmv_v_f_f32m1(inV, 1), 1));
+#elif defined(JPH_CPU_RISCV)
+	float res;
+	asm("fsqrt.s %0, %1" : "=f"(res) : "f"(inV));
+	return res;
 #else
 	return std::sqrt(inV);
 #endif
@@ -78,8 +80,10 @@ JPH_INLINE double Sqrt(double inV)
 	return _mm_cvtsd_f64(_mm_sqrt_sd(_mm_undefined_pd(), _mm_set_sd(inV)));
 #elif defined(JPH_USE_NEON)
 	return vget_lane_f64(vsqrt_f64(vdup_n_f64(inV)), 0);
-#elif defined(JPH_USE_RVV)
-	return __riscv_vfmv_f_s_f64m1_f64(__riscv_vfsqrt_v_f64m1(__riscv_vfmv_v_f_f64m1(inV, 1), 1));
+#elif defined(JPH_CPU_RISCV)
+	double res;
+	asm("fsqrt.d %0, %1" : "=f"(res) : "f"(inV));
+	return res;
 #else
 	return std::sqrt(inV);
 #endif

--- a/Jolt/Math/Quat.inl
+++ b/Jolt/Math/Quat.inl
@@ -200,7 +200,7 @@ Vec3 Quat::GetAngularVelocity(float inDeltaTime) const
 	// Otherwise calculate the angle from w = cos(angle / 2) and determine the axis by normalizing the imaginary part
 	// Note that it is also possible to calculate the angle through angle = 2 * atan2(|xyz|, w). This is more accurate but also 2x as expensive.
 	float angle = 2.0f * ACos(w_pos.GetW());
-	return (xyz / (sqrt(xyz_len_sq) * inDeltaTime)) * angle;
+	return (xyz / (Sqrt(xyz_len_sq) * inDeltaTime)) * angle;
 }
 
 Quat Quat::sFromTo(Vec3Arg inFrom, Vec3Arg inTo)
@@ -235,7 +235,7 @@ Quat Quat::sFromTo(Vec3Arg inFrom, Vec3Arg inTo)
 		which then needs to be normalized because the whole equation was multiplied by 2 cos(angle / 2)
 	*/
 
-	float len_v1_v2 = sqrt(inFrom.LengthSq() * inTo.LengthSq());
+	float len_v1_v2 = Sqrt(inFrom.LengthSq() * inTo.LengthSq());
 	float w = len_v1_v2 + inFrom.Dot(inTo);
 
 	if (w == 0.0f)
@@ -261,7 +261,7 @@ Quat Quat::sRandom(Random &inRandom)
 {
 	std::uniform_real_distribution<float> zero_to_one(0.0f, 1.0f);
 	float x0 = zero_to_one(inRandom);
-	float r1 = sqrt(1.0f - x0), r2 = sqrt(x0);
+	float r1 = Sqrt(1.0f - x0), r2 = Sqrt(x0);
 	std::uniform_real_distribution<float> zero_to_two_pi(0.0f, 2.0f * JPH_PI);
 	Vec4 s, c;
 	Vec4(zero_to_two_pi(inRandom), zero_to_two_pi(inRandom), 0, 0).SinCos(s, c);
@@ -313,7 +313,7 @@ Quat Quat::GetTwist(Vec3Arg inAxis) const
 	Quat twist(Vec4(GetXYZ().Dot(inAxis) * inAxis, GetW()));
 	float twist_len = twist.LengthSq();
 	if (twist_len != 0.0f)
-		return twist / sqrt(twist_len);
+		return twist / Sqrt(twist_len);
 	else
 		return Quat::sIdentity();
 }
@@ -321,7 +321,7 @@ Quat Quat::GetTwist(Vec3Arg inAxis) const
 void Quat::GetSwingTwist(Quat &outSwing, Quat &outTwist) const
 {
 	float x = GetX(), y = GetY(), z = GetZ(), w = GetW();
-	float s = sqrt(Square(w) + Square(x));
+	float s = Sqrt(Square(w) + Square(x));
 	if (s != 0.0f)
 	{
 		outTwist = Quat(x / s, 0, 0, w / s);
@@ -451,7 +451,7 @@ void Quat::StoreFloat4(Float4 *outV) const
 Quat Quat::sLoadFloat3Unsafe(const Float3 &inV)
 {
 	Vec3 v = Vec3::sLoadFloat3Unsafe(inV);
-	float w = sqrt(max(1.0f - v.LengthSq(), 0.0f)); // It is possible that the length of v is a fraction above 1, and we don't want to introduce NaN's in that case so we clamp to 0
+	float w = Sqrt(max(1.0f - v.LengthSq(), 0.0f)); // It is possible that the length of v is a fraction above 1, and we don't want to introduce NaN's in that case so we clamp to 0
 	return Quat(Vec4(v, w));
 }
 

--- a/Jolt/Math/Trigonometry.h
+++ b/Jolt/Math/Trigonometry.h
@@ -58,7 +58,7 @@ JPH_INLINE float ACosApproximate(float inX)
 	// So we observe that the form of the Taylor expansion is f(x) = sqrt(1 - x) * (a + b x) and we fit the function so that f(0) = pi / 2
 	// this gives us a = pi / 2. f(1) = 0 regardless of b. We search for a constant b that minimizes the error in the range [0, 1].
 	float abs_x = min(abs(inX), 1.0f); // Ensure that we don't get a value larger than 1
-	float val = sqrt(1.0f - abs_x) * (JPH_PI / 2 - 0.175394f * abs_x);
+	float val = Sqrt(1.0f - abs_x) * (JPH_PI / 2 - 0.175394f * abs_x);
 
 	// Our approximation is valid in the range [0, 1], extend it to the range [-1, 1]
 	return inX < 0? JPH_PI - val : val;

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -1020,7 +1020,7 @@ float Vec3::Length() const
 	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(sum, 1);
 	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
-	return sqrt(LengthSq());
+	return Sqrt(LengthSq());
 #endif
 }
 
@@ -1037,7 +1037,7 @@ Vec3 Vec3::Sqrt() const
 	__riscv_vse32_v_f32m1(res.mF32, rvv_sqrt, 3);
 	return res;
 #else
-	return Vec3(sqrt(mF32[0]), sqrt(mF32[1]), sqrt(mF32[2]));
+	return Vec3(Sqrt(mF32[0]), Sqrt(mF32[1]), Sqrt(mF32[2]));
 #endif
 }
 
@@ -1122,7 +1122,7 @@ Vec3 Vec3::NormalizedOr(Vec3Arg inZeroValue) const
 	if (len_sq <= FLT_MIN)
 		return inZeroValue;
 	else
-		return *this / sqrt(len_sq);
+		return *this / Sqrt(len_sq);
 #endif
 }
 
@@ -1253,7 +1253,7 @@ Vec3 Vec3::GetNormalizedPerpendicular() const
 	Vec3 perp_x(z, 0.0f, -x);
 	Vec3 perp_y(0.0f, z, -y);
 #endif // JPH_CROSS_PLATFORM_DETERMINISTIC
-	return (xx > yy ? perp_x : perp_y) / sqrt(max(xx, yy) + zz);
+	return (xx > yy ? perp_x : perp_y) / Sqrt(max(xx, yy) + zz);
 #endif // JPH_USE_SSE
 }
 
@@ -1345,7 +1345,7 @@ Vec3 Vec3::sDecompressUnitVector(uint32 inValue)
 	JPH_ASSERT(v.GetZ() == 0.0f);
 
 	// Restore the highest component
-	v.SetZ(sqrt(max(1.0f - v.LengthSq(), 0.0f)));
+	v.SetZ(JPH::Sqrt(max(1.0f - v.LengthSq(), 0.0f)));
 
 	// Extract sign
 	if ((inValue & 0x80000000u) != 0)

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -1020,7 +1020,7 @@ float Vec3::Length() const
 	const vfloat32m1_t sqrt = __riscv_vfsqrt_v_f32m1(sum, 1);
 	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
-	return Sqrt(LengthSq());
+	return JPH::Sqrt(LengthSq());
 #endif
 }
 
@@ -1037,7 +1037,7 @@ Vec3 Vec3::Sqrt() const
 	__riscv_vse32_v_f32m1(res.mF32, rvv_sqrt, 3);
 	return res;
 #else
-	return Vec3(Sqrt(mF32[0]), Sqrt(mF32[1]), Sqrt(mF32[2]));
+	return Vec3(JPH::Sqrt(mF32[0]), JPH::Sqrt(mF32[1]), JPH::Sqrt(mF32[2]));
 #endif
 }
 
@@ -1122,7 +1122,7 @@ Vec3 Vec3::NormalizedOr(Vec3Arg inZeroValue) const
 	if (len_sq <= FLT_MIN)
 		return inZeroValue;
 	else
-		return *this / Sqrt(len_sq);
+		return *this / JPH::Sqrt(len_sq);
 #endif
 }
 
@@ -1253,7 +1253,7 @@ Vec3 Vec3::GetNormalizedPerpendicular() const
 	Vec3 perp_x(z, 0.0f, -x);
 	Vec3 perp_y(0.0f, z, -y);
 #endif // JPH_CROSS_PLATFORM_DETERMINISTIC
-	return (xx > yy ? perp_x : perp_y) / Sqrt(max(xx, yy) + zz);
+	return (xx > yy ? perp_x : perp_y) / JPH::Sqrt(max(xx, yy) + zz);
 #endif // JPH_USE_SSE
 }
 

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -1050,7 +1050,7 @@ float Vec4::Length() const
 	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
 	// Brackets placed so that the order is consistent with the vectorized version
-	return Sqrt((mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]));
+	return JPH::Sqrt((mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]));
 #endif
 }
 
@@ -1067,7 +1067,7 @@ Vec4 Vec4::Sqrt() const
 	__riscv_vse32_v_f32m1(res.mF32, rvv_sqrt, 4);
 	return res;
 #else
-	return Vec4(Sqrt(mF32[0]), Sqrt(mF32[1]), Sqrt(mF32[2]), Sqrt(mF32[3]));
+	return Vec4(JPH::Sqrt(mF32[0]), JPH::Sqrt(mF32[1]), JPH::Sqrt(mF32[2]), JPH::Sqrt(mF32[3]));
 #endif
 }
 

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -1050,7 +1050,7 @@ float Vec4::Length() const
 	return __riscv_vfmv_f_s_f32m1_f32(sqrt);
 #else
 	// Brackets placed so that the order is consistent with the vectorized version
-	return sqrt((mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]));
+	return Sqrt((mF32[0] * mF32[0] + mF32[1] * mF32[1]) + (mF32[2] * mF32[2] + mF32[3] * mF32[3]));
 #endif
 }
 
@@ -1067,7 +1067,7 @@ Vec4 Vec4::Sqrt() const
 	__riscv_vse32_v_f32m1(res.mF32, rvv_sqrt, 4);
 	return res;
 #else
-	return Vec4(sqrt(mF32[0]), sqrt(mF32[1]), sqrt(mF32[2]), sqrt(mF32[3]));
+	return Vec4(Sqrt(mF32[0]), Sqrt(mF32[1]), Sqrt(mF32[2]), Sqrt(mF32[3]));
 #endif
 }
 
@@ -1478,7 +1478,7 @@ Vec4 Vec4::sDecompressUnitVector(uint32 inValue)
 	JPH_ASSERT(v.GetW() == 0.0f);
 
 	// Restore the highest component
-	v.SetW(sqrt(max(1.0f - v.LengthSq(), 0.0f)));
+	v.SetW(JPH::Sqrt(max(1.0f - v.LengthSq(), 0.0f)));
 
 	// Extract sign
 	if ((inValue & 0x80000000u) != 0)

--- a/Jolt/Math/Vector.h
+++ b/Jolt/Math/Vector.h
@@ -180,7 +180,7 @@ public:
 	/// Length of vector
 	inline float				Length() const
 	{
-		return sqrt(LengthSq());
+		return Sqrt(LengthSq());
 	}
 
 	/// Check if vector is normalized

--- a/Jolt/Physics/Body/Body.cpp
+++ b/Jolt/Physics/Body/Body.cpp
@@ -243,7 +243,7 @@ bool Body::ApplyBuoyancyImpulse(float inTotalVolume, float inSubmergedVolume, Ve
 		if (relative_center_of_buoyancy_velocity_len_sq > 1.0e-12f)
 		{
 			Vec3 local_relative_center_of_buoyancy_velocity = GetRotation().InverseRotate(relative_center_of_buoyancy_velocity);
-			area = local_relative_center_of_buoyancy_velocity.Abs().Dot(size.Swizzle<SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_X>() * size.Swizzle<SWIZZLE_Z, SWIZZLE_X, SWIZZLE_Y>()) / sqrt(relative_center_of_buoyancy_velocity_len_sq);
+			area = local_relative_center_of_buoyancy_velocity.Abs().Dot(size.Swizzle<SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_X>() * size.Swizzle<SWIZZLE_Z, SWIZZLE_X, SWIZZLE_Y>()) / Sqrt(relative_center_of_buoyancy_velocity_len_sq);
 		}
 
 		// Calculate the impulse
@@ -253,7 +253,7 @@ bool Body::ApplyBuoyancyImpulse(float inTotalVolume, float inSubmergedVolume, Ve
 		float linear_velocity_len_sq = linear_velocity.LengthSq();
 		float drag_delta_linear_velocity_len_sq = (drag_impulse * inverse_mass).LengthSq();
 		if (drag_delta_linear_velocity_len_sq > linear_velocity_len_sq)
-			drag_impulse *= sqrt(linear_velocity_len_sq / drag_delta_linear_velocity_len_sq);
+			drag_impulse *= Sqrt(linear_velocity_len_sq / drag_delta_linear_velocity_len_sq);
 
 		// Calculate the resulting delta linear velocity due to buoyancy and drag
 		Vec3 delta_linear_velocity = (drag_impulse + buoyancy_impulse) * inverse_mass;
@@ -271,7 +271,7 @@ bool Body::ApplyBuoyancyImpulse(float inTotalVolume, float inSubmergedVolume, Ve
 		float angular_velocity_len_sq = angular_velocity.LengthSq();
 		float drag_delta_angular_velocity_len_sq = drag_delta_angular_velocity.LengthSq();
 		if (drag_delta_angular_velocity_len_sq > angular_velocity_len_sq)
-			drag_delta_angular_velocity *= sqrt(angular_velocity_len_sq / drag_delta_angular_velocity_len_sq);
+			drag_delta_angular_velocity *= Sqrt(angular_velocity_len_sq / drag_delta_angular_velocity_len_sq);
 
 		// Calculate total delta angular velocity due to drag and buoyancy
 		Vec3 delta_angular_velocity = drag_delta_angular_velocity + inv_inertia * inRelativeCenterOfBuoyancy.Cross(buoyancy_impulse + drag_impulse);

--- a/Jolt/Physics/Body/MassProperties.cpp
+++ b/Jolt/Physics/Body/MassProperties.cpp
@@ -97,7 +97,7 @@ Vec3 MassProperties::sGetEquivalentSolidBoxSize(float inMass, Vec3Arg inInertiaD
 	// mass / 12 * [size_y^2 + size_z^2, size_x^2 + size_z^2, size_x^2 + size_y^2]
 	// Solving for size_x, size_y and size_y (diagonal and mass are known):
 	Vec3 diagonal = inInertiaDiagonal * (12.0f / inMass);
-	return Vec3(sqrt(0.5f * (-diagonal[0] + diagonal[1] + diagonal[2])), sqrt(0.5f * (diagonal[0] - diagonal[1] + diagonal[2])), sqrt(0.5f * (diagonal[0] + diagonal[1] - diagonal[2])));
+	return Vec3(Sqrt(0.5f * (-diagonal[0] + diagonal[1] + diagonal[2])), Sqrt(0.5f * (diagonal[0] - diagonal[1] + diagonal[2])), Sqrt(0.5f * (diagonal[0] + diagonal[1] - diagonal[2])));
 }
 
 void MassProperties::Scale(Vec3Arg inScale)

--- a/Jolt/Physics/Body/MotionProperties.inl
+++ b/Jolt/Physics/Body/MotionProperties.inl
@@ -27,7 +27,7 @@ void MotionProperties::ClampLinearVelocity()
 	float len_sq = mLinearVelocity.LengthSq();
 	JPH_ASSERT(isfinite(len_sq));
 	if (len_sq > Square(mMaxLinearVelocity))
-		mLinearVelocity *= mMaxLinearVelocity / sqrt(len_sq);
+		mLinearVelocity *= mMaxLinearVelocity / Sqrt(len_sq);
 }
 
 void MotionProperties::ClampAngularVelocity()
@@ -37,7 +37,7 @@ void MotionProperties::ClampAngularVelocity()
 	float len_sq = mAngularVelocity.LengthSq();
 	JPH_ASSERT(isfinite(len_sq));
 	if (len_sq > Square(mMaxAngularVelocity))
-		mAngularVelocity *= mMaxAngularVelocity / sqrt(len_sq);
+		mAngularVelocity *= mMaxAngularVelocity / Sqrt(len_sq);
 }
 
 inline Mat44 MotionProperties::GetLocalSpaceInverseInertiaUnchecked() const
@@ -118,7 +118,7 @@ void MotionProperties::ApplyGyroscopicForceInternal(QuatArg inBodyRotation, floa
 	// to avoid introducing energy into the system due to the Euler step
 	Vec3 new_local_momentum = local_momentum - inDeltaTime * local_angular_velocity.Cross(local_momentum);
 	float new_local_momentum_len_sq = new_local_momentum.LengthSq();
-	new_local_momentum = new_local_momentum_len_sq > 0.0f? new_local_momentum * sqrt(local_momentum.LengthSq() / new_local_momentum_len_sq) : Vec3::sZero();
+	new_local_momentum = new_local_momentum_len_sq > 0.0f? new_local_momentum * Sqrt(local_momentum.LengthSq() / new_local_momentum_len_sq) : Vec3::sZero();
 
 	// Convert back to world space angular velocity
 	mAngularVelocity = inertia_space_to_world_space * (mInvInertiaDiagonal * new_local_momentum);

--- a/Jolt/Physics/Character/CharacterVirtual.cpp
+++ b/Jolt/Physics/Character/CharacterVirtual.cpp
@@ -194,7 +194,7 @@ Vec3 CharacterVirtual::CalculateCharacterGroundVelocity(RVec3Arg inCenterOfMass,
 	float angular_velocity_len_sq = inAngularVelocity.LengthSq();
 	if (angular_velocity_len_sq < 1.0e-12f)
 		return inLinearVelocity;
-	float angular_velocity_len = sqrt(angular_velocity_len_sq);
+	float angular_velocity_len = Sqrt(angular_velocity_len_sq);
 
 	// Calculate the rotation that the object will make in the time step
 	Quat rotation = Quat::sRotation(inAngularVelocity / angular_velocity_len, angular_velocity_len * inDeltaTime);
@@ -577,7 +577,7 @@ bool CharacterVirtual::GetFirstContactForSweep(RVec3Arg inPosition, Vec3Arg inDi
 	settings.mReturnDeepestPoint = false;
 
 	// Calculate how much extra fraction we need to add to the cast to account for the character padding
-	float character_padding_fraction = mCharacterPadding / sqrt(displacement_len_sq);
+	float character_padding_fraction = mCharacterPadding / Sqrt(displacement_len_sq);
 
 	// Body filter
 	IgnoreSingleBodyFilterChained body_filter(mInnerBodyID, inBodyFilter);

--- a/Jolt/Physics/Collision/CastSphereVsTriangles.cpp
+++ b/Jolt/Physics/Collision/CastSphereVsTriangles.cpp
@@ -107,7 +107,7 @@ float CastSphereVsTriangles::RayCylinder(Vec3Arg inRayDirection, Vec3Arg inCylin
 		return FLT_MAX; // No solution to quadratic equation
 
 	// Solve fraction t where the ray hits the cylinder
-	float t = -(b + sqrt(det)) / a; // normally divided by 2 * a but since a should be divided by 2 we lose the 2
+	float t = -(b + Sqrt(det)) / a; // normally divided by 2 * a but since a should be divided by 2 we lose the 2
 	if (t < 0.0f || t > 1.0f)
 		return FLT_MAX; // Intersection lies outside segment
 	if (start_dot_axis + t * direction_dot_axis < 0.0f || start_dot_axis + t * direction_dot_axis > axis_len_sq)
@@ -145,7 +145,7 @@ void CastSphereVsTriangles::Cast(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2, uint8
 		if (q_len_sq <= Square(mRadius))
 		{
 			// Early out if this hit is deeper than the collector's early out value
-			float q_len = sqrt(q_len_sq);
+			float q_len = Sqrt(q_len_sq);
 			float penetration_depth = mRadius - q_len;
 			if (-penetration_depth >= mCollector.GetEarlyOutFraction())
 				return;

--- a/Jolt/Physics/Collision/CollideSphereVsTriangles.cpp
+++ b/Jolt/Physics/Collision/CollideSphereVsTriangles.cpp
@@ -68,7 +68,7 @@ void CollideSphereVsTriangles::Collide(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2,
 		return;
 
 	// Calculate penetration depth
-	float penetration_depth = mRadius - sqrt(point2_len_sq);
+	float penetration_depth = mRadius - Sqrt(point2_len_sq);
 	if (-penetration_depth >= mCollector.GetEarlyOutFraction())
 		return;
 

--- a/Jolt/Physics/Collision/EstimateCollisionResponse.cpp
+++ b/Jolt/Physics/Collision/EstimateCollisionResponse.cpp
@@ -192,7 +192,7 @@ void EstimateCollisionResponse(const Body &inBody1, const Body &inBody2, const C
 				float total_lambda_sq = Square(lambda1) + Square(lambda2);
 				if (total_lambda_sq > Square(max_impulse))
 				{
-					float scale = max_impulse / sqrt(total_lambda_sq);
+					float scale = max_impulse / Sqrt(total_lambda_sq);
 					lambda1 *= scale;
 					lambda2 *= scale;
 				}

--- a/Jolt/Physics/Collision/Shape/CylinderShape.cpp
+++ b/Jolt/Physics/Collision/Shape/CylinderShape.cpp
@@ -143,7 +143,7 @@ public:
 		// A Fast and Robust GJK Implementation for Collision Detection of Convex Objects - Gino van den Bergen
 		// page 8
 		float x = inDirection.GetX(), y = inDirection.GetY(), z = inDirection.GetZ();
-		float o = sqrt(Square(x) + Square(z));
+		float o = Sqrt(Square(x) + Square(z));
 		if (o > 0.0f)
 			return Vec3((mRadius * x) / o, Sign(y) * mHalfHeight, (mRadius * z) / o);
 		else
@@ -207,7 +207,7 @@ void CylinderShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg in
 	if (xz_sq > y_sq)
 	{
 		// Hitting side
-		float f = -scaled_radius / sqrt(xz_sq);
+		float f = -scaled_radius / Sqrt(xz_sq);
 		float vx = x * f;
 		float vz = z * f;
 		outVertices.push_back(inCenterOfMassTransform * Vec3(vx, scaled_half_height, vz));
@@ -222,7 +222,7 @@ void CylinderShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg in
 		Mat44 transform = inCenterOfMassTransform;
 		if (xz_sq > 0.00765427f * y_sq)
 		{
-			Vec4 base_x = Vec4(x, 0, z, 0) / sqrt(xz_sq);
+			Vec4 base_x = Vec4(x, 0, z, 0) / Sqrt(xz_sq);
 			Vec4 base_z = base_x.Swizzle<SWIZZLE_Z, SWIZZLE_Y, SWIZZLE_X, SWIZZLE_W>() * Vec4(-1, 0, 1, 0);
 			transform = transform * Mat44(base_x, Vec4(0, 1, 0, 0), base_z, Vec4(0, 0, 0, 1));
 		}

--- a/Jolt/Physics/Collision/Shape/SphereShape.cpp
+++ b/Jolt/Physics/Collision/Shape/SphereShape.cpp
@@ -198,7 +198,7 @@ void SphereShape::GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg i
 		if (sDrawSubmergedVolumes)
 		{
 			Vec3 circle_center = inCenterOfMassTransform.GetTranslation() - distance_to_surface * inSurface.GetNormal();
-			float circle_radius = sqrt(Square(scaled_radius) - Square(distance_to_surface));
+			float circle_radius = Sqrt(Square(scaled_radius) - Square(distance_to_surface));
 			DebugRenderer::sInstance->DrawPie(inBaseOffset + circle_center, circle_radius, inSurface.GetNormal(), inSurface.GetNormal().GetNormalizedPerpendicular(), -JPH_PI, JPH_PI, Color::sGreen, DebugRenderer::ECastShadow::Off);
 		}
 	#endif // JPH_DEBUG_RENDERER

--- a/Jolt/Physics/Collision/Shape/TaperedCylinderShape.cpp
+++ b/Jolt/Physics/Collision/Shape/TaperedCylinderShape.cpp
@@ -149,7 +149,7 @@ public:
 	virtual Vec3	GetSupport(Vec3Arg inDirection) const override
 	{
 		float x = inDirection.GetX(), y = inDirection.GetY(), z = inDirection.GetZ();
-		float o = sqrt(Square(x) + Square(z));
+		float o = Sqrt(Square(x) + Square(z));
 		if (o > 0.0f)
 		{
 			Vec3 top_support((mTopRadius * x) / o, mTop, (mTopRadius * z) / o);
@@ -263,7 +263,7 @@ void TaperedCylinderShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec
 		float y_sq = Square(inDirection.GetY());
 		if (xz_sq > 0.00765427f * y_sq)
 		{
-			base_x /= sqrt(xz_sq);
+			base_x /= Sqrt(xz_sq);
 			Vec4 base_z = base_x.Swizzle<SWIZZLE_Z, SWIZZLE_Y, SWIZZLE_X, SWIZZLE_W>() * Vec4(-1, 0, 1, 0);
 			transform = transform * Mat44(base_x, Vec4(0, 1, 0, 0), base_z, Vec4(0, 0, 0, 1));
 		}

--- a/Jolt/Physics/Constraints/ConstraintPart/SwingTwistConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/SwingTwistConstraintPart.h
@@ -250,7 +250,7 @@ public:
 				else if ((outClampedAxis & cClampedSwingYMin) != 0)
 				{
 					float z = ioSwing.GetZ();
-					ioSwing = Quat(0, 0, z, sqrt(1.0f - Square(z)));
+					ioSwing = Quat(0, 0, z, Sqrt(1.0f - Square(z)));
 				}
 			}
 		}
@@ -277,7 +277,7 @@ public:
 			else if ((outClampedAxis & cClampedSwingZMin) != 0)
 			{
 				float y = ioSwing.GetY();
-				ioSwing = Quat(0, y, 0, sqrt(1.0f - Square(y)));
+				ioSwing = Quat(0, y, 0, Sqrt(1.0f - Square(y)));
 			}
 		}
 		else
@@ -291,7 +291,7 @@ public:
 				if (!ellipse.IsInside(point))
 				{
 					Float2 closest = ellipse.GetClosestPoint(point);
-					ioSwing = Quat(0, closest.x, closest.y, sqrt(max(0.0f, 1.0f - Square(closest.x) - Square(closest.y))));
+					ioSwing = Quat(0, closest.x, closest.y, Sqrt(max(0.0f, 1.0f - Square(closest.x) - Square(closest.y))));
 					outClampedAxis |= cClampedSwingYMin | cClampedSwingYMax | cClampedSwingZMin | cClampedSwingZMax; // We're not using the flags on which side we got clamped here
 				}
 			}

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -1664,7 +1664,7 @@ bool ContactConstraintManager::sSolveVelocityConstraint(ContactConstraintBase &i
 			// If the total lambda that we will apply is too large, scale it back
 			if (total_lambda_sq > Square(max_lambda_f))
 			{
-				float scale = max_lambda_f / sqrt(total_lambda_sq);
+				float scale = max_lambda_f / Sqrt(total_lambda_sq);
 				lambda1 *= scale;
 				lambda2 *= scale;
 			}

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -538,7 +538,7 @@ private:
 	ContactListener *			mContactListener = nullptr;
 
 	/// Functions that are used to combine friction and restitution of 2 bodies
-	CombineFunction				mCombineFriction = [](const Body &inBody1, const SubShapeID &, const Body &inBody2, const SubShapeID &) { return sqrt(inBody1.GetFriction() * inBody2.GetFriction()); };
+	CombineFunction				mCombineFriction = [](const Body &inBody1, const SubShapeID &, const Body &inBody2, const SubShapeID &) { return Sqrt(inBody1.GetFriction() * inBody2.GetFriction()); };
 	CombineFunction				mCombineRestitution = [](const Body &inBody1, const SubShapeID &, const Body &inBody2, const SubShapeID &) { return max(inBody1.GetRestitution(), inBody2.GetRestitution()); };
 
 	/// The constraints that were added this frame

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -2242,7 +2242,7 @@ void PhysicsSystem::JobResolveCCDContacts(PhysicsUpdateContext *ioContext, Physi
 							if (friction_direction_len_sq > 1.0e-12f)
 							{
 								// Normalize friction direction
-								friction_direction /= sqrt(friction_direction_len_sq);
+								friction_direction /= Sqrt(friction_direction_len_sq);
 
 								// Calculate max friction impulse
 								float max_lambda_f = contact_settings.mCombinedFriction * contact_constraint.GetTotalLambda();

--- a/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
+++ b/Jolt/Physics/SoftBody/SoftBodyMotionProperties.cpp
@@ -413,7 +413,7 @@ void SoftBodyMotionProperties::ApplyDihedralBendConstraints(const SoftBodyUpdate
 		// Calculate constraint equation
 		// As per "Strain Based Dynamics" Appendix A we need to negate the gradients when (n1 x n2) . e > 0, instead we make sure that the sign of the constraint equation is correct
 		float sign = Sign(n2.Cross(n1).Dot(e));
-		float d = n1.Dot(n2) / sqrt(n1_len_sq_n2_len_sq);
+		float d = n1.Dot(n2) / Sqrt(n1_len_sq_n2_len_sq);
 		float c = sign * ACosApproximate(d) - b->mInitialAngle;
 
 		// Ensure the range is -PI to PI
@@ -545,7 +545,7 @@ void SoftBodyMotionProperties::ApplySkinConstraints(const SoftBodyUpdateContext 
 				if (delta_len_sq < Square(s->mBackStopRadius))
 				{
 					// Push the vertex to the surface of the back stop sphere
-					float delta_len = sqrt(delta_len_sq);
+					float delta_len = Sqrt(delta_len_sq);
 					vertex.mPosition = delta_len > 0.0f?
 						center + delta * (s->mBackStopRadius / delta_len)
 						: center + skin_state.mNormal * s->mBackStopRadius;
@@ -559,7 +559,7 @@ void SoftBodyMotionProperties::ApplySkinConstraints(const SoftBodyUpdateContext 
 				float delta_len_sq = delta.LengthSq();
 				float max_distance_sq = Square(max_distance);
 				if (delta_len_sq > max_distance_sq)
-					vertex.mPosition = skin_pos + delta * sqrt(max_distance_sq / delta_len_sq);
+					vertex.mPosition = skin_pos + delta * Sqrt(max_distance_sq / delta_len_sq);
 			}
 		}
 		else
@@ -693,7 +693,7 @@ void SoftBodyMotionProperties::ApplyLRAConstraints(uint inStartIndex, uint inEnd
 		Vec3 delta = vertex1.mPosition - x0;
 		float delta_len_sq = delta.LengthSq();
 		if (delta_len_sq > Square(lra->mMaxDistance))
-			vertex1.mPosition = x0 + delta * lra->mMaxDistance / sqrt(delta_len_sq);
+			vertex1.mPosition = x0 + delta * lra->mMaxDistance / Sqrt(delta_len_sq);
 	}
 }
 
@@ -858,7 +858,7 @@ void SoftBodyMotionProperties::UpdateSoftBodyState(SoftBodyUpdateContext &ioCont
 
 		// Clamp if velocity is too high
 		if (v_sq > max_linear_velocity_sq)
-			v.mVelocity *= sqrt(max_linear_velocity_sq / v_sq);
+			v.mVelocity *= Sqrt(max_linear_velocity_sq / v_sq);
 
 		// Calculate local linear/angular velocity
 		linear_velocity += v.mVelocity;

--- a/Jolt/Physics/SoftBody/SoftBodySharedSettings.cpp
+++ b/Jolt/Physics/SoftBody/SoftBodySharedSettings.cpp
@@ -522,7 +522,7 @@ void SoftBodySharedSettings::CalculateBendConstraintConstants()
 		// Normals of both triangles
 		Vec3 n1 = e0.Cross(e1);
 		Vec3 n2 = e2.Cross(e0);
-		float denom = sqrt(n1.LengthSq() * n2.LengthSq());
+		float denom = Sqrt(n1.LengthSq() * n2.LengthSq());
 		if (denom < 1.0e-12f)
 			b.mInitialAngle = 0.0f;
 		else

--- a/Jolt/Physics/Vehicle/VehicleCollisionTester.cpp
+++ b/Jolt/Physics/Vehicle/VehicleCollisionTester.cpp
@@ -346,7 +346,7 @@ void VehicleCollisionTesterCastCylinder::PredictContactProperties(PhysicsSystem 
 		// Get the support point of this normal in local space of the cylinder
 		// See CylinderShape::Cylinder::GetSupport
 		float x = inverse_local_normal.GetX(), y = inverse_local_normal.GetY(), z = inverse_local_normal.GetZ();
-		float o = sqrt(Square(x) + Square(z));
+		float o = Sqrt(Square(x) + Square(z));
 		Vec3 support_point;
 		if (o > 0.0f)
 			support_point = Vec3((radius * x) / o, Sign(y) * half_width, (radius * z) / o);

--- a/Jolt/Physics/Vehicle/VehicleConstraint.h
+++ b/Jolt/Physics/Vehicle/VehicleConstraint.h
@@ -239,8 +239,8 @@ private:
 	{
 		float body_friction = inBody2.GetFriction();
 
-		ioLongitudinalFriction = sqrt(ioLongitudinalFriction * body_friction);
-		ioLateralFriction = sqrt(ioLateralFriction * body_friction);
+		ioLongitudinalFriction = Sqrt(ioLongitudinalFriction * body_friction);
+		ioLateralFriction = Sqrt(ioLateralFriction * body_friction);
 	};
 
 	// Callbacks

--- a/Jolt/Renderer/DebugRenderer.cpp
+++ b/Jolt/Renderer/DebugRenderer.cpp
@@ -913,7 +913,7 @@ void DebugRenderer::DrawSwingConeLimits(RMat44Arg inMatrix, float inSwingYHalfAn
 
 					// Calculate the corresponding z value of the quaternion
 					float z_sq = e1_sq - e1_sq / e2_sq * Square(y);
-					z = z_sq <= 0.0f? 0.0f : sqrt(z_sq);
+					z = z_sq <= 0.0f? 0.0f : Sqrt(z_sq);
 				}
 				else
 				{
@@ -922,7 +922,7 @@ void DebugRenderer::DrawSwingConeLimits(RMat44Arg inMatrix, float inSwingYHalfAn
 
 					// Calculate the corresponding y value of the quaternion
 					float y_sq = e2_sq - e2_sq / e1_sq * Square(z);
-					y = y_sq <= 0.0f? 0.0f : sqrt(y_sq);
+					y = y_sq <= 0.0f? 0.0f : Sqrt(y_sq);
 				}
 
 				// If we're tracing the opposite side, flip the values
@@ -934,7 +934,7 @@ void DebugRenderer::DrawSwingConeLimits(RMat44Arg inMatrix, float inSwingYHalfAn
 
 				// Create quaternion
 				Vec3 q_xyz(0, y, z);
-				float w = sqrt(1.0f - q_xyz.LengthSq());
+				float w = Sqrt(1.0f - q_xyz.LengthSq());
 				Quat q(Vec4(q_xyz, w));
 
 				// Store vertex

--- a/Samples/SamplesApp.cpp
+++ b/Samples/SamplesApp.cpp
@@ -1637,7 +1637,7 @@ bool SamplesApp::CastProbe(float inProbeLength, float &outFraction, RVec3 &outPo
 					SphereShape point_sphere(1.0e-6f);
 					point_sphere.SetEmbedded();
 					CollideShapeSettings settings;
-					settings.mMaxSeparationDistance = sqrt(3.0f) * max_distance; // Box is extended in all directions by max_distance
+					settings.mMaxSeparationDistance = Sqrt(3.0f) * max_distance; // Box is extended in all directions by max_distance
 					ClosestHitCollisionCollector<CollideShapeCollector> collide_shape_collector;
 					ts.CollideShape(&point_sphere, Vec3::sOne(), RMat44::sTranslation(start + position), settings, start, collide_shape_collector);
 					if (collide_shape_collector.HadHit())

--- a/Samples/Tests/Character/CharacterSpaceShipTest.cpp
+++ b/Samples/Tests/Character/CharacterSpaceShipTest.cpp
@@ -40,7 +40,7 @@ void CharacterSpaceShipTest::Initialize()
 	StaticCompoundShapeSettings compound;
 	compound.SetEmbedded();
 	for (float h = cSpaceShipRingHeight; h < cSpaceShipHeight; h += cSpaceShipRingHeight)
-		compound.AddShape(Vec3::sZero(), Quat::sIdentity(), new CylinderShape(h, sqrt(Square(cSpaceShipRadius) - Square(cSpaceShipRadius - cSpaceShipHeight - cSpaceShipRingHeight + h))));
+		compound.AddShape(Vec3::sZero(), Quat::sIdentity(), new CylinderShape(h, Sqrt(Square(cSpaceShipRadius) - Square(cSpaceShipRadius - cSpaceShipHeight - cSpaceShipRingHeight + h))));
 	mSpaceShip = mBodyInterface->CreateAndAddBody(BodyCreationSettings(&compound, cShipInitialPosition, Quat::sIdentity(), EMotionType::Kinematic, Layers::MOVING), EActivation::Activate);
 	mSpaceShipPrevTransform = mBodyInterface->GetCenterOfMassTransform(mSpaceShip);
 }

--- a/Samples/Tests/ConvexCollision/EPATest.cpp
+++ b/Samples/Tests/ConvexCollision/EPATest.cpp
@@ -19,7 +19,7 @@ JPH_IMPLEMENT_RTTI_VIRTUAL(EPATest)
 void EPATest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 {
 	AABox box(Vec3(1, 1, -2), Vec3(2, 2, 2));
-	Sphere sphere(Vec3(4, 4, 0), sqrt(8.0f) + 0.01f);
+	Sphere sphere(Vec3(4, 4, 0), Sqrt(8.0f) + 0.01f);
 	Mat44 matrix = Mat44::sRotationTranslation(Quat::sRotation(Vec3(1, 1, 1).Normalized(), 0.25f * JPH_PI), Vec3(1, 2, 3));
 	bool intersecting = CollideBoxSphere(matrix, box, sphere);
 	JPH_ASSERT(intersecting);

--- a/Samples/Tests/ConvexCollision/InteractivePairsTest.cpp
+++ b/Samples/Tests/ConvexCollision/InteractivePairsTest.cpp
@@ -51,7 +51,7 @@ void InteractivePairsTest::PrePhysicsUpdate(const PreUpdateParams &inParams)
 	float z = 0.0f;
 
 	const float r1 = 0.25f * JPH_PI;
-	const float r2 = ATan(1.0f / sqrt(2.0f)); // When rotating cube by 45 degrees the one axis becomes sqrt(2) long while the other stays at length 1
+	const float r2 = ATan(1.0f / Sqrt(2.0f)); // When rotating cube by 45 degrees the one axis becomes sqrt(2) long while the other stays at length 1
 
 	for (int i = 0; i < 2; ++i)
 	{

--- a/Samples/Tests/General/AllowedDOFsTest.cpp
+++ b/Samples/Tests/General/AllowedDOFsTest.cpp
@@ -40,7 +40,7 @@ void AllowedDOFsTest::Initialize()
 		dcs.mPoint1 = bcs.mPosition + Vec3(5, 5, 5);
 		dcs.mPoint2 = bcs.mPosition + box_size;
 		dcs.mMinDistance = 0.0f;
-		dcs.mMaxDistance = sqrt(3.0f) * 5.0f + 1.0f;
+		dcs.mMaxDistance = Sqrt(3.0f) * 5.0f + 1.0f;
 		mPhysicsSystem->AddConstraint(mBodyInterface->CreateConstraint(&dcs, BodyID(), id));
 
 		// Draw degrees of freedom

--- a/Samples/Tests/General/FrictionPerTriangleTest.cpp
+++ b/Samples/Tests/General/FrictionPerTriangleTest.cpp
@@ -80,7 +80,7 @@ void FrictionPerTriangleTest::sOverrideContactSettings(const Body &inBody1, cons
 	sGetFrictionAndRestitution(inBody2, inManifold.mSubShapeID2, friction2, restitution2);
 
 	// Use the default formulas for combining friction and restitution
-	ioSettings.mCombinedFriction = sqrt(friction1 * friction2);
+	ioSettings.mCombinedFriction = Sqrt(friction1 * friction2);
 	ioSettings.mCombinedRestitution = max(restitution1, restitution2);
 }
 

--- a/Samples/Tests/Hair/HairTest.cpp
+++ b/Samples/Tests/Hair/HairTest.cpp
@@ -96,7 +96,7 @@ void HairTest::Initialize()
 			Float3 translation, rotation;
 			stream.Read(translation);
 			stream.Read(rotation);
-			Quat rotation_quat(rotation.x, rotation.y, rotation.z, sqrt(max(0.0f, 1.0f - Vec3(rotation).LengthSq())));
+			Quat rotation_quat(rotation.x, rotation.y, rotation.z, Sqrt(max(0.0f, 1.0f - Vec3(rotation).LengthSq())));
 			mFaceAnimation[frame][joint] = Mat44::sRotationTranslation(rotation_quat, Vec3(translation));
 		}
 	}

--- a/Samples/Tests/Rig/BigWorldTest.cpp
+++ b/Samples/Tests/Rig/BigWorldTest.cpp
@@ -63,7 +63,7 @@ void BigWorldTest::Initialize()
 	for (Real distance : distances)
 	{
 		// Calculate origin for this simulation assuming we want to be 'distance' away and the same distance along each coordinate axis
-		RVec3 origin = RVec3::sReplicate(distance) / sqrt(3.0_r);
+		RVec3 origin = RVec3::sReplicate(distance) / Sqrt(3.0_r);
 
 		// Create floor (floor at 0 was already created)
 		if (distance != 0.0f)

--- a/Samples/Tests/Shapes/DeformedHeightFieldShapeTest.cpp
+++ b/Samples/Tests/Shapes/DeformedHeightFieldShapeTest.cpp
@@ -98,7 +98,7 @@ void DeformedHeightFieldShapeTest::PrePhysicsUpdate(const PreUpdateParams &inPar
 
 		// A function to calculate the delta height at a certain distance from the center of the pit
 		constexpr float cHalfPi = 0.5f * JPH_PI;
-		auto pit_shape = [=](float inDistanceX, float inDistanceY) { return Cos(min(sqrt(Square(inDistanceX) + Square(inDistanceY)) * cHalfPi / cPitRadius, cHalfPi)); };
+		auto pit_shape = [=](float inDistanceX, float inDistanceY) { return Cos(min(Sqrt(Square(inDistanceX) + Square(inDistanceY)) * cHalfPi / cPitRadius, cHalfPi)); };
 
 		AABox affected_area;
 		for (int y = 0; y < count_y; ++y)

--- a/Samples/Tests/SoftBody/SoftBodyShapesTest.cpp
+++ b/Samples/Tests/SoftBody/SoftBodyShapesTest.cpp
@@ -27,7 +27,7 @@ JPH_IMPLEMENT_RTTI_VIRTUAL(SoftBodyShapesTest)
 
 void SoftBodyShapesTest::Initialize()
 {
-	const Quat cCubeOrientation = Quat::sRotation(Vec3::sReplicate(sqrt(1.0f / 3.0f)), DegreesToRadians(45.0f));
+	const Quat cCubeOrientation = Quat::sRotation(Vec3::sReplicate(Sqrt(1.0f / 3.0f)), DegreesToRadians(45.0f));
 
 	// Floor
 	CreateMeshTerrain();

--- a/Samples/Tests/SoftBody/SoftBodyUpdatePositionTest.cpp
+++ b/Samples/Tests/SoftBody/SoftBodyUpdatePositionTest.cpp
@@ -20,7 +20,7 @@ void SoftBodyUpdatePositionTest::Initialize()
 	CreateFloor();
 
 	// Bodies with various settings for 'make rotation identity' and 'update position'
-	SoftBodyCreationSettings sphere(SoftBodySharedSettings::sCreateCube(5, 0.5f), RVec3::sZero(), Quat::sRotation(Vec3::sReplicate(1.0f / sqrt(3.0f)), 0.25f * JPH_PI), Layers::MOVING);
+	SoftBodyCreationSettings sphere(SoftBodySharedSettings::sCreateCube(5, 0.5f), RVec3::sZero(), Quat::sRotation(Vec3::sReplicate(1.0f / Sqrt(3.0f)), 0.25f * JPH_PI), Layers::MOVING);
 
 	for (int update_position = 0; update_position < 2; ++update_position)
 		for (int make_rotation_identity = 0; make_rotation_identity < 2; ++make_rotation_identity)

--- a/UnitTests/Geometry/EPATests.cpp
+++ b/UnitTests/Geometry/EPATests.cpp
@@ -97,28 +97,28 @@ TEST_SUITE("EPATests")
 		{
 			// Sphere just missing box on edge
 			AABox box(Vec3(1, 1, -2), Vec3(2, 2, 2));
-			Sphere sphere(Vec3(4, 4, 0), sqrt(8.0f) - 0.01f);
+			Sphere sphere(Vec3(4, 4, 0), Sqrt(8.0f) - 0.01f);
 			CHECK(!CollideBoxSphere(inMatrix, box, sphere));
 		}
 
 		{
 			// Sphere just penetrating box on edge
 			AABox box(Vec3(1, 1, -2), Vec3(2, 2, 2));
-			Sphere sphere(Vec3(4, 4, 0), sqrt(8.0f) + 0.01f);
+			Sphere sphere(Vec3(4, 4, 0), Sqrt(8.0f) + 0.01f);
 			CHECK(CollideBoxSphere(inMatrix, box, sphere));
 		}
 
 		{
 			// Sphere just missing box on vertex
 			AABox box(Vec3(1, 1, 1), Vec3(2, 2, 2));
-			Sphere sphere(Vec3(4, 4, 4), sqrt(12.0f) - 0.01f);
+			Sphere sphere(Vec3(4, 4, 4), Sqrt(12.0f) - 0.01f);
 			CHECK(!CollideBoxSphere(inMatrix, box, sphere));
 		}
 
 		{
 			// Sphere just penetrating box on vertex
 			AABox box(Vec3(1, 1, 1), Vec3(2, 2, 2));
-			Sphere sphere(Vec3(4, 4, 4), sqrt(12.0f) + 0.01f);
+			Sphere sphere(Vec3(4, 4, 4), Sqrt(12.0f) + 0.01f);
 			CHECK(CollideBoxSphere(inMatrix, box, sphere));
 		}
 	}

--- a/UnitTests/Geometry/EllipseTest.cpp
+++ b/UnitTests/Geometry/EllipseTest.cpp
@@ -35,6 +35,6 @@ TEST_SUITE("EllipseTests")
 		Ellipse e2(2.0f, 2.0f);
 
 		c = e2.GetClosestPoint(Float2(4.0f, 4.0f));
-		CHECK_APPROX_EQUAL(c, Float2(sqrt(2.0f), sqrt(2.0f)));
+		CHECK_APPROX_EQUAL(c, Float2(Sqrt(2.0f), Sqrt(2.0f)));
 	}
 }

--- a/UnitTests/Geometry/GJKTests.cpp
+++ b/UnitTests/Geometry/GJKTests.cpp
@@ -32,7 +32,7 @@ TEST_SUITE("GJKTests")
 		Sphere s2(c2, 1.0f);
 
 		// Sphere 3 is exactly 2 away from s1
-		float l = 2.0f / sqrt(3.0f);
+		float l = 2.0f / Sqrt(3.0f);
 		Vec3 c3(l, l, l);
 		Sphere s3(c3, 1.0f);
 
@@ -51,7 +51,7 @@ TEST_SUITE("GJKTests")
 		{
 			// Test sphere s1 and s2, they should not collide, verify their closest points
 			Vec3 pa, pb, v = Vec3::sZero();
-			float d = sqrt(gjk.GetClosestPoints(s1, s2, 1.0e-4f, cLargeFloat, v, pa, pb));
+			float d = Sqrt(gjk.GetClosestPoints(s1, s2, 1.0e-4f, cLargeFloat, v, pa, pb));
 			CHECK_APPROX_EQUAL(c2.Length() - 2.0f, d, 1.0e-4f);
 			CHECK_APPROX_EQUAL(c2.Normalized(), pa, 1.0e-4f);
 			CHECK_APPROX_EQUAL(c2 - c2.Normalized(), pb, 1.0e-4f);
@@ -60,7 +60,7 @@ TEST_SUITE("GJKTests")
 		{
 			// Test sphere s1 and s3, they should touch exactly, verify their closest points
 			Vec3 pa, pb, v = Vec3::sZero();
-			float d = sqrt(gjk.GetClosestPoints(s1, s3, 1.0e-4f, cLargeFloat, v, pa, pb));
+			float d = Sqrt(gjk.GetClosestPoints(s1, s3, 1.0e-4f, cLargeFloat, v, pa, pb));
 			CHECK_APPROX_EQUAL(0.0f, d, 1.0e-4f);
 			CHECK_APPROX_EQUAL(c2.Normalized(), pa, 1.0e-4f);
 			CHECK_APPROX_EQUAL(c2.Normalized(), pb, 1.0e-4f);

--- a/UnitTests/Math/DVec3Tests.cpp
+++ b/UnitTests/Math/DVec3Tests.cpp
@@ -251,12 +251,12 @@ TEST_SUITE("DVec3Tests")
 	TEST_CASE("TestDVec3Length")
 	{
 		CHECK(DVec3(2, 3, 4).LengthSq() == double(4 + 9 + 16));
-		CHECK(DVec3(2, 3, 4).Length() == sqrt(double(4 + 9 + 16)));
+		CHECK(DVec3(2, 3, 4).Length() == Sqrt(double(4 + 9 + 16)));
 	}
 
 	TEST_CASE("TestDVec3Sqrt")
 	{
-		CHECK(DVec3(13, 15, 17).Sqrt() == DVec3(sqrt(13.0), sqrt(15.0), sqrt(17.0)));
+		CHECK(DVec3(13, 15, 17).Sqrt() == DVec3(Sqrt(13.0), Sqrt(15.0), Sqrt(17.0)));
 	}
 
 	TEST_CASE("TestDVec3Equals")
@@ -314,7 +314,7 @@ TEST_SUITE("DVec3Tests")
 
 	TEST_CASE("TestDVec3Normalize")
 	{
-		CHECK(DVec3(3, 2, 1).Normalized() == DVec3(3, 2, 1) / sqrt(9.0 + 4.0 + 1.0));
+		CHECK(DVec3(3, 2, 1).Normalized() == DVec3(3, 2, 1) / Sqrt(9.0 + 4.0 + 1.0));
 	}
 
 	TEST_CASE("TestDVec3Sign")

--- a/UnitTests/Math/QuatTests.cpp
+++ b/UnitTests/Math/QuatTests.cpp
@@ -504,7 +504,7 @@ TEST_SUITE("QuatTests")
 
 		{
 			// Length of a vector is squared inside the function: try with sqrt(FLT_MIN) to see if that still returns a valid rotation
-			Vec3 v1(0, sqrt(FLT_MIN), 0);
+			Vec3 v1(0, Sqrt(FLT_MIN), 0);
 			Vec3 v2(1, 0, 0);
 			Quat q = Quat::sFromTo(v1, v2);
 			CHECK_APPROX_EQUAL(v2.Normalized(), (q * v1).Normalized());

--- a/UnitTests/Math/Vec3Tests.cpp
+++ b/UnitTests/Math/Vec3Tests.cpp
@@ -262,12 +262,12 @@ TEST_SUITE("Vec3Tests")
 	TEST_CASE("TestVec3Length")
 	{
 		CHECK(Vec3(1, 2, 3).LengthSq() == float(1 + 4 + 9));
-		CHECK(Vec3(1, 2, 3).Length() == sqrt(float(1 + 4 + 9)));
+		CHECK(Vec3(1, 2, 3).Length() == Sqrt(float(1 + 4 + 9)));
 	}
 
 	TEST_CASE("TestVec3Sqrt")
 	{
-		CHECK_APPROX_EQUAL(Vec3(13, 15, 17).Sqrt(), Vec3(sqrt(13.0f), sqrt(15.0f), sqrt(17.0f)));
+		CHECK_APPROX_EQUAL(Vec3(13, 15, 17).Sqrt(), Vec3(Sqrt(13.0f), Sqrt(15.0f), Sqrt(17.0f)));
 	}
 
 	TEST_CASE("TestVec3Cross")
@@ -282,11 +282,11 @@ TEST_SUITE("Vec3Tests")
 
 	TEST_CASE("TestVec3Normalize")
 	{
-		CHECK(Vec3(3, 2, 1).Normalized() == Vec3(3, 2, 1) / sqrt(9.0f + 4.0f + 1.0f));
-		CHECK(Vec3(3, 2, 1).NormalizedOr(Vec3(1, 2, 3)) == Vec3(3, 2, 1) / sqrt(9.0f + 4.0f + 1.0f));
+		CHECK(Vec3(3, 2, 1).Normalized() == Vec3(3, 2, 1) / Sqrt(9.0f + 4.0f + 1.0f));
+		CHECK(Vec3(3, 2, 1).NormalizedOr(Vec3(1, 2, 3)) == Vec3(3, 2, 1) / Sqrt(9.0f + 4.0f + 1.0f));
 		CHECK(Vec3::sZero().NormalizedOr(Vec3(1, 2, 3)) == Vec3(1, 2, 3));
-		CHECK(Vec3(0.999f * sqrt(FLT_MIN), 0, 0).NormalizedOr(Vec3(1, 2, 3)) == Vec3(1, 2, 3)); // A vector that has a squared length that is denormal should also be treated as zero
-		CHECK_APPROX_EQUAL(Vec3(1.001f * sqrt(FLT_MIN), 0, 0).NormalizedOr(Vec3(1, 2, 3)), Vec3(1, 0, 0)); // A value that is just above being denormal should work normally
+		CHECK(Vec3(0.999f * Sqrt(FLT_MIN), 0, 0).NormalizedOr(Vec3(1, 2, 3)) == Vec3(1, 2, 3)); // A vector that has a squared length that is denormal should also be treated as zero
+		CHECK_APPROX_EQUAL(Vec3(1.001f * Sqrt(FLT_MIN), 0, 0).NormalizedOr(Vec3(1, 2, 3)), Vec3(1, 0, 0)); // A value that is just above being denormal should work normally
 	}
 
 	TEST_CASE("TestVec3Cast")

--- a/UnitTests/Math/Vec4Tests.cpp
+++ b/UnitTests/Math/Vec4Tests.cpp
@@ -504,17 +504,17 @@ TEST_SUITE("Vec4Tests")
 	TEST_CASE("TestVec4Length")
 	{
 		CHECK(Vec4(1, 2, 3, 4).LengthSq() == float(1 + 4 + 9 + 16));
-		CHECK(Vec4(1, 2, 3, 4).Length() == sqrt(float(1 + 4 + 9 + 16)));
+		CHECK(Vec4(1, 2, 3, 4).Length() == Sqrt(float(1 + 4 + 9 + 16)));
 	}
 
 	TEST_CASE("TestVec4Sqrt")
 	{
-		CHECK_APPROX_EQUAL(Vec4(13, 15, 17, 19).Sqrt(), Vec4(sqrt(13.0f), sqrt(15.0f), sqrt(17.0f), sqrt(19.0f)));
+		CHECK_APPROX_EQUAL(Vec4(13, 15, 17, 19).Sqrt(), Vec4(Sqrt(13.0f), Sqrt(15.0f), Sqrt(17.0f), Sqrt(19.0f)));
 	}
 
 	TEST_CASE("TestVec4Normalize")
 	{
-		CHECK(Vec4(1, 2, 3, 4).Normalized() == Vec4(1, 2, 3, 4) / sqrt(30.0f));
+		CHECK(Vec4(1, 2, 3, 4).Normalized() == Vec4(1, 2, 3, 4) / Sqrt(30.0f));
 	}
 
 	TEST_CASE("TestVec4Cast")

--- a/UnitTests/Physics/ConvexVsTrianglesTest.cpp
+++ b/UnitTests/Physics/ConvexVsTrianglesTest.cpp
@@ -178,9 +178,9 @@ TEST_SUITE("ConvexVsTrianglesTest")
 	static void sTestConvexVsTriangles()
 	{
 		const float cRadius = 0.5f;
-		const float cRadiusRS2 = cRadius / sqrt(2.0f);
+		const float cRadiusRS2 = cRadius / Sqrt(2.0f);
 		const float cDistanceToTriangle = 0.1f;
-		const float cDistanceToTriangleRS2 = cDistanceToTriangle / sqrt(2.0f);
+		const float cDistanceToTriangleRS2 = cDistanceToTriangle / Sqrt(2.0f);
 		const float cEpsilon = 1.0e-6f; // A small epsilon to ensure we hit the front side
 		const float cMaxSeparationDistance = 0.5f;
 		const float cSeparationDistance = 0.1f;

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -1712,7 +1712,7 @@ TEST_SUITE("PhysicsTests")
 	{
 		const float friction_floor = 0.9f;
 		const float friction_box = 0.8f;
-		const float combined_friction = sqrt(friction_floor * friction_box);
+		const float combined_friction = Sqrt(friction_floor * friction_box);
 
 		for (float angle = 0; angle < 360.0f; angle += 30.0f)
 		{
@@ -1764,7 +1764,7 @@ TEST_SUITE("PhysicsTests")
 
 			// Create box
 			RVec3 initial_position(1, 2, 3);
-			Quat initial_rotation = Quat::sRotation(Vec3::sReplicate(sqrt(1.0f / 3.0f)), DegreesToRadians(20.0f));
+			Quat initial_rotation = Quat::sRotation(Vec3::sReplicate(Sqrt(1.0f / 3.0f)), DegreesToRadians(20.0f));
 			ShapeRefC box_shape = new BoxShape(Vec3(0.3f, 0.5f, 0.7f));
 			BodyCreationSettings box_settings(box_shape, initial_position, initial_rotation, EMotionType::Dynamic, Layers::MOVING);
 			box_settings.mLinearDamping = 0;

--- a/UnitTests/Physics/ShapeTests.cpp
+++ b/UnitTests/Physics/ShapeTests.cpp
@@ -755,7 +755,7 @@ TEST_SUITE("ShapeTests")
 		Ref<MutableCompoundShape> mutable_compound = new MutableCompoundShape();
 
 		// A non-identity rotation
-		Quat rotation = Quat::sRotation(Vec3::sReplicate(1.0f / sqrt(3.0f)), 0.1f * JPH_PI);
+		Quat rotation = Quat::sRotation(Vec3::sReplicate(1.0f / Sqrt(3.0f)), 0.1f * JPH_PI);
 
 		// Check that local bounding box is a single point
 		AABox bounds1 = mutable_compound->GetLocalBounds();


### PR DESCRIPTION
std::sqrt is required to set errno in case of an error, but we don't care about that. This sometimes causes the function to not be inlined.