### PR TITLE
Added DifferenceOfProducts and Vec3::CrossPrecise functions

### DIFF
--- a/Build/CMakeLists.txt
+++ b/Build/CMakeLists.txt
@@ -257,7 +257,7 @@ else()
 
 		# On clang 14 and later we can turn off float contraction through a pragma, older versions and deterministic versions need it off always, see Core.h
 		# clang on LoongArch does not support such pragma, also turn off contraction for it.
-		if (CMAKE_CXX_COMPILER_VERSION LESS 14 OR CROSS_PLATFORM_DETERMINISTIC OR "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "loongarch")
+		if (CMAKE_CXX_COMPILER_VERSION LESS 14 OR CROSS_PLATFORM_DETERMINISTIC OR NOT USE_FMADD OR EMSCRIPTEN OR "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "loongarch")
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-contract=off")
 
 			# Clang 20 and later complain with: overriding '-ffp-model=precise' option with '-ffp-contract=off' [-Woverriding-option], but this is exactly what we want.

--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -130,6 +130,11 @@
 		#define JPH_VECTOR_ALIGNMENT 8 // 32-bit ARM does not support aligning on the stack on 16 byte boundaries
 		#define JPH_DVECTOR_ALIGNMENT 8
 	#endif
+	#ifndef JPH_CROSS_PLATFORM_DETERMINISTIC // FMA is not compatible with cross platform determinism
+		#if defined(__ARM_FEATURE_FMA) && !defined(JPH_USE_FMADD)
+			#define JPH_USE_FMADD
+		#endif
+	#endif
 #elif defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 	// X86 CPU architecture
 	#define JPH_CPU_X86

--- a/Jolt/Geometry/EPAConvexHullBuilder.h
+++ b/Jolt/Geometry/EPAConvexHullBuilder.h
@@ -707,10 +707,6 @@ private:
 #endif
 };
 
-// The determinant that is calculated in the Triangle constructor is really sensitive
-// to numerical round off, disable the fmadd instructions to maintain precision.
-JPH_PRECISE_MATH_ON
-
 EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, const Vec3 *inPositions)
 {
 	// Fill in indexes
@@ -747,7 +743,7 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 	if (y20_dot_y20 < y21_dot_y21)
 	{
 		// We select the edges y10 and y20
-		mNormal = y10.Cross(y20);
+		mNormal = y10.CrossPrecise(y20);
 
 		// Check if triangle is degenerate
 		float normal_len_sq = mNormal.LengthSq();
@@ -775,13 +771,13 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 			// Cramers rule to invert matrix:
 			float y10_dot_y10 = y10.LengthSq();
 			float y10_dot_y20 = y10.Dot(y20);
-			float determinant = y10_dot_y10 * y20_dot_y20 - y10_dot_y20 * y10_dot_y20;
+			float determinant = DifferenceOfProducts(y10_dot_y10, y20_dot_y20, y10_dot_y20, y10_dot_y20);
 			if (determinant > 0.0f) // If determinant == 0 then the system is linearly dependent and the triangle is degenerate, since y10.10 * y20.y20 > y10.y20^2 it should also be > 0
 			{
 				float y0_dot_y10 = y0.Dot(y10);
 				float y0_dot_y20 = y0.Dot(y20);
-				float l0 = (y10_dot_y20 * y0_dot_y20 - y20_dot_y20 * y0_dot_y10) / determinant;
-				float l1 = (y10_dot_y20 * y0_dot_y10 - y10_dot_y10 * y0_dot_y20) / determinant;
+				float l0 = DifferenceOfProducts(y10_dot_y20, y0_dot_y20, y20_dot_y20, y0_dot_y10) / determinant;
+				float l1 = DifferenceOfProducts(y10_dot_y20, y0_dot_y10, y10_dot_y10, y0_dot_y20) / determinant;
 				mLambda[0] = l0;
 				mLambda[1] = l1;
 				mLambdaRelativeTo0 = true;
@@ -797,7 +793,7 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 	else
 	{
 		// We select the edges y10 and y21
-		mNormal = y10.Cross(y21);
+		mNormal = y10.CrossPrecise(y21);
 
 		// Check if triangle is degenerate
 		float normal_len_sq = mNormal.LengthSq();
@@ -821,13 +817,13 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 			// Cramers rule to invert matrix:
 			float y10_dot_y10 = y10.LengthSq();
 			float y10_dot_y21 = y10.Dot(y21);
-			float determinant = y10_dot_y10 * y21_dot_y21 - y10_dot_y21 * y10_dot_y21;
+			float determinant = DifferenceOfProducts(y10_dot_y10, y21_dot_y21, y10_dot_y21, y10_dot_y21);
 			if (determinant > 0.0f)
 			{
 				float y1_dot_y10 = y1.Dot(y10);
 				float y1_dot_y21 = y1.Dot(y21);
-				float l0 = (y21_dot_y21 * y1_dot_y10 - y10_dot_y21 * y1_dot_y21) / determinant;
-				float l1 = (y10_dot_y21 * y1_dot_y10 - y10_dot_y10 * y1_dot_y21) / determinant;
+				float l0 = DifferenceOfProducts(y21_dot_y21, y1_dot_y10, y10_dot_y21, y1_dot_y21) / determinant;
+				float l1 = DifferenceOfProducts(y10_dot_y21, y1_dot_y10, y10_dot_y10, y1_dot_y21) / determinant;
 				mLambda[0] = l0;
 				mLambda[1] = l1;
 				mLambdaRelativeTo0 = false;
@@ -839,7 +835,5 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 		}
 	}
 }
-
-JPH_PRECISE_MATH_OFF
 
 JPH_NAMESPACE_END

--- a/Jolt/Geometry/RayTriangle.h
+++ b/Jolt/Geometry/RayTriangle.h
@@ -40,7 +40,7 @@ JPH_INLINE float RayTriangle(Vec3Arg inOrigin, Vec3Arg inDirection, Vec3Arg inV0
 	Vec3 u = Vec3::sReplicate(s.Dot(p)) / det;
 
 	// Prepare to test v parameter
-	Vec3 q = s.Cross(e1);
+	Vec3 q = s.CrossPrecise(e1);
 
 	// Calculate v parameter
 	Vec3 v = Vec3::sReplicate(inDirection.Dot(q)) / det;
@@ -121,9 +121,9 @@ JPH_INLINE Vec4 RayTriangle4(Vec3Arg inOrigin, Vec3Arg inDirection, Vec4Arg inV0
 	Vec4 u = Vec4::sXor(sx * px + sy * py + sz * pz, det_sign);
 
 	// Prepare to test v parameter
-	Vec4 qx = sy * e1z - sz * e1y;
-	Vec4 qy = sz * e1x - sx * e1z;
-	Vec4 qz = sx * e1y - sy * e1x;
+	Vec4 qx = Vec4::sDifferenceOfProducts(sy, e1z, sz, e1y);
+	Vec4 qy = Vec4::sDifferenceOfProducts(sz, e1x, sx, e1z);
+	Vec4 qz = Vec4::sDifferenceOfProducts(sx, e1y, sy, e1x);
 
 	// Calculate v parameter and flip sign if determinant was negative
 	Vec4 v = Vec4::sXor(dx * qx + dy * qy + dz * qz, det_sign);

--- a/Jolt/Geometry/RayTriangle.h
+++ b/Jolt/Geometry/RayTriangle.h
@@ -22,7 +22,7 @@ JPH_INLINE float RayTriangle(Vec3Arg inOrigin, Vec3Arg inDirection, Vec3Arg inV0
 	Vec3 e2 = inV2 - inV0;
 
 	// Begin calculating determinant - also used to calculate u parameter
-	Vec3 p = inDirection.Cross(e2);
+	Vec3 p = inDirection.CrossPrecise(e2);
 
 	// if determinant is near zero, ray lies in plane of triangle
 	Vec3 det = Vec3::sReplicate(e1.Dot(p));
@@ -95,9 +95,9 @@ JPH_INLINE Vec4 RayTriangle4(Vec3Arg inOrigin, Vec3Arg inDirection, Vec4Arg inV0
 	Vec4 dz = inDirection.SplatZ();
 
 	// Begin calculating determinant - also used to calculate u parameter
-	Vec4 px = dy * e2z - dz * e2y;
-	Vec4 py = dz * e2x - dx * e2z;
-	Vec4 pz = dx * e2y - dy * e2x;
+	Vec4 px = Vec4::sDifferenceOfProducts(dy, e2z, dz, e2y);
+	Vec4 py = Vec4::sDifferenceOfProducts(dz, e2x, dx, e2z);
+	Vec4 pz = Vec4::sDifferenceOfProducts(dx, e2y, dy, e2x);
 
 	// if determinant is near zero, ray lies in plane of triangle
 	Vec4 det = e1x * px + e1y * py + e1z * pz;

--- a/Jolt/Math/DVec3.inl
+++ b/Jolt/Math/DVec3.inl
@@ -418,22 +418,22 @@ DVec3 DVec3::sGreaterOrEqual(DVec3Arg inV1, DVec3Arg inV2)
 
 DVec3 DVec3::sFusedMultiplyAdd(DVec3Arg inMul1, DVec3Arg inMul2, DVec3Arg inAdd)
 {
-#if defined(JPH_USE_AVX)
-	#ifdef JPH_USE_FMADD
+#ifdef JPH_USE_FMADD
+	#ifdef JPH_USE_AVX
 		return _mm256_fmadd_pd(inMul1.mValue, inMul2.mValue, inAdd.mValue);
+	#elif defined(JPH_USE_NEON)
+		return DVec3({ vmlaq_f64(inAdd.mValue.val[0], inMul1.mValue.val[0], inMul2.mValue.val[0]), vmlaq_f64(inAdd.mValue.val[1], inMul1.mValue.val[1], inMul2.mValue.val[1]) });
+	#elif defined(JPH_USE_RVV)
+		DVec3 res;
+		const vfloat64m2_t v1 = __riscv_vle64_v_f64m2(inMul1.mF64, 3);
+		const vfloat64m2_t v2 = __riscv_vle64_v_f64m2(inMul2.mF64, 3);
+		const vfloat64m2_t rvv_add = __riscv_vle64_v_f64m2(inAdd.mF64, 3);
+		const vfloat64m2_t fmadd = __riscv_vfmacc_vv_f64m2(rvv_add, v1, v2, 3);
+		__riscv_vse64_v_f64m2(res.mF64, fmadd, 3);
+		return res;
 	#else
-		return _mm256_add_pd(_mm256_mul_pd(inMul1.mValue, inMul2.mValue), inAdd.mValue);
+		return inMul1 * inMul2 + inAdd;
 	#endif
-#elif defined(JPH_USE_NEON)
-	return DVec3({ vmlaq_f64(inAdd.mValue.val[0], inMul1.mValue.val[0], inMul2.mValue.val[0]), vmlaq_f64(inAdd.mValue.val[1], inMul1.mValue.val[1], inMul2.mValue.val[1]) });
-#elif defined(JPH_USE_RVV)
-	DVec3 res;
-	const vfloat64m2_t v1 = __riscv_vle64_v_f64m2(inMul1.mF64, 3);
-	const vfloat64m2_t v2 = __riscv_vle64_v_f64m2(inMul2.mF64, 3);
-	const vfloat64m2_t rvv_add = __riscv_vle64_v_f64m2(inAdd.mF64, 3);
-	const vfloat64m2_t fmadd = __riscv_vfmacc_vv_f64m2(rvv_add, v1, v2, 3);
-	__riscv_vse64_v_f64m2(res.mF64, fmadd, 3);
-	return res;
 #else
 	return inMul1 * inMul2 + inAdd;
 #endif

--- a/Jolt/Math/FindRoot.h
+++ b/Jolt/Math/FindRoot.h
@@ -17,7 +17,15 @@ inline int FindRoot(const T inA, const T inB, const T inC, T &outX1, T &outX2)
 	{
 		// Check if this is a constant equation
 		if (inB == T(0))
+		{
+			if (inC == T(0))
+			{
+				outX1 = outX2 = 0.0f;
+				return 1; // Actually infinitely many solutions
+			}
+
 			return 0;
+		}
 
 		// Linear equation with 1 solution
 		outX1 = outX2 = -inC / inB;
@@ -25,7 +33,7 @@ inline int FindRoot(const T inA, const T inB, const T inC, T &outX1, T &outX2)
 	}
 
 	// See Numerical Recipes in C, Chapter 5.6 Quadratic and Cubic Equations
-	T det = Square(inB) - T(4) * inA * inC;
+	T det = DifferenceOfProducts(inB, inB, T(4) * inA, inC);
 	if (det < T(0))
 		return 0;
 	T q = (inB + Sign(inB) * Sqrt(det)) / T(-2);

--- a/Jolt/Math/Mat44.inl
+++ b/Jolt/Math/Mat44.inl
@@ -959,7 +959,7 @@ Mat44 Mat44::InversedRotationTranslation() const
 
 float Mat44::GetDeterminant3x3() const
 {
-	return GetAxisX().Dot(GetAxisY().Cross(GetAxisZ()));
+	return GetAxisX().Dot(GetAxisY().CrossPrecise(GetAxisZ()));
 }
 
 Mat44 Mat44::Adjointed3x3() const

--- a/Jolt/Math/Math.h
+++ b/Jolt/Math/Math.h
@@ -43,6 +43,21 @@ inline float CenterAngleAroundZero(float inV)
 	return inV;
 }
 
+/// Calculates inA * inB - inC * inD with higher accuracy when fused multiply add instructions are available.
+/// If inA * inB and inC * inD are large, the subtraction can cause a large loss of precision when the result is small.
+/// See: https://pharr.org/matt/blog/2019/11/03/difference-of-floats (or search for Kahan's algorithm)
+JPH_INLINE float DifferenceOfProducts(float inA, float inB, float inC, float inD)
+{
+#ifdef JPH_USE_FMADD
+	float cd = inC * inD;
+	float err = std::fma(-inC, inD, cd);
+	float dop = std::fma(inA, inB, -cd);
+	return dop + err;
+#else
+	return inA * inB - inC * inD;
+#endif
+}
+
 /// Clamp a value between two values
 template <typename T>
 JPH_INLINE constexpr T Clamp(T inV, T inMin, T inMax)

--- a/Jolt/Math/Matrix.h
+++ b/Jolt/Math/Matrix.h
@@ -242,7 +242,7 @@ inline bool Matrix<2, 2>::SetInversed(const Matrix<2, 2> &inM)
 	float d = inM.mCol[1].mF32[1];
 
 	// Calculate determinant
-	float det = a * d - b * c;
+	float det = DifferenceOfProducts(a, d, b, c);
 	if (det == 0.0f)
 		return false;
 

--- a/Jolt/Math/Vec3.h
+++ b/Jolt/Math/Vec3.h
@@ -223,8 +223,14 @@ public:
 	/// Reciprocal vector (1 / value) for each of the components
 	JPH_INLINE Vec3				Reciprocal() const;
 
+	/// Calculates inA * inB - inC * inD with more precision when FMA instructions are available. See DifferenceOfProducts.
+	JPH_INLINE static Vec3		sDifferenceOfProducts(Vec3Arg inA, Vec3Arg inB, Vec3Arg inC, Vec3Arg inD);
+
 	/// Cross product
 	JPH_INLINE Vec3				Cross(Vec3Arg inV2) const;
+
+	/// Cross product (more precise version when FMA is available)
+	JPH_INLINE Vec3				CrossPrecise(Vec3Arg inV2) const;
 
 	/// Dot product, returns the dot product in X, Y and Z components
 	JPH_INLINE Vec3				DotV(Vec3Arg inV2) const;

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -352,26 +352,24 @@ UVec4 Vec3::sGreaterOrEqual(Vec3Arg inV1, Vec3Arg inV2)
 
 Vec3 Vec3::sFusedMultiplyAdd(Vec3Arg inMul1, Vec3Arg inMul2, Vec3Arg inAdd)
 {
-#if defined(JPH_USE_SSE)
-	#ifdef JPH_USE_FMADD
+#ifdef JPH_USE_FMADD
+	#ifdef JPH_USE_SSE
 		return _mm_fmadd_ps(inMul1.mValue, inMul2.mValue, inAdd.mValue);
+	#elif defined(JPH_USE_NEON)
+		return vmlaq_f32(inAdd.mValue, inMul1.mValue, inMul2.mValue);
+	#elif defined(JPH_USE_RVV)
+		Vec3 res;
+		const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(inMul1.mF32, 3);
+		const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inMul2.mF32, 3);
+		const vfloat32m1_t rvv_add = __riscv_vle32_v_f32m1(inAdd.mF32, 3);
+		const vfloat32m1_t fmadd = __riscv_vfmacc_vv_f32m1(rvv_add, v1, v2, 3);
+		__riscv_vse32_v_f32m1(res.mF32, fmadd, 3);
+		return res;
 	#else
-		return _mm_add_ps(_mm_mul_ps(inMul1.mValue, inMul2.mValue), inAdd.mValue);
+		return inMul1 * inMul2 + inAdd;
 	#endif
-#elif defined(JPH_USE_NEON)
-	return vmlaq_f32(inAdd.mValue, inMul1.mValue, inMul2.mValue);
-#elif defined(JPH_USE_RVV)
-	Vec3 res;
-	const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(inMul1.mF32, 3);
-	const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inMul2.mF32, 3);
-	const vfloat32m1_t rvv_add = __riscv_vle32_v_f32m1(inAdd.mF32, 3);
-	const vfloat32m1_t fmadd = __riscv_vfmacc_vv_f32m1(rvv_add, v1, v2, 3);
-	__riscv_vse32_v_f32m1(res.mF32, fmadd, 3);
-	return res;
 #else
-	return Vec3(inMul1.mF32[0] * inMul2.mF32[0] + inAdd.mF32[0],
-				inMul1.mF32[1] * inMul2.mF32[1] + inAdd.mF32[1],
-				inMul1.mF32[2] * inMul2.mF32[2] + inAdd.mF32[2]);
+	return inMul1 * inMul2 + inAdd;
 #endif
 }
 

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -838,6 +838,18 @@ Vec3 Vec3::Reciprocal() const
 	return sOne() / mValue;
 }
 
+Vec3 Vec3::sDifferenceOfProducts(Vec3Arg inA, Vec3Arg inB, Vec3Arg inC, Vec3Arg inD)
+{
+#ifdef JPH_USE_FMADD
+	Vec3 cd = inC * inD;
+	Vec3 err = Vec3::sFusedMultiplyAdd(-inC, inD, cd);
+	Vec3 dop = Vec3::sFusedMultiplyAdd(inA, inB, -cd);
+	return dop + err;
+#else
+	return inA * inB - inC * inD;
+#endif
+}
+
 Vec3 Vec3::Cross(Vec3Arg inV2) const
 {
 #if defined(JPH_USE_SSE)
@@ -874,6 +886,11 @@ Vec3 Vec3::Cross(Vec3Arg inV2) const
 				mF32[2] * inV2.mF32[0] - mF32[0] * inV2.mF32[2],
 				mF32[0] * inV2.mF32[1] - mF32[1] * inV2.mF32[0]);
 #endif
+}
+
+Vec3 Vec3::CrossPrecise(Vec3Arg inV2) const
+{
+	return sDifferenceOfProducts(*this, inV2.Swizzle<SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_X>(), Swizzle<SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_X>(), inV2).Swizzle<SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_X>();
 }
 
 Vec3 Vec3::DotV(Vec3Arg inV2) const

--- a/Jolt/Math/Vec4.h
+++ b/Jolt/Math/Vec4.h
@@ -230,6 +230,9 @@ public:
 	/// Reciprocal vector (1 / value) for each of the components
 	JPH_INLINE Vec4				Reciprocal() const;
 
+	/// Calculates inA * inB - inC * inD with more precision when FMA instructions are available. See DifferenceOfProducts.
+	JPH_INLINE static Vec4		sDifferenceOfProducts(Vec4Arg inA, Vec4Arg inB, Vec4Arg inC, Vec4Arg inD);
+
 	/// Dot product, returns the dot product in X, Y, Z and W components
 	JPH_INLINE Vec4				DotV(Vec4Arg inV2) const;
 

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -977,6 +977,18 @@ Vec4 Vec4::Reciprocal() const
 	return sOne() / mValue;
 }
 
+Vec4 Vec4::sDifferenceOfProducts(Vec4Arg inA, Vec4Arg inB, Vec4Arg inC, Vec4Arg inD)
+{
+#ifdef JPH_USE_FMADD
+	Vec4 cd = inC * inD;
+	Vec4 err = Vec4::sFusedMultiplyAdd(-inC, inD, cd);
+	Vec4 dop = Vec4::sFusedMultiplyAdd(inA, inB, -cd);
+	return dop + err;
+#else
+	return inA * inB - inC * inD;
+#endif
+}
+
 Vec4 Vec4::DotV(Vec4Arg inV2) const
 {
 #if defined(JPH_USE_SSE4_1)

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -349,28 +349,25 @@ UVec4 Vec4::sGreaterOrEqual(Vec4Arg inV1, Vec4Arg inV2)
 
 Vec4 Vec4::sFusedMultiplyAdd(Vec4Arg inMul1, Vec4Arg inMul2, Vec4Arg inAdd)
 {
-#if defined(JPH_USE_SSE)
-	#ifdef JPH_USE_FMADD
+#ifdef JPH_USE_FMADD
+	#ifdef JPH_USE_SSE
 		return _mm_fmadd_ps(inMul1.mValue, inMul2.mValue, inAdd.mValue);
+	#elif defined(JPH_USE_NEON)
+		return vmlaq_f32(inAdd.mValue, inMul1.mValue, inMul2.mValue);
+	#elif defined(JPH_USE_RVV)
+		Vec4 res;
+		const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(inMul1.mF32, 4);
+		const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inMul2.mF32, 4);
+		const vfloat32m1_t rvv_add = __riscv_vle32_v_f32m1(inAdd.mF32, 4);
+		const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v1, v2, 4);
+		const vfloat32m1_t fmadd = __riscv_vfadd_vv_f32m1(rvv_add, mul, 4);
+		__riscv_vse32_v_f32m1(res.mF32, fmadd, 4);
+		return res;
 	#else
-		return _mm_add_ps(_mm_mul_ps(inMul1.mValue, inMul2.mValue), inAdd.mValue);
+		return inMul1 * inMul2 + inAdd;
 	#endif
-#elif defined(JPH_USE_NEON)
-	return vmlaq_f32(inAdd.mValue, inMul1.mValue, inMul2.mValue);
-#elif defined(JPH_USE_RVV)
-	Vec4 res;
-	const vfloat32m1_t v1 = __riscv_vle32_v_f32m1(inMul1.mF32, 4);
-	const vfloat32m1_t v2 = __riscv_vle32_v_f32m1(inMul2.mF32, 4);
-	const vfloat32m1_t rvv_add = __riscv_vle32_v_f32m1(inAdd.mF32, 4);
-	const vfloat32m1_t mul = __riscv_vfmul_vv_f32m1(v1, v2, 4);
-	const vfloat32m1_t fmadd = __riscv_vfadd_vv_f32m1(rvv_add, mul, 4);
-	__riscv_vse32_v_f32m1(res.mF32, fmadd, 4);
-	return res;
 #else
-	return Vec4(inMul1.mF32[0] * inMul2.mF32[0] + inAdd.mF32[0],
-				inMul1.mF32[1] * inMul2.mF32[1] + inAdd.mF32[1],
-				inMul1.mF32[2] * inMul2.mF32[2] + inAdd.mF32[2],
-				inMul1.mF32[3] * inMul2.mF32[3] + inAdd.mF32[3]);
+	return inMul1 * inMul2 + inAdd;
 #endif
 }
 

