### PR TITLE
Fix EPA contact point for mesh triangles with long edges

### DIFF
--- a/Jolt/Physics/Collision/CollideConvexVsTriangles.cpp
+++ b/Jolt/Physics/Collision/CollideConvexVsTriangles.cpp
@@ -12,6 +12,7 @@
 #include <Jolt/Physics/Collision/NarrowPhaseStats.h>
 #include <Jolt/Geometry/EPAPenetrationDepth.h>
 #include <Jolt/Geometry/Plane.h>
+#include <Jolt/Geometry/ClosestPoint.h>
 
 JPH_NAMESPACE_BEGIN
 
@@ -83,7 +84,24 @@ void CollideConvexVsTriangles::Collide(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2,
 	// Check result of collision detection
 	if (status == EPAPenetrationDepth::EStatus::NotColliding)
 		return;
-	else if (status == EPAPenetrationDepth::EStatus::Indeterminate)
+
+	// Mesh triangles with edges much longer than the query shape cause float32 cancellation in
+	// the simplex cross products, so GJK/EPA can report witness points that are implausibly far
+	// apart. A real contact keeps point1 and point2 within the query shape's own size; use the
+	// squared bounding-box diagonal as the largest plausible witness separation.
+	Vec3 bounds_size = mBoundsOf1.mMax - mBoundsOf1.mMin;
+	float max_contact_dist_sq = bounds_size.LengthSq();
+
+	// GJK Colliding can return point1 outside the shape bounds, or point2 blown to a far triangle
+	// vertex while point1 looks plausible
+	if (status == EPAPenetrationDepth::EStatus::Colliding)
+	{
+		AABox expanded_bounds(mBoundsOf1.mMin - bounds_size, mBoundsOf1.mMax + bounds_size);
+		if (!expanded_bounds.Contains(point1) || (point2 - point1).LengthSq() > max_contact_dist_sq)
+			status = EPAPenetrationDepth::EStatus::Indeterminate;
+	}
+
+	if (status == EPAPenetrationDepth::EStatus::Indeterminate)
 	{
 		// Need to run expensive EPA algorithm
 
@@ -103,6 +121,20 @@ void CollideConvexVsTriangles::Collide(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2,
 		// Perform EPA step
 		if (!pen_depth.GetPenetrationDepthStepEPA(shape1_add_max_separation_distance, triangle, mCollideShapeSettings.mPenetrationTolerance, penetration_axis, point1, point2))
 			return;
+
+		// EPA can converge to the wrong facet and report the witnesses far apart. Snap point2 to
+		// the closest point on the triangle; if they are still further apart than the shape, point1
+		// is unreliable too, so discard rather than feed a bogus deep penetration downstream.
+		if ((point2 - point1).LengthSq() > max_contact_dist_sq)
+		{
+			uint32 set;
+			point2 = ClosestPoint::GetClosestPointOnTriangle(v0 - point1, v1 - point1, v2 - point1, set) + point1;
+
+			// The snapped point2 no longer matches EPA's axis; recompute it A->B and re-check.
+			penetration_axis = point2 - point1;
+			if (penetration_axis.LengthSq() > max_contact_dist_sq) // both points unfixable, skip contact
+				return;
+		}
 	}
 
 	// Check if the penetration is bigger than the early out fraction

--- a/UnitTests/Physics/ConvexVsTrianglesTest.cpp
+++ b/UnitTests/Physics/ConvexVsTrianglesTest.cpp
@@ -5,6 +5,7 @@
 #include "UnitTestFramework.h"
 #include "PhysicsTestContext.h"
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
 #include <Jolt/Physics/Collision/Shape/TriangleShape.h>
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/Collision/CollideShape.h>
@@ -358,4 +359,58 @@ TEST_SUITE("ConvexVsTrianglesTest")
 	{
 		sTestConvexVsTriangles<CollideSphereVsTriangles>();
 	}
+
+	// Regression test for EPA producing a degenerate contact when the mesh triangle has
+	// a very long edge relative to the query shape.  In production a ~200 m needle triangle
+	// against a 0.25 m capsule caused EPA to converge to the wrong Minkowski polytope facet
+	// (float32 precision loss in cross products of 200 m vectors) and report point2 ~100 m
+	// from point1, failing a downstream sanity assert.
+	TEST_CASE("TestCapsuleVsNeedleTriangle")
+	{
+		// CapsuleShape from the crash dump: halfHeight=0.5, radius=0.25.
+		Ref<CapsuleShape> capsule = new CapsuleShape(0.5f, 0.25f);
+
+		Mat44 transform1 = Mat44::sIdentity();
+		Mat44 transform2 = Mat44::sIdentity();
+
+		Vec3 inV0(0.252283931f, -172.936920f, -0.093847394f);
+		Vec3 inV1(0.242991686f,   27.608593f, -0.127187848f);
+		Vec3 inV2(0.228017807f,   27.608591f, -0.140446782f);
+
+		CollideShapeSettings settings;
+		settings.mBackFaceMode          = EBackFaceMode::IgnoreBackFaces;
+		settings.mActiveEdgeMode        = EActiveEdgeMode::CollideOnlyWithActive;
+		settings.mCollisionTolerance    = 1.0e-4f;
+		settings.mPenetrationTolerance  = 1.0e-4f;
+		settings.mMaxSeparationDistance = 0.05f;
+
+		AllHitCollisionCollector<CollideShapeCollector> collector;
+		CollideConvexVsTriangles collider(capsule, Vec3::sOne(), Vec3::sOne(),
+			transform1, transform2,
+			SubShapeID(), settings, collector);
+		collider.Collide(inV0, inV1, inV2, 0b011, SubShapeID());
+
+		CHECK(collector.mHits.size() == 1);
+		if (collector.mHits.empty()) return;
+		const CollideShapeResult &hit = collector.mHits[0];
+
+		// Without the fix, EPA snaps point2 to a far triangle vertex ~100 m from point1,
+		// giving mPenetrationDepth ~ -100 m.  With the fix the contact must lie within
+		// the capsule's own size (radius 0.25 + halfHeight 0.5 = 0.75 m; 2x as margin).
+		float capsule_max_extent = 2.0f * (0.5f + 0.25f); // 1.5 m
+		CHECK(hit.mPenetrationDepth > -capsule_max_extent);
+		CHECK(hit.mPenetrationDepth < capsule_max_extent);
+
+		// point2 must be close to point1, not 100 m away.
+		float dist = (hit.mContactPointOn2 - hit.mContactPointOn1).Length();
+		CHECK(dist < capsule_max_extent);
+
+		// The penetration axis must point from the capsule towards the triangle, i.e.
+		// against the triangle's (v1-v0)x(v2-v0) normal (the capsule center sits on the
+		// positive-normal side of the triangle plane).  Guards the contact normal that
+		// feeds collision response from coming out backwards.
+		Vec3 triangle_normal = (inV1 - inV0).Cross(inV2 - inV0);
+		CHECK(hit.mPenetrationAxis.Dot(triangle_normal) < 0.0f);
+	}
+
 }


### PR DESCRIPTION
When a convex shape collides with a mesh triangle whose edge length is much larger than the penetration depth (e.g. ~84m edge vs ~5cm penetration, a ~1700:1 ratio), EPA converges to the wrong Minkowski polytope facet due to float32 precision loss. GetPenetrationDepthStepEPA returns true but point2 can be tens of meters outside the triangle, producing degenerate contact data.

The fix runs after GetPenetrationDepthStepEPA in CollideConvexVsTriangles::Collide. A valid point2 lies on the triangle and must be inside its axis-aligned bounding box — this is the fast-path check (six float compares, no cost in the normal case). If point2 is outside the bbox, we compute the actual closest point on the triangle to point1 and, if point2 is farther from it than the query shape's AABB diagonal, snap point2 there and update penetration_axis. The two-level structure ensures correctness: any epsilon-outside false positives from the bbox check are caught by the distance threshold and produce no correction.

This is reproducible with open-world game levels where large floor/wall tiles are used directly as physics mesh geometry. Subdividing such meshes is not always viable - the BVH codec has a hard size limit that is exceeded when large terrain meshes are split to a safe edge length.

Actual data that caused assert on bad contact point produced:
Level geometry mesh vertices: (-75.6, 15.0, 320.2), (-112.7, 15.0, 245.4), (-104.2, 15.0, 262.5) - longest edge 83.5m, flat floor tile
Vehicle position: approximately (-90, 15.05, 300) - 5cm above the triangle plane
Actual penetration depth: ~5cm, scale ratio ~1700:1
EPA reported point2 = (-70.21, 15.0, 330.99) - 84m outside the triangle
Resulting contact: point1 = (-88.4, 15.05, 298.7), point2 = (-54.6, 15.0, 332.5), distance 34m, penetration depth -33.85m