### PR TITLE
Draft: Support deterministic body IDs when restoring state

### DIFF
--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -9,6 +9,7 @@
 #include <Jolt/Physics/Body/BodyCreationSettings.h>
 #include <Jolt/Physics/Body/BodyLock.h>
 #include <Jolt/Physics/Body/BodyActivationListener.h>
+#include <Jolt/Physics/Collision/BroadPhase/BroadPhase.h>
 #include <Jolt/Physics/SoftBody/SoftBodyMotionProperties.h>
 #include <Jolt/Physics/SoftBody/SoftBodyCreationSettings.h>
 #include <Jolt/Physics/SoftBody/SoftBodyShape.h>
@@ -360,6 +361,45 @@ Body *BodyManager::RemoveBodyInternal(const BodyID &inBodyID)
 	return body;
 }
 
+void BodyManager::RestoreFreeList(const Array<uint32> &inSavedFreeList)
+{
+	LockAllBodies();
+
+	// Grow body slots if needed upfront
+	if (!inSavedFreeList.empty())
+	{
+		uint32 max_saved_slot = 0;
+		for (uint32 slot : inSavedFreeList)
+			max_saved_slot = max(max_saved_slot, slot);
+
+		if (max_saved_slot >= (uint32)mBodies.size())
+			mBodies.resize(max_saved_slot + 1, (Body *)cBodyIDFreeListEnd);
+	}
+
+	Array<uint8> in_saved((uint32)mBodies.size(), uint8(0));
+	for (uint32 slot : inSavedFreeList)
+		in_saved[slot] = 1;
+
+	// Put free slots that weren't saved at the end so they don't affect saved slot order
+	uintptr_t next = cBodyIDFreeListEnd;
+	for (uint32 i = (uint32)mBodies.size(); i-- > 0; )
+		if ((uintptr_t(mBodies[i]) & cIsFreedBody) != 0 && !in_saved[i])
+		{
+			mBodies[i] = (Body *)next;
+			next = (uintptr_t(i) << cFreedBodyIndexShift) | cIsFreedBody;
+		}
+	for (int j = (int)inSavedFreeList.size() - 1; j >= 0; --j)
+	{
+		uint32 slot = inSavedFreeList[j];
+		JPH_ASSERT((uintptr_t(mBodies[slot]) & cIsFreedBody) != 0, "Saved free slot is occupied, was a body not destroyed?");
+		mBodies[slot] = (Body *)next;
+		next = (uintptr_t(slot) << cFreedBodyIndexShift) | cIsFreedBody;
+	}
+	mBodyIDFreeListStart = next;
+
+	UnlockAllBodies();
+}
+
 #if defined(JPH_DEBUG) && defined(JPH_ENABLE_ASSERTS)
 
 void BodyManager::ValidateFreeList() const
@@ -701,8 +741,10 @@ void BodyManager::UnlockAllBodies() const
 	mBodyMutexes.UnlockAll();
 }
 