--- a/Jolt/Physics/Collision/CastSphereVsTriangles.cpp
+++ b/Jolt/Physics/Collision/CastSphereVsTriangles.cpp
@@ -102,7 +102,7 @@ float CastSphereVsTriangles::RayCylinder(Vec3Arg inRayDirection, Vec3Arg inCylin
 		return FLT_MAX; // Segment runs parallel to cylinder axis, stop processing, we will either hit at fraction = 0 or we'll hit a vertex
 	float b = axis_len_sq * start.Dot(inRayDirection) - direction_dot_axis * start_dot_axis; // should be multiplied by 2, instead we'll divide a and c by 2 when we solve the quadratic equation
 	float c = axis_len_sq * (start.LengthSq() - Square(inRadius)) - Square(start_dot_axis);
-	float det = Square(b) - a * c; // normally 4 * a * c but since both a and c need to be divided by 2 we lose the 4
+	float det = DifferenceOfProducts(b, b, a, c); // normally 4 * a * c but since both a and c need to be divided by 2 we lose the 4
 	if (det < 0.0f)
 		return FLT_MAX; // No solution to quadratic equation
 

--- a/UnitTests/Math/MathTests.cpp
+++ b/UnitTests/Math/MathTests.cpp
@@ -81,4 +81,17 @@ TEST_SUITE("Mat44Tests")
 		CHECK(!IsPowerOf2(65535));
 		CHECK(!IsPowerOf2(65537));
 	}
