### PR TITLE
Adding options to Linux CMake build script

### DIFF
--- a/Build/cmake_linux_clang_gcc.sh
+++ b/Build/cmake_linux_clang_gcc.sh
@@ -1,28 +1,79 @@
 #!/bin/sh
 
-if [ -z $1 ]
-then
-	BUILD_TYPE=Debug
-else
-	BUILD_TYPE=$1
-	shift
+BUILD_TYPE=""
+COMPILER=""
+SHARED_LIB=false
+POSTFIX_DEBUG=false
+ENV_SCRIPT=""
+CMAKE_EXTRA_ARGS=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --shared)
+      SHARED_LIB=true
+      ;;
+    --postfix-debug)
+      POSTFIX_DEBUG=true
+      ;;
+    --env-script=*)
+      ENV_SCRIPT="${arg#*=}"
+      ;;
+    *)
+      if [ -z "$BUILD_TYPE" ]; then
+        BUILD_TYPE="$arg"
+      elif [ -z "$COMPILER" ]; then
+        COMPILER="$arg"
+      else
+        CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $arg"
+      fi
+      ;;
+  esac
+done
+
+if [ -z "$BUILD_TYPE" ]; then
+  echo "No build type argument, using default BUILD_TYPE=Debug"
+  BUILD_TYPE="Debug"
+fi
+if [ -z "$COMPILER" ]; then
+  echo "No compiler argument, using default COMPILER=clang++"
+  COMPILER="clang++"
 fi
 
-if [ -z $1 ]
-then
-	COMPILER=clang++
-else
-	COMPILER=$1
-	shift
+echo ""
+echo "Usage: ./cmake_linux_clang_gcc.sh [BUILD_TYPE] [COMPILER] [--shared] [--postfix-debug] [--env-script=...]"
+echo "Build type options: Debug, Release, Distribution, ReleaseUBSAN, ReleaseASAN, ReleaseTSAN, ReleaseCoverage"
+echo "Compiler options: clang++, clang++-XX, g++, g++-XX where XX is the version"
+echo ""
+
+if [ -n "$ENV_SCRIPT" ]; then
+  . "$ENV_SCRIPT"
 fi
 
 BUILD_DIR=Linux_$BUILD_TYPE
+POSTFIX_ARG=""
+SHARED_ARG=""
+if [ "$BUILD_TYPE" = "Debug" ] && [ "$POSTFIX_DEBUG" = true ]; then
+  POSTFIX_ARG="-DCMAKE_DEBUG_POSTFIX=-d"
+fi
+if [ "$SHARED_LIB" = true ]; then
+  BUILD_DIR=${BUILD_DIR}_shared
+  SHARED_ARG="-DBUILD_SHARED_LIBS=ON"
+fi
+if [ -n "$POSTFIX_ARG" ]; then
+  CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $POSTFIX_ARG"
+fi
+if [ -n "$SHARED_ARG" ]; then
+  CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $SHARED_ARG"
+fi
 
-echo Usage: ./cmake_linux_clang_gcc.sh [Configuration] [Compiler]
-echo "Possible configurations: Debug (default), Release, Distribution, ReleaseUBSAN, ReleaseASAN, ReleaseTSAN, ReleaseCoverage"
-echo "Possible compilers: clang++, clang++-XX, g++, g++-XX where XX is the version"
 echo Generating Makefile for build type \"$BUILD_TYPE\" and compiler \"$COMPILER\" in folder \"$BUILD_DIR\"
+cmake -S . -B $BUILD_DIR -G "Unix Makefiles" \
+  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DCMAKE_CXX_COMPILER=$COMPILER \
+  $CMAKE_EXTRA_ARGS
 
-cmake -S . -B $BUILD_DIR -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=$COMPILER "${@}"
-
-echo Compile by running \"make -j $(nproc) \&\& ./UnitTests\" in folder \"$BUILD_DIR\"
+echo ""
+echo Compile by running:
+echo "cd ${BUILD_DIR} && make -j$(nproc)"
+echo Run tests: ./UnitTests
+echo ""

--- a/Build/cmake_linux_clang_gcc.sh
+++ b/Build/cmake_linux_clang_gcc.sh
@@ -5,27 +5,30 @@ COMPILER=""
 SHARED_LIB=false
 POSTFIX_DEBUG=false
 ENV_SCRIPT=""
-CMAKE_EXTRA_ARGS=""
 
-for arg in "$@"; do
-  case "$arg" in
+while [ $# -gt 0 ]; do
+  case "$1" in
     --shared)
       SHARED_LIB=true
+      shift
       ;;
     --postfix-debug)
       POSTFIX_DEBUG=true
+      shift
       ;;
     --env-script=*)
-      ENV_SCRIPT="${arg#*=}"
+      ENV_SCRIPT="${1#*=}"
+      shift
       ;;
     *)
       if [ -z "$BUILD_TYPE" ]; then
-        BUILD_TYPE="$arg"
+        BUILD_TYPE="$1"
       elif [ -z "$COMPILER" ]; then
-        COMPILER="$arg"
+        COMPILER="$1"
       else
-        CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $arg"
+        break
       fi
+      shift
       ;;
   esac
 done
@@ -59,21 +62,15 @@ if [ "$SHARED_LIB" = true ]; then
   BUILD_DIR=${BUILD_DIR}_shared
   SHARED_ARG="-DBUILD_SHARED_LIBS=ON"
 fi
-if [ -n "$POSTFIX_ARG" ]; then
-  CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $POSTFIX_ARG"
-fi
-if [ -n "$SHARED_ARG" ]; then
-  CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS $SHARED_ARG"
-fi
 
 echo Generating Makefile for build type \"$BUILD_TYPE\" and compiler \"$COMPILER\" in folder \"$BUILD_DIR\"
 cmake -S . -B $BUILD_DIR -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_CXX_COMPILER=$COMPILER \
-  $CMAKE_EXTRA_ARGS
+  "$@" $POSTFIX_ARG $SHARED_ARG
 
-echo ""
-echo Compile by running:
-echo "cd ${BUILD_DIR} && make -j$(nproc)"
-echo Run tests: ./UnitTests
-echo ""
+  echo ""
+  echo Compile by running:
+  echo "cd ${BUILD_DIR} && make -j$(nproc)"
+  echo Run tests: ./UnitTests
+  echo ""


### PR DESCRIPTION
Hey.
I added JoltPhysics to the Magnum Graphics Engine, I'm making adjustment for Linux systems: [Adding Jolt Physics integration as JoltIntegration #121](https://github.com/mosra/magnum-integration/pull/121)

So I added some options so I can package both Release and Debug artifacts, for example as RPM, along with a shared library. That also aligned some of the conversions Magnum has and make sense. The default behavior of the script is kept. You can just run without parameters, defaults would be used, and no additional options are required.

Additional script options:
* Adding `--shared` to build `.so` instead
* Adding `--postfix-debug` to append `-d` to artifacts
* Adding `--env-script` to source a script before running build

I will gladly later add an RPM package spec for Fedora and RHEL systems using these options.

The Vulkan environment script was required for `dxc` on my Fedora system. There are some "unofficial" packages but the easiest way to get the compiler is actually just download whatever Vulkan SDK you want.