-void BodyManager::SaveState(StateRecorder &inStream, const StateRecorderFilter *inFilter) const
+void BodyManager::SaveState(StateRecorder &inStream, const StateRecorderFilter *inFilter, bool inSaveIdSequences) const
 {
+	JPH_ASSERT(!inSaveIdSequences || inFilter == nullptr, "Filtered bodies cannot be represented in the state, so id sequences cannot be restored deterministically");
+
 	{
 		LockAllBodies();
 
@@ -723,13 +765,47 @@ void BodyManager::SaveState(StateRecorder &inStream, const StateRecorderFilter *
 			b->SaveState(inStream);
 		}
 
+		if (inSaveIdSequences)
+		{
+			// Write sequence numbers for body slots not currently in the broad phase so we can fully restore the slot counters
+			// since they may not be used by bodies anymore but we still want to make sure the the next counter allocation is correct
+			uint32 num_entries = 0;
+			for (uint32 i = 0, n = (uint32)mBodies.size(); i < n; ++i)
+			{
+				const Body *b = mBodies[i];
+				if ((!sIsValidBodyPointer(b) || !b->IsInBroadPhase()) && mBodySequenceNumbers[i] != 0)
+					++num_entries;
+			}
+			inStream.Write(num_entries);
+			for (uint32 i = 0, n = (uint32)mBodies.size(); i < n; ++i)
+			{
+				const Body *b = mBodies[i];
+				if ((!sIsValidBodyPointer(b) || !b->IsInBroadPhase()) && mBodySequenceNumbers[i] != 0)
+				{
+					inStream.Write(i);
+					inStream.Write(mBodySequenceNumbers[i]);
+				}
+			}
+
+			// Write the free list order so we can rebuild it (see: RestoreFreeList)
+			uint32 num_free_slots = 0;
+			for (uintptr_t ptr = mBodyIDFreeListStart; ptr != cBodyIDFreeListEnd; ptr = uintptr_t(mBodies[ptr >> cFreedBodyIndexShift]))
+				++num_free_slots;
+			inStream.Write(num_free_slots);
+			for (uintptr_t ptr = mBodyIDFreeListStart; ptr != cBodyIDFreeListEnd; ptr = uintptr_t(mBodies[ptr >> cFreedBodyIndexShift]))
+				inStream.Write(uint32(ptr >> cFreedBodyIndexShift));
+		}
+
 		UnlockAllBodies();
 	}
 }
 
-bool BodyManager::RestoreState(StateRecorder &inStream)
+bool BodyManager::RestoreState(StateRecorder &inStream, BroadPhase *ioBroadPhase, bool inRestoreIdSequences, bool inDestroyBodiesNotInState)
 {
-	BodyIDVector bodies_to_activate, bodies_to_deactivate;
+	JPH_ASSERT(ioBroadPhase != nullptr || (!inRestoreIdSequences && !inDestroyBodiesNotInState), "Broad phase is required to correct body IDs and destroy bodies");
+
+	BodyIDVector bodies_to_activate, bodies_to_deactivate, bodies_to_destroy, ids_changed;
+	Array<uint32> saved_free_list;
 
 	{
 		LockAllBodies();
@@ -772,6 +848,28 @@ bool BodyManager::RestoreState(StateRecorder &inStream)
 					}
 					b->RestoreState(inStream);
 				}