+
+	TEST_CASE("TestDifferenceOfProducts")
+	{
+		float a = 33962.035f, b = -30438.8f, c = 41563.4f, d = -24871.969f;
+		float result = DifferenceOfProducts(a, b, c, d);
+		double expected = double(a) * double(b) - double(c) * double(d);
+		CHECK(expected == -75.165603637695312);
+	#ifdef JPH_USE_FMADD
+		CHECK(result == float(expected));
+	#else
+		CHECK(result == -128.0f); // The products are in the order of 10^9, so the subtraction causes a large loss of precision and we get a very different result. This is expected when fused multiply add instructions are not available.
+	#endif
+	}
 }

--- a/UnitTests/Math/MathTests.cpp
+++ b/UnitTests/Math/MathTests.cpp
@@ -4,6 +4,7 @@
 
 #include "UnitTestFramework.h"
 #include <Jolt/Math/Mat44.h>
+#include <Jolt/Math/FindRoot.h>
 
 TEST_SUITE("Mat44Tests")
 {
@@ -80,6 +81,53 @@ TEST_SUITE("Mat44Tests")
 		CHECK(!IsPowerOf2(17));
 		CHECK(!IsPowerOf2(65535));
 		CHECK(!IsPowerOf2(65537));
+	}
+
+	TEST_CASE("TestFindRoot")
+	{
+		{
+			// Quadratic, 2 solutions
+			float x1, x2;
+			CHECK(FindRoot(2.0f, 8.0f, 6.0f, x1, x2) == 2);
+			CHECK(x1 == -3.0f);
+			CHECK(x2 == -1.0f);
+		}
+
+		{
+			// Quadratic without b term, 2 solutions
+			float x1, x2;
+			CHECK(FindRoot(2.0f, 0.0f, -8.0f, x1, x2) == 2);
+			CHECK(x1 == -2.0f);
+			CHECK(x2 == 2.0f);
+		}
+
+		{
+			// Quadratic without solution
+			float x1, x2;
+			CHECK(FindRoot(2.0f, 1.0f, 8.0f, x1, x2) == 0);
+		}
+
+		{
+			// Linear
+			float x1, x2;
+			CHECK(FindRoot(0.0f, 8.0f, 4.0f, x1, x2) == 1);
+			CHECK(x1 == -0.5f);
+			CHECK(x2 == -0.5f);
+		}
+
+		{
+			// Constant
+			float x1, x2;
+			CHECK(FindRoot(0.0f, 0.0f, 0.0f, x1, x2) == 1);
+			CHECK(x1 == 0.0f);
+			CHECK(x2 == 0.0f);
+		}
+
+		{
+			// Constant, no solution
+			float x1, x2;
+			CHECK(FindRoot(0.0f, 0.0f, 1.0f, x1, x2) == 0);
+		}
 	}
 
 	TEST_CASE("TestDifferenceOfProducts")

