### PR TITLE
Moved definition of JPH_ENABLE_ASSERTS earlier

### DIFF
--- a/Jolt/Core/Core.h
+++ b/Jolt/Core/Core.h
@@ -9,6 +9,16 @@
 #define JPH_VERSION_MINOR 6
 #define JPH_VERSION_PATCH 1
 
+// Determine if we want extra debugging code to be active
+#if !defined(NDEBUG) && !defined(JPH_NO_DEBUG)
+	#define JPH_DEBUG
+#endif
+
+// Always turn on asserts in Debug mode
+#if defined(JPH_DEBUG) && !defined(JPH_ENABLE_ASSERTS)
+	#define JPH_ENABLE_ASSERTS
+#endif
+
 // Determine which features the library was compiled with
 #ifdef JPH_DOUBLE_PRECISION
 	#define JPH_VERSION_FEATURE_BIT_1 1
@@ -557,11 +567,6 @@ static_assert(sizeof(uint8) == 1, "Invalid size of uint8");
 static_assert(sizeof(uint16) == 2, "Invalid size of uint16");
 static_assert(sizeof(uint32) == 4, "Invalid size of uint32");
 static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
-
-// Determine if we want extra debugging code to be active
-#if !defined(NDEBUG) && !defined(JPH_NO_DEBUG)
-	#define JPH_DEBUG
-#endif
 
 // Define inline macro
 #if defined(JPH_NO_FORCE_INLINE)

--- a/Jolt/Core/IssueReporting.h
+++ b/Jolt/Core/IssueReporting.h
@@ -10,11 +10,6 @@ JPH_NAMESPACE_BEGIN
 using TraceFunction = void (*)(const char *inFMT, ...);
 JPH_EXPORT extern TraceFunction Trace;
 
-// Always turn on asserts in Debug mode
-#if defined(JPH_DEBUG) && !defined(JPH_ENABLE_ASSERTS)
-	#define JPH_ENABLE_ASSERTS
-#endif
-
 #ifdef JPH_ENABLE_ASSERTS
 	/// Function called when an assertion fails. This function should return true if a breakpoint needs to be triggered
 	using AssertFailedFunction = bool(*)(const char *inExpression, const char *inMessage, const char *inFile, uint inLine);


### PR DESCRIPTION
The definition was too late for JPH_VERSION_ID to include it

Fixes #2084