+
+			// Consume the sequence number and free list sections, just walk past it
+			if (inRestoreIdSequences)
+			{
+				uint32 num_entries = 0;
+				inStream.Read(num_entries);
+				for (uint32 i = 0; i < num_entries; ++i)
+				{
+					uint32 idx;
+					inStream.Read(idx);
+					uint8 seq;
+					inStream.Read(seq);
+				}
+
+				uint32 num_free_slots = 0;
+				inStream.Read(num_free_slots);
+				for (uint32 i = 0; i < num_free_slots; ++i)
+				{
+					uint32 slot;
+					inStream.Read(slot);
+				}
+			}
 		}
 		else
 		{
@@ -779,28 +877,112 @@ bool BodyManager::RestoreState(StateRecorder &inStream)
 			uint32 num_bodies = 0;
 			inStream.Read(num_bodies);
 
+			// Reset all sequence numbers
+			// slots present in the state are restored below whether recorded directly or in recorded ids
+			// slots created after the snapshot correctly start over at 0
+			if (inRestoreIdSequences)
+				std::fill(mBodySequenceNumbers.begin(), mBodySequenceNumbers.end(), uint8(0));
+
+			uint32 slot = 0;
+			uint32 num_slots = (uint32)mBodies.size();
+
 			// Iterate over the stored bodies and restore their state
-			for (uint32 idx = 0; idx < num_bodies; ++idx)
+			// while also collecting bodies that are not present in the state
+			for (uint32 stream_idx = 0; stream_idx < num_bodies; ++stream_idx)
 			{
-				BodyID body_id;
-				inStream.Read(body_id);
-				Body *b = TryGetBody(body_id);
-				if (b == nullptr)
+				BodyID stream_id;
+				inStream.Read(stream_id);
+
+				// Walk slots until we get to the one that should be holding this body
+				// Any body we pass on the way is not present in the state and is collected for destruction if that is enabled
+				while (slot < num_slots)
+				{
+					Body *b = mBodies[slot];
+					if (!sIsValidBodyPointer(b))
+					{
+						++slot;
+						continue;
+					}
+					if (b->IsInBroadPhase() && b->GetID().GetIndex() >= stream_id.GetIndex())
+						break;
+					if (inDestroyBodiesNotInState)
+						bodies_to_destroy.push_back(b->GetID());
+					++slot;
+				}
+
+				Body *b = slot < num_slots ? mBodies[slot] : nullptr;
+				if (b == nullptr || !sIsValidBodyPointer(b) || b->GetID().GetIndex() != stream_id.GetIndex())
 				{
 					JPH_ASSERT(false, "Restoring state for non-existing body");
 					UnlockAllBodies();
 					return false;
 				}
+
+				// we can't change the id of a body that is registered in the broad phase we reregister it under its restored id after the walk
+				if (inRestoreIdSequences)
+				{
+					mBodySequenceNumbers[slot] = stream_id.GetSequenceNumber();
+					if (b->mID != stream_id)
+						ids_changed.push_back(b->mID);
+				}
+				else if (b->mID != stream_id)
+				{
+					JPH_ASSERT(false, "Body sequence number mismatch");
+					UnlockAllBodies();
+					return false;
+				}
+
 				bool is_active;
 				inStream.Read(is_active);
 				if (is_active != b->IsActive())
 				{
+					// use the current id for now,  correct it later
 					if (is_active)
-						bodies_to_activate.push_back(body_id);
+						bodies_to_activate.push_back(b->mID);
 					else
-						bodies_to_deactivate.push_back(body_id);
+						bodies_to_deactivate.push_back(b->mID);
 				}
 				b->RestoreState(inStream);
+				++slot;
+			}
+
+			// All remaining bodies are not present in the state
+			if (inDestroyBodiesNotInState)
+				while (slot < num_slots)
+				{
+					Body *b = mBodies[slot];
+					if (sIsValidBodyPointer(b))
+						bodies_to_destroy.push_back(b->GetID());
+					++slot;
+				}
+
+			// Restore sequence numbers for body slots that were not in the broad phase at save time
+			if (inRestoreIdSequences)
+			{
+				uint32 num_entries = 0;
+				inStream.Read(num_entries);
+				for (uint32 i = 0; i < num_entries; ++i)
+				{
+					uint32 idx;
+					inStream.Read(idx);
+					uint8 seq;
+					inStream.Read(seq);
+					if (idx < (uint32)mBodySequenceNumbers.size())
+						mBodySequenceNumbers[idx] = seq;
+				}
+
+				// Read the free list but apply later once the bodies not in the state have been destroyed so we can free those slots potentially
+				uint32 num_free_slots = 0;
+				inStream.Read(num_free_slots);
+				if (inDestroyBodiesNotInState)
+					saved_free_list.reserve(num_free_slots);
+				for (uint32 i = 0; i < num_free_slots; ++i)
+				{
+					uint32 free_slot;
+					inStream.Read(free_slot);
+					if (inDestroyBodiesNotInState)
+						saved_free_list.push_back(free_slot);
+				}
 			}
 		}
 
@@ -822,6 +1004,48 @@ bool BodyManager::RestoreState(StateRecorder &inStream)
 			RemoveBodyFromActiveBodies(*body);
 		}
 	}