--- a/UnitTests/Math/Vec3Tests.cpp
+++ b/UnitTests/Math/Vec3Tests.cpp
@@ -425,4 +425,17 @@ TEST_SUITE("Vec3Tests")
 			CHECK(diff < 1.0e-4f);
 		}
 	}
+
+	TEST_CASE("TestDifferenceOfProducts")
+	{
+		Vec3 a = Vec3(33962.035f, 33962.0351f, 33962.0352f), b = Vec3(-30438.8f, -30438.801f, -30438.802f), c = Vec3(41563.4f, 41563.401f, 41563.402f), d = Vec3(-24871.969f, -24871.970f, -24871.971f);
+		Vec3 result = Vec3::sDifferenceOfProducts(a, b, c, d);
+		DVec3 expected = DVec3(a) * DVec3(b) - DVec3(c) * DVec3(d);
+		CHECK(expected == DVec3(-75.165603637695312, 103.16904449462891, 36.836944580078125));
+	#ifdef JPH_USE_FMADD
+		CHECK(result == Vec3(expected));
+	#else
+		CHECK(result == Vec3(-128.0f, 64.0f, 0.0f)); // The products are in the order of 10^9, so the subtraction causes a large loss of precision and we get a very different result. This is expected when fused multiply add instructions are not available.
+	#endif
+	}
 }

