### PR TITLE
Added links to new C and Jai bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If you're interested in how Jolt scales with multiple CPUs and compares to other
 * [Rust](https://github.com/SecondHalfGames/jolt-rust)
 * [Python](https://github.com/Evilpasture/Culverin)
 * [Zig](https://github.com/zig-gamedev/zphysics)
-* [Jai](https://github.com/ostef/Jolt-Jai), based on this [binding generator](https://github.com/ostef/JoltC-BindGen)
+* [Jai](https://github.com/ostef/Jolt-Jai), based on this [bindings generator](https://github.com/ostef/JoltC-BindGen)
 
 ## Integrations in other engines
 

--- a/README.md
+++ b/README.md
@@ -154,13 +154,14 @@ If you're interested in how Jolt scales with multiple CPUs and compares to other
 
 ## Bindings for other languages
 
-* C [here](https://github.com/amerkoleci/joltc), [here](https://github.com/zig-gamedev/zphysics/tree/main/libs/JoltC) and [here](https://github.com/SecondHalfGames/JoltC/)
+* C [here](https://github.com/amerkoleci/joltc), [here](https://github.com/zig-gamedev/zphysics/tree/main/libs/JoltC), [here](https://github.com/SecondHalfGames/JoltC/) and [here](https://github.com/ostef/JoltC/)
 * [C#](https://github.com/amerkoleci/JoltPhysicsSharp)
 * Java or Kotlin [here](https://stephengold.github.io/jolt-jni-docs) and [here](https://github.com/Morgoth398/JoltPhysics-JavaFFM)
 * [JavaScript](https://github.com/jrouwe/JoltPhysics.js)
 * [Rust](https://github.com/SecondHalfGames/jolt-rust)
 * [Python](https://github.com/Evilpasture/Culverin)
 * [Zig](https://github.com/zig-gamedev/zphysics)
+* [Jai](https://github.com/ostef/Jolt-Jai), based on this [binding generator](https://github.com/ostef/JoltC-BindGen)
 
 ## Integrations in other engines
 


### PR DESCRIPTION
Hello, I've made a C interface along with a bindings generator. It generates Jai bindings for now, though other languages can be added.

The C interface uses heavy namespacing, which is maybe not very convenient to use in C, but it allows the bindings generator to generate code structured in much the same way as the original C++ code (apart from things that had to be made opaque or need a translation layer). So if the target language supports methods, namespacing and inheritence or a mechanism to mimic it, then we can take advantage of that.

I don't know if it makes sense to add yet another C bindings to the list as there are already three, let me know if you think I should remove it.