### PR TITLE
Docs: document INTERPROCEDURAL_OPTIMIZATION for XCFramework builds

### DIFF
--- a/Build/README.md
+++ b/Build/README.md
@@ -227,6 +227,10 @@ If you receive the following error when linking:
 
 Then you have not enabled interprocedural optimizations (link time optimizations) for your own application. See the INTERPROCEDURAL_OPTIMIZATION option in CMakeLists.txt.
 
+Bitcode is deprecated on Apple platforms, but the `-flto=thin` flag (which is what `INTERPROCEDURAL_OPTIMIZATION` enables when using AppleClang) still embeds LLVM bitcode into the object files. When you consume Jolt as a static library, your own application must therefore be built with interprocedural optimizations enabled as well (via `SET_INTERPROCEDURAL_OPTIMIZATION()` or by setting `CMAKE_INTERPROCEDURAL_OPTIMIZATION ON` for your project).
+
+If you are bundling the Jolt static library into an XCFramework instead of linking it into your application, the embedded bitcode can cause errors such as `Unknown header: 0xb17c0de`. In that case disable interprocedural optimizations when building Jolt by turning the `INTERPROCEDURAL_OPTIMIZATION` cmake option off (for example with `cmake -B build -DINTERPROCEDURAL_OPTIMIZATION=OFF`). This is safe to do when the static library is distributed separately from the code that consumes it, since the Jolt static library is then recompiled as part of your own application.
+
 ### Link Error: Unresolved External Symbol
 
 If you receive a link error that looks like:

--- a/Build/README.md
+++ b/Build/README.md
@@ -54,7 +54,7 @@ There are a number of user configurable C++ defines that turn on/off certain fea
 		<li>JPH_USE_F16C - Enable half float CPU instructions (default: on, x86/x64 only)</li>
 		<li>JPH_USE_FMADD - Enable fused multiply add CPU instructions (default: on, x86/x64 only)</li>
 		<li>JPH_USE_LZCNT - Enable the lzcnt CPU instruction (default: on, x86/x64 only)</li>
-		<li>JPH_USE_NEON - Enable NEON on ARM (default: on for 64-bit ARM)</li> 
+		<li>JPH_USE_NEON - Enable NEON on ARM (default: on for 64-bit ARM)</li>
 		<li>JPH_USE_RVV - Enable RVV on RISC-V (default: off)</li>
 		<li>JPH_USE_SSE - Use SSE2 instructions (enabled on x86/x64)</li>
 		<li>JPH_USE_SSE4_1 - Enable SSE4.1 CPU instructions (default: on, x86/x64 only)</li>
@@ -227,9 +227,19 @@ If you receive the following error when linking:
 
 Then you have not enabled interprocedural optimizations (link time optimizations) for your own application. See the INTERPROCEDURAL_OPTIMIZATION option in CMakeLists.txt.
 
-Bitcode is deprecated on Apple platforms, but the `-flto=thin` flag (which is what `INTERPROCEDURAL_OPTIMIZATION` enables when using AppleClang) still embeds LLVM bitcode into the object files. When you consume Jolt as a static library, your own application must therefore be built with interprocedural optimizations enabled as well (via `SET_INTERPROCEDURAL_OPTIMIZATION()` or by setting `CMAKE_INTERPROCEDURAL_OPTIMIZATION ON` for your project).
+### Unknown Header Error on Apple Platforms
 
-If you are bundling the Jolt static library into an XCFramework instead of linking it into your application, the embedded bitcode can cause errors such as `Unknown header: 0xb17c0de`. In that case disable interprocedural optimizations when building Jolt by turning the `INTERPROCEDURAL_OPTIMIZATION` cmake option off (for example with `cmake -B build -DINTERPROCEDURAL_OPTIMIZATION=OFF`). This is safe to do when the static library is distributed separately from the code that consumes it, since the Jolt static library is then recompiled as part of your own application.
+Apple's application bitcode workflow is deprecated, but the `-flto=thin` flag (which is what the `INTERPROCEDURAL_OPTIMIZATION` cmake flag enables in non-debug builds) still produces object files with LLVM bitcode.
+If you package Jolt's static library into an XCFramework, the embedded bitcode can cause errors such as:
+
+```
+Unknown header: 0xb17c0de
+```
+
+If you receive this error, disable interprocedural optimizations by turning the `INTERPROCEDURAL_OPTIMIZATION` cmake option `OFF`.
+This removes LLVM bitcode and produces regular object files instead. Disabling this option disables link-time and cross-translation-unit optimizations so may reduce performance.
+
+When directly linking Jolt's static library into your application, this error should not occur and you can leave the `INTERPROCEDURAL_OPTIMIZATION` option `ON`.
 
 ### Link Error: Unresolved External Symbol
 


### PR DESCRIPTION
Closes #1261

When a static Jolt library is bundled into an XCFramework, the `-flto=thin` bitcode embedded by `INTERPROCEDURAL_OPTIMIZATION` causes errors like `Unknown header: 0xb17c0de` on Apple platforms. Document this and how to turn the option off for XCFramework builds.

No code changes; documentation only.