### PR TITLE
Fixes for MSVC 18.6.0

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -38,6 +38,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * Fixed `CharacterVirtual::GetFirstContactForSweep` crashing if the body that it hit was removed from another thread between `CastShape` and `GetTransformedShape`.
 * Fixed an issue that broke cross platform determinism between ARM64 and x64 builds when compiling with double precision.
 * Fixed some warnings when compiling with clang using C++26.
+* Fixed unit test failures + floating point exceptions in Samples when using MSVC 18.6.0.
 
 ## v5.5.0
 

--- a/Jolt/Math/Vec3.inl
+++ b/Jolt/Math/Vec3.inl
@@ -1353,10 +1353,11 @@ Vec3 Vec3::sDecompressUnitVector(uint32 inValue)
 	constexpr uint cNumBits = 14;
 	constexpr uint cMask = (1u << cNumBits) - 1;
 	constexpr uint cMaxValue = cMask - 1; // Need odd number of buckets to quantize to or else we can't encode 0
+	constexpr int cHalfMaxValue = int(cMaxValue >> 1);
 	constexpr float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore two components
-	Vec3 v = Vec3(UVec4(inValue & cMask, (inValue >> cNumBits) & cMask, 0, 0).ToFloat()) * cScale - Vec3(cOneOverSqrt2, cOneOverSqrt2, 0.0f);
+	Vec3 v = Vec3(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), 0) * cScale;
 	JPH_ASSERT(v.GetZ() == 0.0f);
 
 	// Restore the highest component

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -1484,7 +1484,7 @@ Vec4 Vec4::sDecompressUnitVector(uint32 inValue)
 	constexpr float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore three components
-	Vec4 v = Vec4(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float((inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue, 0) * cScale;
+	Vec4 v = Vec4(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float(int(inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue, 0) * cScale;
 	JPH_ASSERT(v.GetW() == 0.0f);
 
 	// Restore the highest component

--- a/Jolt/Math/Vec4.inl
+++ b/Jolt/Math/Vec4.inl
@@ -1480,10 +1480,11 @@ Vec4 Vec4::sDecompressUnitVector(uint32 inValue)
 	constexpr uint cNumBits = 9;
 	constexpr uint cMask = (1u << cNumBits) - 1;
 	constexpr uint cMaxValue = cMask - 1; // Need odd number of buckets to quantize to or else we can't encode 0
+	constexpr int cHalfMaxValue = int(cMaxValue >> 1);
 	constexpr float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore three components
-	Vec4 v = Vec4(UVec4(inValue & cMask, (inValue >> cNumBits) & cMask, (inValue >> (2 * cNumBits)) & cMask, 0).ToFloat()) * cScale - Vec4(cOneOverSqrt2, cOneOverSqrt2, cOneOverSqrt2, 0.0f);
+	Vec4 v = Vec4(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float((inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue, 0) * cScale;
 	JPH_ASSERT(v.GetW() == 0.0f);
 
 	// Restore the highest component

--- a/Jolt/Shaders/ShaderQuat.h
+++ b/Jolt/Shaders/ShaderQuat.h
@@ -46,10 +46,11 @@ inline JPH_Quat JPH_QuatDecompress(uint inValue)
 	const uint cNumBits = 9;
 	const uint cMask = (1u << cNumBits) - 1;
 	const uint cMaxValue = cMask - 1; // Need odd number of buckets to quantize to or else we can't encode 0
+	const int cHalfMaxValue = int(cMaxValue >> 1);
 	const float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore two components
-	float3 v3 = float3(float(inValue & cMask), float((inValue >> cNumBits) & cMask), float((inValue >> (2 * cNumBits)) & cMask)) * cScale - float3(cOneOverSqrt2, cOneOverSqrt2, cOneOverSqrt2);
+	float3 v3 = float3(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float((inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue) * cScale;
 
 	// Restore the highest component
 	float4 v = float4(v3, sqrt(max(1.0f - dot(v3, v3), 0.0f)));

--- a/Jolt/Shaders/ShaderQuat.h
+++ b/Jolt/Shaders/ShaderQuat.h
@@ -50,7 +50,7 @@ inline JPH_Quat JPH_QuatDecompress(uint inValue)
 	const float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore two components
-	float3 v3 = float3(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float((inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue) * cScale;
+	float3 v3 = float3(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue), float(int(inValue >> (2 * cNumBits)) & cMask) - cHalfMaxValue) * cScale;
 
 	// Restore the highest component
 	float4 v = float4(v3, sqrt(max(1.0f - dot(v3, v3), 0.0f)));

--- a/Jolt/Shaders/ShaderVec3.h
+++ b/Jolt/Shaders/ShaderVec3.h
@@ -8,10 +8,11 @@ inline float3 JPH_Vec3DecompressUnit(uint inValue)
 	const uint cNumBits = 14;
 	const uint cMask = (1u << cNumBits) - 1;
 	const uint cMaxValue = cMask - 1; // Need odd number of buckets to quantize to or else we can't encode 0
+	const int cHalfMaxValue = int(cMaxValue >> 1);
 	const float cScale = 2.0f * cOneOverSqrt2 / float(cMaxValue);
 
 	// Restore two components
-	float2 v2 = float2(float(inValue & cMask), float((inValue >> cNumBits) & cMask)) * cScale - float2(cOneOverSqrt2, cOneOverSqrt2);
+	float2 v2 = float2(float(int(inValue & cMask) - cHalfMaxValue), float(int((inValue >> cNumBits) & cMask) - cHalfMaxValue)) * cScale;
 
 	// Restore the highest component
 	float3 v = float3(v2, sqrt(max(1.0f - dot(v2, v2), 0.0f)));

--- a/TestFramework/UI/UIManager.cpp
+++ b/TestFramework/UI/UIManager.cpp
@@ -267,6 +267,7 @@ void UIManager::DrawQuad(int inX, int inY, int inWidth, int inHeight, const UITe
 	{
 		// UV calculations below can generate exceptions
 		FPExceptionDisableInvalid disable_invalid;
+		JPH_UNUSED(disable_invalid);
 
 		bool has_inner = inQuad.HasInnerPart();
 

--- a/TestFramework/UI/UIManager.cpp
+++ b/TestFramework/UI/UIManager.cpp
@@ -7,6 +7,7 @@
 #include <UI/UIManager.h>
 #include <UI/UIAnimationSlide.h>
 #include <Jolt/Core/Profiler.h>
+#include <Jolt/Core/FPException.h>
 #include <Renderer/Renderer.h>
 #include <Renderer/Font.h>
 
@@ -264,6 +265,9 @@ void UIManager::DrawQuad(int inX, int inY, int inWidth, int inHeight, const UITe
 
 	if (inQuad.mTexture != nullptr)
 	{
+		// UV calculations below can generate exceptions
+		FPExceptionDisableInvalid disable_invalid;
+
 		bool has_inner = inQuad.HasInnerPart();
 
 		Ref<RenderPrimitive> primitive = mRenderer->CreateRenderPrimitive(PipelineState::ETopology::Triangle);


### PR DESCRIPTION
* The compiler started using FMA for vector decompression which caused a small rounding error
* The compiler started vectorizing UV coordinate calculations which caused floating point exceptions