### PR TITLE
Fix SetHeights corrupting the range block hierarchy when the block count is not a power of 2

### DIFF
--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -10,6 +10,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * If `GJKClosestPoint::CastShape` failed to converge, it was accidentally using the rejected support point to calculate the contact point. In some cases this could lead to returning the wrong contact point.
 * When colliding with very long and thin triangles, GJK could fail to find the closest point to the triangle because it used a fixed epsilon to determine if the triangle was too thin. Changed this epsilon so that it is dependent on the length of the edges of the triangle so that we fall back to closest point to edge in those cases.
 * MinGW32 defines `__STDCPP_DEFAULT_NEW_ALIGNMENT__` as 16 but its allocations are actually 8 byte aligned. This caused unaligned read access violations in `TriangleSplitterBinning::mBins`.
+* `HeightFieldShape::SetHeights` updated the coarser levels of the range block hierarchy with a stride of `(num_blocks + 1) / 2` while they are stored with a stride of `1 << level`. When the number of blocks was not a power of 2 this wrote the updated ranges into unrelated nodes, so collision queries with a small bounding box (e.g. a `CharacterVirtual`) could miss the height field far away from the updated area.
 
 ### Removed functionality
 

--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -10,7 +10,7 @@ For breaking API changes see [this document](https://github.com/jrouwe/JoltPhysi
 * If `GJKClosestPoint::CastShape` failed to converge, it was accidentally using the rejected support point to calculate the contact point. In some cases this could lead to returning the wrong contact point.
 * When colliding with very long and thin triangles, GJK could fail to find the closest point to the triangle because it used a fixed epsilon to determine if the triangle was too thin. Changed this epsilon so that it is dependent on the length of the edges of the triangle so that we fall back to closest point to edge in those cases.
 * MinGW32 defines `__STDCPP_DEFAULT_NEW_ALIGNMENT__` as 16 but its allocations are actually 8 byte aligned. This caused unaligned read access violations in `TriangleSplitterBinning::mBins`.
-* `HeightFieldShape::SetHeights` updated the coarser levels of the range block hierarchy with a stride of `(num_blocks + 1) / 2` while they are stored with a stride of `1 << level`. When the number of blocks was not a power of 2 this wrote the updated ranges into unrelated nodes, so collision queries with a small bounding box (e.g. a `CharacterVirtual`) could miss the height field far away from the updated area.
+* `HeightFieldShape::SetHeights` corrupted the bounding volume tree when the number of blocks (`GetNumBlocks`) was not a power of 2. This resulted in collision queries possibly failing to report the correct collision.
 
 ### Removed functionality
 

--- a/Jolt/Physics/Collision/Shape/HeightFieldShape.cpp
+++ b/Jolt/Physics/Collision/Shape/HeightFieldShape.cpp
@@ -1166,7 +1166,7 @@ void HeightFieldShape::SetHeights(uint inX, uint inY, uint inSizeX, uint inSizeY
 	{
 		// Get offset and stride for destination blocks. Only the most detailed level is stored with a stride of
 		// (num_blocks + 1) / 2, all coarser levels are stored with a stride of 1 << level (see the constructor and
-		// WalkHeightField), so the stride cannot be derived from the halved block count.
+		// WalkHeightField)
 		uint dst_range_block_offset = sGridOffsets[max_level - 2];
 		uint dst_range_block_stride = 1u << (max_level - 2);
 

--- a/Jolt/Physics/Collision/Shape/HeightFieldShape.cpp
+++ b/Jolt/Physics/Collision/Shape/HeightFieldShape.cpp
@@ -1164,9 +1164,11 @@ void HeightFieldShape::SetHeights(uint inX, uint inY, uint inSizeX, uint inSizeY
 	// Update hierarchy of range blocks
 	while (max_level > 1)
 	{
-		// Get offset and stride for destination blocks
-		uint dst_range_block_offset, dst_range_block_stride;
-		sGetRangeBlockOffsetAndStride(num_blocks >> 1, max_level - 1, dst_range_block_offset, dst_range_block_stride);
+		// Get offset and stride for destination blocks. Only the most detailed level is stored with a stride of
+		// (num_blocks + 1) / 2, all coarser levels are stored with a stride of 1 << level (see the constructor and
+		// WalkHeightField), so the stride cannot be derived from the halved block count.
+		uint dst_range_block_offset = sGridOffsets[max_level - 2];
+		uint dst_range_block_stride = 1u << (max_level - 2);
 
 		// We'll be processing 2x2 blocks below so we need the start coordinates to be even and we extend the number of blocks to correct for that
 		if (block_start_x & 1) { --block_start_x; ++num_blocks_x; }

--- a/UnitTests/Physics/HeightFieldShapeTests.cpp
+++ b/UnitTests/Physics/HeightFieldShapeTests.cpp
@@ -7,6 +7,10 @@
 #include <Jolt/Physics/Collision/RayCast.h>
 #include <Jolt/Physics/Collision/CastResult.h>
 #include <Jolt/Physics/Collision/Shape/HeightFieldShape.h>
+#include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Collision/CollisionDispatch.h>
+#include <Jolt/Physics/Collision/CollideShape.h>
+#include <Jolt/Physics/Collision/CollisionCollectorImpl.h>
 #include <Jolt/Physics/Collision/PhysicsMaterialSimple.h>
 
 TEST_SUITE("HeightFieldShapeTests")
@@ -319,6 +323,67 @@ TEST_SUITE("HeightFieldShapeTests")
 				else
 					CHECK(verify_heights[idx] == original_heights[idx]); // We didn't modify this and it is outside of the affected range
 			}
+	}
+
+	TEST_CASE("TestSetHeightsNonPowerOf2BlockCount")
+	{
+		// 20 x 20 samples with a block size of 2 gives 10 blocks per side, which is not a power of 2.
+		// The coarser levels of the range block hierarchy are stored at stride 1 << level, only the most
+		// detailed level is stored at stride (num_blocks + 1) / 2. SetHeights must update them at the same
+		// strides, otherwise the updated ranges land on unrelated nodes and the cells below those nodes
+		// stop colliding until something big enough overlaps the wrong range.
+		const uint cSampleCount = 20;
+
+		HeightFieldShapeSettings settings;
+		settings.mSampleCount = cSampleCount;
+		settings.mBlockSize = 2;
+		settings.mMinHeightValue = 0.0f;
+		settings.mMaxHeightValue = 200.0f;
+		settings.mHeightSamples.resize(Square(cSampleCount), 0.0f);
+
+		Ref<Shape> shape = settings.Create().Get();
+		HeightFieldShape *height_field = StaticCast<HeightFieldShape>(shape);
+
+		// Raise a block aligned rectangle in one corner of the height field
+		const uint sx = 0, sy = 16, cx = 6, cy = 4;
+		const float cRaisedHeight = 100.0f;
+		Array<float> raised_heights(cx * cy, cRaisedHeight);
+		TempAllocatorMalloc temp_allocator;
+		height_field->SetHeights(sx, sy, cx, cy, raised_heights.data(), cx, temp_allocator);
+
+		// Heights as the shape quantized them, so the sphere below can be placed on the actual surface
+		Array<float> heights(Square(cSampleCount));
+		height_field->GetHeights(0, 0, cSampleCount, cSampleCount, heights.data(), cSampleCount);
+
+		// A sphere that dips 0.25 below the highest corner of a cell must collide with that cell.
+		// Its bounding box is 1 high, so it only overlaps the range of the node it is really under.
+		const float cSphereRadius = 0.5f;
+		Ref<Shape> sphere = new SphereShape(cSphereRadius);
+		CollideShapeSettings collide_settings;
+		auto test_cell = [&](uint inX, uint inY)
+		{
+			float top = max(max(heights[inY * cSampleCount + inX], heights[inY * cSampleCount + inX + 1]), max(heights[(inY + 1) * cSampleCount + inX], heights[(inY + 1) * cSampleCount + inX + 1]));
+			Vec3 sphere_position(float(inX) + 0.5f, top + cSphereRadius - 0.25f, float(inY) + 0.5f);
+			AllHitCollisionCollector<CollideShapeCollector> collector;
+			CollisionDispatch::sCollideShapeVsShape(sphere, shape, Vec3::sOne(), Vec3::sOne(), Mat44::sTranslation(sphere_position), Mat44::sIdentity(), SubShapeIDCreator(), SubShapeIDCreator(), collide_settings, collector);
+			return collector.HadHit();
+		};
+
+		// Every cell that was not raised must still collide
+		for (uint y = 0; y + 1 < cSampleCount; ++y)
+			for (uint x = 0; x + 1 < cSampleCount; ++x)
+			{
+				// Skip the raised rectangle and the cells that connect to it
+				if (x < sx + cx && y + 1 >= sy)
+					continue;
+
+				CAPTURE(x);
+				CAPTURE(y);
+				CHECK(test_cell(x, y));
+			}
+
+		// And the raised part must collide at its new height
+		CHECK(test_cell(sx + 1, sy + 1));
 	}
 
 	TEST_CASE("TestSetMaterials")


### PR DESCRIPTION
## Problem

`HeightFieldShape` stores its range block hierarchy with a stride of `1 << level` for every level except the most detailed one, which is clamped to `(num_blocks + 1) / 2` (constructor, "Create blocks" loop, and `WalkHeightField`: `stride = min(1U << level, max_stride)`).

`SetHeights` rebuilds the parent levels through `sGetRangeBlockOffsetAndStride(num_blocks >> 1, max_level - 1, ...)`, whose stride is `(n + 1) >> 1` at every level. For a block count that is a power of 2 the two agree. For any other block count they differ from the first parent level on (454 blocks: 114 vs 128, then 57 vs 64, ...), so the updated min/max values are written into unrelated nodes and the real parents keep their old range. Later iterations also read their source ranges with the wrong stride.

The effect is invisible to `CastRay` most of the time (a long ray's AABB still overlaps the wrong range) but `CollideShape` / `CharacterVirtual` queries with a small vertical extent get culled over the cells whose ancestor received a foreign range. In our game a `CharacterVirtual` walking over a 908 x 908 sample terrain (block size 2) fell through the ground at a fixed world position after the first `SetHeights` call elsewhere on the field, and only regained contact once it had sunk ~0.5 m, i.e. once its box reached the foreign range.

## Fix

Use the stored layout when updating the hierarchy: the destination level `max_level - 2` lives at `sGridOffsets[max_level - 2]` with stride `1 << (max_level - 2)`. The clamp to `(num_blocks + 1) / 2` never applies below the most detailed level because `1 << level <= 2^(max_level - 2) < (num_blocks + 1) / 2` for every `num_blocks > 2^(max_level - 1)`, so no `min()` is needed. The source stride for the next iteration follows automatically since it is taken from the previous destination.

## Test

`TestSetHeightsNonPowerOf2BlockCount` builds a 20 x 20 field with block size 2 (10 blocks per side), raises a block aligned rectangle in one corner with `SetHeights`, and then collides a small sphere with every untouched cell. Before the fix the cells under the node that received the raised range (samples x 16..19, z 8..11) report no hit; after the fix every cell collides and the raised part is found at its new height.
