### PR TITLE
Docs: fix typos in PerformanceTest.md and Samples.md

### DIFF
--- a/Docs/PerformanceTest.md
+++ b/Docs/PerformanceTest.md
@@ -13,7 +13,7 @@ The performance test application contains a couple of simple scenes to test perf
 - -i=[iterations]: Number of physics steps before the test finishes.
 - -q=[quality]: This limits the motion quality types that the test will run on. By default it will test both. [quality] can be:
     - Discrete: Discrete collision detection
-    - LinearCast: Linear cast continous collision detection
+    - LinearCast: Linear cast continuous collision detection
 - -t=[num]: This sets the amount of threads the test will run on. By default it will test 1 .. number of virtual processors. Can be 'max' to run on as many thread as the CPU has.
 - -no_sleep: Disable sleeping.
 - -p: Outputs a profile snapshot every 100 iterations

--- a/Docs/Samples.md
+++ b/Docs/Samples.md
@@ -5,7 +5,7 @@ This document describes the demos in the [Samples](https://github.com/jrouwe/Jol
 * Select Test - This allows you to select between the different types of physics tests
 * Test Settings - Some tests will allow extra configuration, if not this setting will be greyed out
 * Restart Test (R) - When selecting this, the test will go back to its initial state
-* Run All Tests - This will run every tests for 10 seconds before proceeding to the next. This is a good way of visually inspecting the simulation before commiting a code change.
+* Run All Tests - This will run every test for 10 seconds before proceeding to the next. This is a good way of visually inspecting the simulation before committing a code change.
 * Next Test (N) - When running all tests, this option can be used to quickly skip to the next test.
 * Physics Settings - This menu contains all physics configuration.
 * Drawing Options - This menu shows all the options for drawing the internal state of the physics simulation.


### PR DESCRIPTION
Small documentation fixes:

- `Docs/PerformanceTest.md`: "Linear cast **continous** collision detection" → "continuous"
- `Docs/Samples.md`: "run every **tests**" → "run every test", "before **commiting** a code change" → "committing"