### PR TITLE
Fixed VS2026 unit test failure

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -608,6 +608,28 @@ static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
 // Macro to indicate that a parameter / variable is unused
 #define JPH_UNUSED(x)			(void)x
 
+// Macro to enable floating point precise mode
+#if defined(JPH_COMPILER_CLANG)
+	#define JPH_PRECISE_MATH_ON										\
+		_Pragma("clang diagnostic push")							\
+		_Pragma("clang diagnostic ignored \"-Wignored-pragmas\"")	\
+		_Pragma("float_control(precise, on, push)")					\
+		_Pragma("clang diagnostic pop")
+	#define JPH_PRECISE_MATH_OFF									\
+		_Pragma("clang diagnostic push")							\
+		_Pragma("clang diagnostic ignored \"-Wignored-pragmas\"")	\
+		_Pragma("float_control(pop)")								\
+		_Pragma("clang diagnostic pop")
+#elif defined(JPH_COMPILER_MSVC)
+	#define JPH_PRECISE_MATH_ON										\
+		__pragma(float_control(precise, on, push))
+	#define JPH_PRECISE_MATH_OFF									\
+		__pragma(float_control(pop))
+#else
+	#define JPH_PRECISE_MATH_ON
+	#define JPH_PRECISE_MATH_OFF
+#endif
+
 // Check if Thread Sanitizer is enabled
 #ifdef __has_feature
 	#if __has_feature(thread_sanitizer)

--- a/Jolt/Geometry/EPAConvexHullBuilder.h
+++ b/Jolt/Geometry/EPAConvexHullBuilder.h
@@ -707,6 +707,8 @@ private:
 #endif
 };
 
+JPH_PRECISE_MATH_ON
+
 EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, const Vec3 *inPositions)
 {
 	// Fill in indexes
@@ -835,5 +837,7 @@ EPAConvexHullBuilder::Triangle::Triangle(int inIdx0, int inIdx1, int inIdx2, con
 		}
 	}
 }
+
+JPH_PRECISE_MATH_OFF
 
 JPH_NAMESPACE_END

--- a/UnitTests/Geometry/PlaneTests.cpp
+++ b/UnitTests/Geometry/PlaneTests.cpp
@@ -25,7 +25,7 @@ TEST_SUITE("PlaneTests")
 		Plane p2 = Plane::sFromPointAndNormal(transform * point, transform.Multiply3x3(normal));
 
 		CHECK_APPROX_EQUAL(p1.GetNormal(), p2.GetNormal());
-		CHECK_APPROX_EQUAL(p1.GetConstant(), p2.GetConstant());
+		CHECK_APPROX_EQUAL(p1.GetConstant(), p2.GetConstant(), 2.0e-6f);
 	}
 
 	TEST_CASE("TestPlaneIntersectPlanes")


### PR DESCRIPTION
MSVC 18.6.0 introduced much more aggressive floating point optimizations so /fp:fast needed to be turned off for one function again.