+
+	// Finally... reregister bodies who have ids that drifted from the saved value
+	// The broad phase and the active body list track bodies by id, so remove the body under its old id, change it, then readd.
+	if (!ids_changed.empty())
+	{
+		ioBroadPhase->RemoveBodies(ids_changed.data(), (int)ids_changed.size());
+		{
+			UniqueLock lock(mActiveBodiesMutex JPH_IF_ENABLE_ASSERTS(, this, EPhysicsLockTypes::ActiveBodiesList));
+			for (BodyID &id : ids_changed)
+			{
+				Body *b = mBodies[id.GetIndex()];
+				bool active = b->IsActive();
+				if (active)
+					RemoveBodyFromActiveBodies(*b);
+				b->mID = id = BodyID(id.GetIndex(), mBodySequenceNumbers[id.GetIndex()]); // The restored sequence number was stored during the walk above
+				if (active)
+					AddBodyToActiveBodies(*b);
+			}
+		}
+		BroadPhase::AddState add_state = ioBroadPhase->AddBodiesPrepare(ids_changed.data(), (int)ids_changed.size());
+		ioBroadPhase->AddBodiesFinalize(ids_changed.data(), (int)ids_changed.size(), add_state);
+	}
+
+	// Destroy bodies that are not present in the state
+	if (!bodies_to_destroy.empty())
+	{
+		// Move bodies that are in the broad phase to the front, they need to be deactivated and removed from the broad phase before they can be destroyed
+		int num_in_broad_phase = 0;
+		for (int i = 0; i < (int)bodies_to_destroy.size(); ++i)
+			if (GetBody(bodies_to_destroy[i]).IsInBroadPhase())
+				std::swap(bodies_to_destroy[num_in_broad_phase++], bodies_to_destroy[i]);
+		if (num_in_broad_phase > 0)
+		{
+			DeactivateBodies(bodies_to_destroy.data(), num_in_broad_phase);
+			ioBroadPhase->RemoveBodies(bodies_to_destroy.data(), num_in_broad_phase);
+		}
+		DestroyBodies(bodies_to_destroy.data(), (int)bodies_to_destroy.size());
+	}
+
+	// Rebuild the free list in saved order so future body creation produces the same ids
+	if (inRestoreIdSequences && inDestroyBodiesNotInState)
+		RestoreFreeList(saved_free_list);
 
 	return true;
 }

--- a/Jolt/Physics/Body/BodyManager.h
+++ b/Jolt/Physics/Body/BodyManager.h
@@ -15,6 +15,7 @@ class BodyCreationSettings;
 class SoftBodyCreationSettings;
 class BodyActivationListener;
 class StateRecorderFilter;
+class BroadPhase;
 struct PhysicsSettings;
 #ifdef JPH_DEBUG_RENDERER
 class DebugRenderer;
@@ -206,11 +207,15 @@ public:
 	/// Return the BroadPhaseLayerInterface that this class has been initialized with
 	const BroadPhaseLayerInterface &GetBroadPhaseLayerInterface() const			{ return *mBroadPhaseLayerInterface; }
 
-	/// Saving state for replay
-	void							SaveState(StateRecorder &inStream, const StateRecorderFilter *inFilter) const;
+	/// Saving state for replay.
+	/// If inSaveIdSequences is true, also writes the body id sequence numbers and free list (see EStateRecorderState::IdSequences).
+	void							SaveState(StateRecorder &inStream, const StateRecorderFilter *inFilter, bool inSaveIdSequences = false) const;
 
 	/// Restoring state for replay. Returns false if failed.
-	bool							RestoreState(StateRecorder &inStream);
+	/// If inRestoreIdSequences is true, restores the body id sequence numbers and free list so that bodies created after the restore get the same ids they got originally
+	/// If inDestroyBodiesNotInState is true, bodies not present in the state are destroyed.
+	/// ioBroadPhase is required when either flag is set.
+	bool							RestoreState(StateRecorder &inStream, BroadPhase *ioBroadPhase = nullptr, bool inRestoreIdSequences = false, bool inDestroyBodiesNotInState = false);
 
 	/// Save the state of a single body for replay
 	void							SaveBodyState(const Body &inBody, StateRecorder &inStream) const;
@@ -330,6 +335,9 @@ private:
 
 	/// Helper function to delete a body (which could actually be a BodyWithMotionProperties)
 	inline static void				sDeleteBody(Body *inBody);
+
+	/// Rebuild the body id free list so that the slots in inSavedFreeList come first (in that order), followed by any other free slots
+	void							RestoreFreeList(const Array<uint32> &inSavedFreeList);
 
 #if defined(JPH_DEBUG) && defined(JPH_ENABLE_ASSERTS)
 	/// Function to check that the free list is not corrupted

