### PR TITLE
Reduce sleep-stats wire sphere cost

### DIFF
--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1025,7 +1025,7 @@ void BodyManager::Draw(const DrawSettings &inDrawSettings, const PhysicsSettings
 				Color sleep_color = Color(0, 255 - g, g);
 				inRenderer->DrawText3D(body->GetCenterOfMassPosition(), text, sleep_color, 0.2f);
 				for (int i = 0; i < 3; ++i)
-					inRenderer->DrawWireSphere(JPH_IF_DOUBLE_PRECISION(body->mMotionProperties->GetSleepTestOffset() +) body->mMotionProperties->mSleepTestSpheres[i].GetCenter(), body->mMotionProperties->mSleepTestSpheres[i].GetRadius(), sleep_color);
+					inRenderer->DrawWireSphere(JPH_IF_DOUBLE_PRECISION(body->mMotionProperties->GetSleepTestOffset() +) body->mMotionProperties->mSleepTestSpheres[i].GetCenter(), body->mMotionProperties->mSleepTestSpheres[i].GetRadius(), sleep_color, 0);
 			}
 
 			if (body->IsSoftBody())

--- a/Jolt/Physics/Body/BodyManager.cpp
+++ b/Jolt/Physics/Body/BodyManager.cpp
@@ -1025,7 +1025,7 @@ void BodyManager::Draw(const DrawSettings &inDrawSettings, const PhysicsSettings
 				Color sleep_color = Color(0, 255 - g, g);
 				inRenderer->DrawText3D(body->GetCenterOfMassPosition(), text, sleep_color, 0.2f);
 				for (int i = 0; i < 3; ++i)
-					inRenderer->DrawWireSphere(JPH_IF_DOUBLE_PRECISION(body->mMotionProperties->GetSleepTestOffset() +) body->mMotionProperties->mSleepTestSpheres[i].GetCenter(), body->mMotionProperties->mSleepTestSpheres[i].GetRadius(), sleep_color, 0);
+					inRenderer->DrawMarker(JPH_IF_DOUBLE_PRECISION(body->mMotionProperties->GetSleepTestOffset() +) body->mMotionProperties->mSleepTestSpheres[i].GetCenter(), sleep_color, body->mMotionProperties->mSleepTestSpheres[i].GetRadius());
 			}
 
 			if (body->IsSoftBody())


### PR DESCRIPTION
BodyManager::Draw calls DrawWireSphere 3 times per body per step, using the default 3 subdivision levels when mDrawSleepStats is true. That amounts to 1536 line segments per sphere, for a total of 4608 per body. 

Needless to say, that's way too many for visualizing sleep test spheres, so I passed 0 InLevel to DrawWireSphere. 1 works fine too, but I didn't see much of a visual difference (from afar, anyway).