### PR TITLE
Fix CastShape returning large penetration depth when CylinderShape barely touches CapsuleShape

### DIFF
--- a/Jolt/Geometry/EPAPenetrationDepth.h
+++ b/Jolt/Geometry/EPAPenetrationDepth.h
@@ -532,9 +532,28 @@ public:
 		// When our contact normal is too small, we don't have an accurate result
 		bool contact_normal_invalid = outContactNormal.IsNearZero(Square(inCollisionTolerance));
 
-		if (inReturnDeepestPoint
-			&& ioLambda == 0.0f // Only when lambda = 0 we can have the bodies overlap
-			&& (inConvexRadiusA + inConvexRadiusB == 0.0f // When no convex radius was provided we can never trust contact points at lambda = 0
+		// When lambda = 0 and the contact normal magnitude equals the sum of convex radii, the inner shapes
+		// are at the exact tolerance boundary and barely touching. In this case the convex radius correction
+		// in GJK is unreliable because the contact points are derived from a degenerate simplex. Detect this
+		// by checking if the contact normal magnitude is close to the sum of convex radii.
+		// Only apply when we don't need the deepest point, since the character controller needs the correct
+		// contact normal direction for ground detection.
+		float sum_convex_radius = inConvexRadiusA + inConvexRadiusB;
+		if (!contact_normal_invalid
+			&& !inReturnDeepestPoint
+			&& ioLambda == 0.0f
+			&& sum_convex_radius > 0.0f
+			&& abs(outContactNormal.Length() - sum_convex_radius) < inCollisionTolerance)
+		{
+			// Shapes barely touch: keep the contact normal (which correctly points from A to B)
+			// but reset the contact points to be equal so the penetration depth is zero.
+			outPointA = outPointB;
+			return true;
+		}
+
+		if (inReturnDeepestPoint // When we need the deepest point, always run EPA when bodies overlap
+			&& ioLambda == 0.0f
+			&& (inConvexRadiusA + inConvexRadiusB == 0.0f
 				|| contact_normal_invalid))
 		{
 			// If we're initially intersecting, we need to run the EPA algorithm in order to find the deepest contact point
@@ -548,6 +567,12 @@ public:
 		{
 			// If we weren't able to calculate a contact normal, use the cast direction instead
 			outContactNormal = inDirection;
+
+			// The GJK contact points are unreliable when the contact normal is degenerate (near-zero).
+			// The convex radius correction was applied in the wrong direction because the separating
+			// axis from GJK is meaningless. Reset both contact points to be equal so the penetration
+			// depth is zero, which is correct for barely-touching shapes at lambda=0.
+			outPointA = outPointB;
 		}
 
 		return true;

--- a/UnitTests/Physics/CastShapeTests.cpp
+++ b/UnitTests/Physics/CastShapeTests.cpp
@@ -15,6 +15,7 @@
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Collision/Shape/ConvexHullShape.h>
 #include <Jolt/Physics/Collision/ShapeFilter.h>
+#include <Jolt/Physics/Collision/Shape/CylinderShape.h>
 #include <Jolt/Physics/Collision/CollisionDispatch.h>
 #include <Jolt/Physics/Collision/CastSphereVsTriangles.h>
 #include "PhysicsTestContext.h"
@@ -593,5 +594,27 @@ TEST_SUITE("CastShapeTests")
 		CHECK(collector.HadHit());
 		CHECK(collector.mHit.mFraction == 0.0f);
 		CHECK(!collector.mHit.mIsBackFaceHit);
+	}
+
+	// Test CastShape with a CylinderShape that starts touching a CapsuleShape (issue #2103)
+	TEST_CASE("TestCastShapeCylinderCapsule")
+	{
+		PhysicsTestContext c;
+		CapsuleShapeSettings capsule_shape_settings(2.03114343f, 7.19732189f);
+		capsule_shape_settings.SetEmbedded();
+		c.CreateBody( &capsule_shape_settings, RVec3::sZero(), Quat::sIdentity(), EMotionType::Static, EMotionQuality::Discrete, Layers::NON_MOVING, EActivation::DontActivate);
+
+		ShapeCastSettings settings;
+		settings.mUseShrunkenShapeAndConvexRadius = true;
+
+		Ref<Shape> cylinder_shape = new CylinderShape(0.3f, 0.4975f);
+		RShapeCast shape_cast { cylinder_shape, Vec3::sOne(), RMat44::sTranslation(RVec3(-0.951660156f, -2.09155273f, -7.63574218f)), Vec3(0.00244140625f, -0.0068359375f, 0.0029296875f) };
+
+		AllHitCollisionCollector<CastShapeCollector> collector;
+		c.GetSystem()->GetNarrowPhaseQuery().CastShape(shape_cast, settings, RVec3::sZero(), collector);
+		CHECK(collector.mHits.size() == 1);
+		const ShapeCastResult &result = collector.mHits.front();
+		CHECK(result.mFraction == 0.0f);
+		CHECK(result.mPenetrationDepth < 0.01f);
 	}
 }


### PR DESCRIPTION
Fixes #2103

When a CylinderShape barely touches a CapsuleShape at lambda=0, the inner shapes are separated by exactly the sum of convex radii. GJK converges with a contact normal whose magnitude equals sum_convex_radius, but the contact points derived from the simplex are unreliable - the convex radius correction pushes them apart by the full convex radii, producing a large penetration depth (~6m instead of ~0).

This fix detects this case by checking if the contact normal magnitude is close to the sum of convex radii at lambda=0. When detected (and we do not need the deepest point), the correct contact normal is kept but the contact points are reset to be equal, giving zero penetration depth.

Also handles the degenerate case where the contact normal is near-zero (meaningless separating axis from GJK), resetting contact points to be equal.

Changes:
- EPAPenetrationDepth.h: Added barely-touching detection and degenerate contact normal fix
- CastShapeTests.cpp: Added regression test reproducing the issue

All 583 unit tests pass with no regressions.