--- a/Jolt/Physics/PhysicsSystem.cpp
+++ b/Jolt/Physics/PhysicsSystem.cpp
@@ -2907,9 +2907,10 @@ void PhysicsSystem::SaveState(StateRecorder &inStream, EStateRecorderState inSta
 		inStream.Write(mPreviousStepDeltaTime);
 		inStream.Write(mGravity);
 	}
-
+	
+	JPH_ASSERT(!(uint8(inState) & uint8(EStateRecorderState::IdSequences)) || (uint8(inState) & uint8(EStateRecorderState::Bodies)), "IdSequences must be combined with Bodies");
 	if (uint8(inState) & uint8(EStateRecorderState::Bodies))
-		mBodyManager.SaveState(inStream, inFilter);
+		mBodyManager.SaveState(inStream, inFilter, uint8(inState) & uint8(EStateRecorderState::IdSequences));
 
 	if (uint8(inState) & uint8(EStateRecorderState::Contacts))
 		mContactManager.SaveState(inStream, inFilter);
@@ -2918,7 +2919,7 @@ void PhysicsSystem::SaveState(StateRecorder &inStream, EStateRecorderState inSta
 		mConstraintManager.SaveState(inStream, inFilter);
 }
 
-bool PhysicsSystem::RestoreState(StateRecorder &inStream, const StateRecorderFilter *inFilter)
+bool PhysicsSystem::RestoreState(StateRecorder &inStream, const StateRecorderFilter *inFilter, bool inDestroyBodiesNotInState)
 {
 	JPH_PROFILE_FUNCTION();
 
@@ -2933,7 +2934,7 @@ bool PhysicsSystem::RestoreState(StateRecorder &inStream, const StateRecorderFil
 
 	if (uint8(state) & uint8(EStateRecorderState::Bodies))
 	{
-		if (!mBodyManager.RestoreState(inStream))
+		if (!mBodyManager.RestoreState(inStream, mBroadPhase, uint8(state) & uint8(EStateRecorderState::IdSequences), inDestroyBodiesNotInState))
 			return false;
 
 		// Update bounding boxes for all bodies in the broadphase

--- a/Jolt/Physics/PhysicsSystem.h
+++ b/Jolt/Physics/PhysicsSystem.h
@@ -165,7 +165,9 @@ public:
 	void						SaveState(StateRecorder &inStream, EStateRecorderState inState = EStateRecorderState::All, const StateRecorderFilter *inFilter = nullptr) const;
 
 	/// Restoring state for replay. Returns false if failed.
-	bool						RestoreState(StateRecorder &inStream, const StateRecorderFilter *inFilter = nullptr);
+	/// If inDestroyBodiesNotInState is true, any body currently in the broad phase but absent from
+	/// the state will be removed from the broad phase and destroyed.
+	bool						RestoreState(StateRecorder &inStream, const StateRecorderFilter *inFilter = nullptr, bool inDestroyBodiesNotInState = false);
 
 	/// Saving state of a single body.
 	void						SaveBodyState(const Body &inBody, StateRecorder &inStream) const;

--- a/Jolt/Physics/StateRecorder.h
+++ b/Jolt/Physics/StateRecorder.h
@@ -19,12 +19,14 @@ JPH_GCC_SUPPRESS_WARNING("-Wshadow") // GCC complains about the 'Constraints' va
 /// A bit field that determines which aspects of the simulation to save
 enum class EStateRecorderState : uint8
 {
-	None				= 0,														///< Save nothing
-	Global				= 1,														///< Save global physics system state (delta time, gravity, etc.)
-	Bodies				= 2,														///< Save the state of bodies
-	Contacts			= 4,														///< Save the state of contacts
-	Constraints			= 8,														///< Save the state of constraints
-	All					= Global | Bodies | Contacts | Constraints					///< Save all state
+	None					= 0,													///< Save nothing
+	Global					= 1,													///< Save global physics system state (delta time, gravity, etc.)
+	Bodies					= 2,													///< Save the state of bodies
+	Contacts				= 4,													///< Save the state of contacts
+	Constraints				= 8,													///< Save the state of constraints
+	All						= Global | Bodies | Contacts | Constraints,				///< Save all state
+
+	IdSequences				= 16													///< Save body id sequence number generation data so that bodies created after a restore get the same ids they got originally. Must be combined with Bodies.
 };
 
 JPH_SUPPRESS_WARNING_POP

--- a/UnitTests/Physics/StateRecorderTests.cpp
+++ b/UnitTests/Physics/StateRecorderTests.cpp
@@ -1,0 +1,216 @@
+// Jolt Physics Library (https://github.com/jrouwe/JoltPhysics)
+// SPDX-FileCopyrightText: 2021 Jorrit Rouwe
+// SPDX-License-Identifier: MIT
+
+#include "UnitTestFramework.h"
+#include "PhysicsTestContext.h"
+#include "Layers.h"
+#include <Jolt/Physics/StateRecorderImpl.h>
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+
+TEST_SUITE("StateRecorderTests")
+{
+	static BodyID sCreateBox(BodyInterface &inBI)
+	{
+		BodyCreationSettings settings(new BoxShape(Vec3::sReplicate(0.5f)), RVec3::sZero(), Quat::sIdentity(), EMotionType::Dynamic, Layers::MOVING);
+		Body *body = inBI.CreateBody(settings);
+		CHECK(body != nullptr);
+		inBI.AddBody(body->GetID(), EActivation::Activate);
+		return body->GetID();
+	}
+
+	static void sRemoveAndDestroy(BodyInterface &inBI, BodyID inID)
+	{
+		inBI.RemoveBody(inID);
+		inBI.DestroyBody(inID);
+	}
+
+	// Test that body id allocation after RestoreState matches the original allocation when restoring with EStateRecorderState::IdSequences
+	TEST_CASE("TestBodyIDConsistencyAfterRestore")
+	{
+		PhysicsTestContext c;
+		BodyInterface &bi = c.GetBodyInterface();
+		PhysicsSystem *system = c.GetSystem();
+
+		// Create two persistent bodies
+		BodyID p0 = sCreateBox(bi);
+		BodyID p1 = sCreateBox(bi);
+		CHECK(p0.GetIndex() == 0);
+		CHECK(p0.GetSequenceNumber() == 1);
+		CHECK(p1.GetIndex() == 1);
+		CHECK(p1.GetSequenceNumber() == 1);
+
+		c.SimulateSingleStep();
+
+		// Save state with and without sequence numbers
+		StateRecorderImpl state_no_seq;
+		system->SaveState(state_no_seq, EStateRecorderState::All);
+		StateRecorderImpl state_with_seq;
+		system->SaveState(state_with_seq, EStateRecorderState::All | EStateRecorderState::IdSequences);
+
+		// Create and destroy a body after the snapshot, this advances the sequence number of slot 2
+		BodyID first_transient = sCreateBox(bi);
+		CHECK(first_transient.GetIndex() == 2);
+		CHECK(first_transient.GetSequenceNumber() == 1);
+		sRemoveAndDestroy(bi, first_transient);
+
+		// Restore without sequence numbers: the slot 2 counter is not rolled back so the next body gets a different id
+		{
+			state_no_seq.Rewind();
+			CHECK(system->RestoreState(state_no_seq));
+
+			BodyID after_no_seq = sCreateBox(bi);
+			CHECK(after_no_seq.GetIndex() == 2);
+			CHECK(after_no_seq.GetSequenceNumber() == 2);
+			CHECK(after_no_seq != first_transient);
+			sRemoveAndDestroy(bi, after_no_seq);
+		}
+
+		// Restore with sequence numbers: the counter is rolled back so the next body gets the same id as the first time
+		{
+			state_with_seq.Rewind();
+			CHECK(system->RestoreState(state_with_seq));
+
+			BodyID after_with_seq = sCreateBox(bi);
+			CHECK(after_with_seq.GetIndex() == 2);
+			CHECK(after_with_seq.GetSequenceNumber() == 1);
+			CHECK(after_with_seq == first_transient);
+			sRemoveAndDestroy(bi, after_with_seq);
+		}
+	}
+
+	// Test that the free list order is restored so that body creation after a restore produces the same ids it did after the snapshot was taken
+	TEST_CASE("TestFreeListOrderPreservedAfterRestore")
+	{
+		PhysicsTestContext c;
+		BodyInterface &bi = c.GetBodyInterface();
+		PhysicsSystem *system = c.GetSystem();
+
+		// Create and destroy a body so slot 0 is on the free list
+		BodyID first = sCreateBox(bi);
+		CHECK(first.GetIndex() == 0);
+		sRemoveAndDestroy(bi, first);
+
+		c.SimulateSingleStep();
+
+		StateRecorderImpl snapshot;
+		system->SaveState(snapshot, EStateRecorderState::All | EStateRecorderState::IdSequences);
+
+		// Create two bodies and destroy them in reverse order so the free list order no longer matches the snapshot
+		BodyID b0 = sCreateBox(bi);
+		CHECK(b0.GetIndex() == 0);
+		CHECK(b0.GetSequenceNumber() == 2);
+		BodyID b1 = sCreateBox(bi);
+		CHECK(b1.GetIndex() == 1);
+		CHECK(b1.GetSequenceNumber() == 1);
+		sRemoveAndDestroy(bi, b1);
+		sRemoveAndDestroy(bi, b0);
+
+		snapshot.Rewind();
+		CHECK(system->RestoreState(snapshot));
+
+		// Creating the same bodies again should produce the same ids
+		BodyID r0 = sCreateBox(bi);
+		CHECK(r0 == b0);
+		BodyID r1 = sCreateBox(bi);
+		CHECK(r1 == b1);
+
+		sRemoveAndDestroy(bi, r0);
+		sRemoveAndDestroy(bi, r1);
+	}
+
+	// Test that bodies not present in the state are destroyed when restoring with inDestroyBodiesNotInState
+	TEST_CASE("TestRestoreStateDestroyOrphanBodies")
+	{
+		PhysicsTestContext c;
+		BodyInterface &bi = c.GetBodyInterface();
+		PhysicsSystem *system = c.GetSystem();
+
+		BodyID p0 = sCreateBox(bi);
+		BodyID p1 = sCreateBox(bi);
+
+		c.SimulateSingleStep();
+
+		StateRecorderImpl snapshot;
+		system->SaveState(snapshot, EStateRecorderState::All | EStateRecorderState::IdSequences);
+		CHECK(system->GetNumBodies() == 2);
+
+		// Create a body that is not part of the snapshot
+		BodyID orphan = sCreateBox(bi);
+		CHECK(orphan.GetIndex() == 2);
+		CHECK(system->GetNumBodies() == 3);
+
+		SUBCASE("OrphanSurvivesRestore")
+		{
+			snapshot.Rewind();
+			CHECK(system->RestoreState(snapshot, nullptr, false));
+
+			CHECK(system->GetNumBodies() == 3);
+			CHECK(bi.IsAdded(orphan));
+
+			sRemoveAndDestroy(bi, orphan);
+		}
+
+		SUBCASE("OrphanDestroyedOnRestore")
+		{
+			snapshot.Rewind();
+			CHECK(system->RestoreState(snapshot, nullptr, true));
+
+			CHECK(system->GetNumBodies() == 2);
+			CHECK_FALSE(bi.IsAdded(orphan));
+			{
+				BodyLockRead lock(system->GetBodyLockInterface(), orphan);
+				CHECK_FALSE(lock.Succeeded());
+			}
+			CHECK(bi.IsAdded(p0));
+			CHECK(bi.IsAdded(p1));
+
+			// The next body created reuses the orphan slot and gets the same id
+			BodyID reuse = sCreateBox(bi);
+			CHECK(reuse == orphan);
+
+			sRemoveAndDestroy(bi, reuse);
+		}
+	}
+
+	// Test that a body whose slot was reused after the snapshot (destroy + create -> same slot), gets its id corrected back to the saved value on restore
+	TEST_CASE("TestBodyIDDriftCorrectedOnRestore")
+	{
+		PhysicsTestContext c;
+		BodyInterface &bi = c.GetBodyInterface();
+		PhysicsSystem *system = c.GetSystem();
+
+		BodyID a = sCreateBox(bi);
+		CHECK(a.GetSequenceNumber() == 1);
+
+		c.SimulateSingleStep();
+		RVec3 a_pos = bi.GetPosition(a);
+
+		StateRecorderImpl snapshot;
+		system->SaveState(snapshot, EStateRecorderState::All | EStateRecorderState::IdSequences);
+
+		// Destroy the body and create a new one, this reuses the slot with a higher sequence number
+		sRemoveAndDestroy(bi, a);
+		BodyID b = sCreateBox(bi);
+		CHECK(b.GetIndex() == a.GetIndex());
+		CHECK(b.GetSequenceNumber() == 2);
+
+		// The body occupying the slots is matched by index and its id is corrected back to the saved value
+		snapshot.Rewind();
+		CHECK(system->RestoreState(snapshot, nullptr, true));
+
+		CHECK(bi.IsAdded(a));
+		CHECK_FALSE(bi.IsAdded(b));
+		CHECK(bi.IsActive(a));
+		CHECK(bi.GetPosition(a) == a_pos);
+
+		// Id allocation continues deterministically from the snapshot state
+		BodyID next = sCreateBox(bi);
+		CHECK(next.GetIndex() == 1);
+		CHECK(next.GetSequenceNumber() == 1);
+
+		sRemoveAndDestroy(bi, next);
+		sRemoveAndDestroy(bi, a);
+	}
+
+} // TEST_SUITE("StateRecorderTests")

--- a/UnitTests/UnitTests.cmake
+++ b/UnitTests/UnitTests.cmake
@@ -66,6 +66,7 @@ set(UNIT_TESTS_SRC_FILES
 	${UNIT_TESTS_ROOT}/Physics/PhysicsStepListenerTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/PhysicsTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/RayShapeTests.cpp
+	${UNIT_TESTS_ROOT}/Physics/StateRecorderTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/SensorTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/ShapeFilterTests.cpp
 	${UNIT_TESTS_ROOT}/Physics/ShapeTests.cpp


### PR DESCRIPTION
As a continuation from https://github.com/jrouwe/JoltPhysics/discussions/1930
I ended up disappearing for GDC and never updated. But following that discussion I have been successful synchronizing ids and context for shape/material out of band, while sending a full staterecorder over the wire only once at the beginning of each client connection. In addition, storing one for each tick within history for reprediction. I quickly noticed that id generation was not deterministic after restoring, which inspired these changes:

I added a `EStateRecorderState::IdSequences` to save/restore body id sequence numbers and the free list order, and then an option to `PhysicsSystem::RestoreState` to destroy bodies not present in the state.

Together these make body ID allocation after a restore identical to the original run, which I needed for rollback/reprediction. Also adds some state recorder tests to verify.

Currently a draft because I'm also looking for a bit guidance on expected guarantees for serialization format of the state recorder. I put all of this in the new `IdSequences` so theoretically it could be backwards compatible if folks were saving previous recordings to disk. Also, maybe it makes sense to not care about deterministic body id on replay. It's not as important if you're just using it for like visual debugging or forking. So I wanted to keep it as a separate option. You can also tell I hesitated to add it to All and that it awkwardly tags onto the body logic. Happy to clean this up or drop it altogether if you prefer another approach. I'm sure it also needs extra warning/handling for filters or other partial state saves. Or the free list restore not working if you don't have the entity destruction enabled.

I've been using these changes successful for a while in my prototype for the past few weeks, but it's not incredibly complex at the moment.

Ultimately I needed 2 things:
* When rewinding the simulation (for network reprediction) body id generation is replayed deterministically for all observers once all inputs converge
* An easy way to remove bodies that were not present in a state recording, ideally without rewriting or rereading the snapshot