--- a/UnitTests/Math/Vec4Tests.cpp
+++ b/UnitTests/Math/Vec4Tests.cpp
@@ -805,4 +805,25 @@ TEST_SUITE("Vec4Tests")
 			CHECK(diff < 5.0e-3f);
 		}
 	}
+
+	TEST_CASE("TestDifferenceOfProducts")
+	{
+		Vec4 a = Vec4(33962.035f, 33962.0351f, 33962.0352f, 33962.0353f), b = Vec4(-30438.8f, -30438.801f, -30438.802f, -30438.803f), c = Vec4(41563.4f, 41563.401f, 41563.402f, 41563.403f), d = Vec4(-24871.969f, -24871.970f, -24871.971f, -24871.972f);
+		Vec4 result = Vec4::sDifferenceOfProducts(a, b, c, d);
+		double expected[4] = {
+			double(a.GetX()) * double(b.GetX()) - double(c.GetX()) * double(d.GetX()),
+			double(a.GetY()) * double(b.GetY()) - double(c.GetY()) * double(d.GetY()),
+			double(a.GetZ()) * double(b.GetZ()) - double(c.GetZ()) * double(d.GetZ()),
+			double(a.GetW()) * double(b.GetW()) - double(c.GetW()) * double(d.GetW())
+		};
+		CHECK(expected[0] == -75.165603637695312);
+		CHECK(expected[1] == 103.16904449462891);
+		CHECK(expected[2] == 36.836944580078125);
+		CHECK(expected[3] == 118.01546478271484);
+	#ifdef JPH_USE_FMADD
+		CHECK(result == Vec4(float(expected[0]), float(expected[1]), float(expected[2]), float(expected[3])));
+	#else
+		CHECK(result == Vec4(-128.0f, 64.0f, 0.0f, 64.0f)); // The products are in the order of 10^9, so the subtraction causes a large loss of precision and we get a very different result. This is expected when fused multiply add instructions are not available.
+	#endif
+	}
 }


### PR DESCRIPTION
This returns a more accurate result of a * b - c * d when FMA is enabled. Using this function enables us to run the EPAConvexHullBuilder without using JPH_PRECISE_MATH_ON 