### PR TITLE
Avoiding overflow to INF if inverse effective mass is denormal

### DIFF
--- a/Jolt/Physics/Constraints/ConstraintPart/AngleConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/AngleConstraintPart.h
@@ -82,7 +82,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inBody2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 		{
@@ -104,7 +104,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inBody2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (inFrequency > 0.0f)
 			mSpringPart.CalculateSpringPropertiesWithFrequencyAndDamping(inDeltaTime, inv_effective_mass, inBias, inC, inFrequency, inDamping, mEffectiveMass);
@@ -128,7 +128,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inBody2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (inStiffness > 0.0f || inDamping > 0.0f)
 			mSpringPart.CalculateSpringPropertiesWithStiffnessAndDamping(inDeltaTime, inv_effective_mass, inBias, inC, inStiffness, inDamping, mEffectiveMass);
@@ -145,7 +145,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inBody2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (!inSpringSettings.HasStiffness())
 		{
@@ -164,7 +164,7 @@ public:
 
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inBody2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 			mSpringPart.CalculateSpringPropertiesWithSettings(inDeltaTime, inv_effective_mass, inBias, inC, inSpringSettings, mEffectiveMass);

--- a/Jolt/Physics/Constraints/ConstraintPart/AngularFrictionConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/AngularFrictionConstraintPart.h
@@ -86,7 +86,7 @@ public:
 		else
 			JPH_ASSERT(false); // Static vs static is nonsensical!
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			this->Deactivate();
 		else
 			this->mEffectiveMass = 1.0f / inv_effective_mass;

--- a/Jolt/Physics/Constraints/ConstraintPart/AxisConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/AxisConstraintPart.h
@@ -146,7 +146,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inR1PlusU, inBody2, inR2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 		{
@@ -170,7 +170,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inR1PlusU, inBody2, inR2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (inFrequency > 0.0f)
 			mSpringPart.CalculateSpringPropertiesWithFrequencyAndDamping(inDeltaTime, inv_effective_mass, inBias, inC, inFrequency, inDamping, mEffectiveMass);
@@ -196,7 +196,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inR1PlusU, inBody2, inR2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (inStiffness > 0.0f || inDamping > 0.0f)
 			mSpringPart.CalculateSpringPropertiesWithStiffnessAndDamping(inDeltaTime, inv_effective_mass, inBias, inC, inStiffness, inDamping, mEffectiveMass);
@@ -213,7 +213,7 @@ public:
 	{
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inR1PlusU, inBody2, inR2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else if (!inSpringSettings.HasStiffness())
 		{
@@ -232,7 +232,7 @@ public:
 
 		float inv_effective_mass = CalculateInverseEffectiveMass(inBody1, inR1PlusU, inBody2, inR2, inWorldSpaceAxis);
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 			mSpringPart.CalculateSpringPropertiesWithSettings(inDeltaTime, inv_effective_mass, inBias, inC, inSpringSettings, mEffectiveMass);

--- a/Jolt/Physics/Constraints/ConstraintPart/ContactConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/ContactConstraintPart.h
@@ -151,7 +151,7 @@ public:
 			}
 		}
 
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			this->Deactivate();
 		else
 			this->mEffectiveMass = 1.0f / inv_effective_mass;

--- a/Jolt/Physics/Constraints/ConstraintPart/GearConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/GearConstraintPart.h
@@ -79,7 +79,7 @@ public:
 
 		// K^-1 = 1 / (J M^-1 J^T) = 1 / (a^T I1^-1 a + r^2 * b^T I2^-1 b)
 		float inv_effective_mass = (inWorldSpaceHingeAxis1.Dot(mInvI1_A) + inWorldSpaceHingeAxis2.Dot(mInvI2_B) * Square(inRatio));
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 			mEffectiveMass = 1.0f / inv_effective_mass;

--- a/Jolt/Physics/Constraints/ConstraintPart/IndependentAxisConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/IndependentAxisConstraintPart.h
@@ -113,7 +113,7 @@ public:
 		}
 
 		// Calculate inverse effective mass: K = J M^-1 J^T
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 			mEffectiveMass = 1.0f / inv_effective_mass;

--- a/Jolt/Physics/Constraints/ConstraintPart/RackAndPinionConstraintPart.h
+++ b/Jolt/Physics/Constraints/ConstraintPart/RackAndPinionConstraintPart.h
@@ -80,7 +80,7 @@ public:
 
 		// K^-1 = 1 / (J M^-1 J^T) = 1 / (a^T I1^-1 a + 1/m2 * r^2 * b . b)
 		float inv_effective_mass = (inWorldSpaceHingeAxis.Dot(mInvI1_A) + inv_m2 * Square(inRatio));
-		if (inv_effective_mass == 0.0f)
+		if (inv_effective_mass < FLT_MIN)
 			Deactivate();
 		else
 			mEffectiveMass = 1.0f / inv_effective_mass;

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -1907,6 +1907,31 @@ TEST_SUITE("PhysicsTests")
 		CHECK(body->GetPosition() == initial_position);
 	}
 
+	TEST_CASE("TestAllowedDOFsVsSmallRotation")
+	{
+		PhysicsTestContext c;
+		Body &floor = c.CreateFloor();
+		floor.SetFriction(1.0f);
+
+		const float cPenetrationSlop = c.GetSystem()->GetPhysicsSettings().mPenetrationSlop;
+		const RVec3 cInitialPos(0, 0.5_r - cPenetrationSlop, 0);
+
+		// Introduce a slight rotation around the X axis (which has been frozen by EAllowedDOFs).
+		// This creates a very tiny (denormalized float) effective mass for the angular friction component.
+		// Inverting this effective mass will make it INF and cause a FP exception if not handled properly.
+		BodyCreationSettings bcs(new BoxShape(Vec3::sReplicate(0.5f)), cInitialPos, Quat(1.0e-20f, 0, 0, 1.0f), EMotionType::Dynamic, Layers::MOVING);
+		bcs.mAllowedDOFs = EAllowedDOFs::Plane2D;
+		bcs.mLinearVelocity = Vec3(0, -1, 0);
+		bcs.mFriction = 1.0f;
+		BodyID id = c.GetBodyInterface().CreateAndAddBody(bcs, EActivation::Activate);
+
+		c.SimulateSingleStep();
+
+		// Check not moved
+		CHECK_APPROX_EQUAL(c.GetBodyInterface().GetPosition(id), cInitialPos, 1.0e-5f);
+		CHECK_APPROX_EQUAL(c.GetBodyInterface().GetLinearVelocity(id), Vec3::sZero(), 1.0e-3f);
+	}
+
 	TEST_CASE("TestSelectiveStateSaveAndRestore")
 	{
 		class MyFilter : public StateRecorderFilter


### PR DESCRIPTION
When restricting the rotation of an object using EAllowedDOFs, a tiny rotation in a restricted axis can cause the effective mass of the angular friction component to overflow to INF and cause an FP exception.

Fixes #2092