### PR TITLE
Use per-body contact points as friction lever arms (fixes #2121)

### DIFF
--- a/Jolt/Physics/Collision/EstimateCollisionResponse.cpp
+++ b/Jolt/Physics/Collision/EstimateCollisionResponse.cpp
@@ -74,6 +74,7 @@ void EstimateCollisionResponse(const Body &inBody1, const Body &inBody2, const C
 	ContactConstraintPart<EMotionType::Dynamic, EMotionType::Dynamic> contact_constraints[ContactPoints::Capacity];
 	Vec3 contact_points[ContactPoints::Capacity];
 	Vec3 friction_point = Vec3::sZero();
+	Vec3 friction_point1 = Vec3::sZero(), friction_point2 = Vec3::sZero();
 	for (uint c = 0; c < num_points; ++c)
 	{
 		// Calculate contact points relative to body 1 and 2
@@ -82,6 +83,12 @@ void EstimateCollisionResponse(const Body &inBody1, const Body &inBody2, const C
 		// Calculate friction point
 		contact_points[c] = p;
 		friction_point += p;
+
+		// Calculate friction lever arm points per body so that the friction lever arm is not perturbed
+		// by the normal-direction separation of a speculative contact (the non-penetration constraint
+		// above is unaffected by this separation and keeps using the midpoint p)
+		friction_point1 += inManifold.mRelativeContactPointsOn1[c];
+		friction_point2 += inManifold.mRelativeContactPointsOn2[c];
 
 		// Calculate contact point relative to com
 		Vec3 r1 = p - com1;
@@ -109,6 +116,8 @@ void EstimateCollisionResponse(const Body &inBody1, const Body &inBody2, const C
 	// Calculate distance to friction center for each point
 	float num_points_f = float(num_points);
 	friction_point /= num_points_f;
+	friction_point1 /= num_points_f;
+	friction_point2 /= num_points_f;
 	float distance_to_friction_center[ContactPoints::Capacity];
 	for (uint c = 0; c < num_points; ++c)
 	{
@@ -125,8 +134,8 @@ void EstimateCollisionResponse(const Body &inBody1, const Body &inBody2, const C
 	friction2.SetTotalLambda(0.0f);
 	if (inCombinedFriction > 0.0f)
 	{
-		Vec3 r1 = friction_point - com1;
-		Vec3 r2 = friction_point - com2;
+		Vec3 r1 = friction_point1 - com1;
+		Vec3 r2 = friction_point2 - com2;
 
 		friction1.CalculateConstraintProperties(inv_m1, inv_i1, r1, inv_m2, inv_i2, r2, outResult.mTangent1);
 		friction2.CalculateConstraintProperties(inv_m1, inv_i1, r1, inv_m2, inv_i2, r2, outResult.mTangent2);

--- a/Jolt/Physics/Constraints/ContactConstraintManager.cpp
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.cpp
@@ -138,16 +138,28 @@ JPH_INLINE void ContactConstraintManager::WorldContactPoint<Type1, Type2>::Calcu
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <EMotionType Type1, EMotionType Type2>
-void ContactConstraintManager::ContactConstraint<Type1, Type2>::CalculateFrictionConstraintProperties(const Body &inBody1, const Body &inBody2, float inInvM1, float inInvM2, Mat44Arg inInvI1, Mat44Arg inInvI2, const RVec3 *inWorldSpaceContacts, Vec3Arg inWorldSpaceNormal, Vec3Arg inWorldSpaceTangent1, Vec3Arg inWorldSpaceTangent2, const ContactSettings &inSettings)
+void ContactConstraintManager::ContactConstraint<Type1, Type2>::CalculateFrictionConstraintProperties(const Body &inBody1, const Body &inBody2, float inInvM1, float inInvM2, Mat44Arg inInvI1, Mat44Arg inInvI2, const RVec3 *inWorldSpaceContacts1, const RVec3 *inWorldSpaceContacts2, Vec3Arg inWorldSpaceNormal, Vec3Arg inWorldSpaceTangent1, Vec3Arg inWorldSpaceTangent2, const ContactSettings &inSettings)
 {
 	// Calculate friction part
 	if (inSettings.mCombinedFriction > 0.0f)
 	{
-		// Calculate point where the friction applies by averaging the contact points
-		RVec3 friction_point = RVec3::sZero();
+		// Calculate the point where the friction applies for each body separately by averaging that
+		// body's own contact points. For a speculative contact the two bodies' contact points are still
+		// separated along the normal, so using their shared midpoint as the friction application point
+		// (as the non-penetration constraint does) would give both friction lever arms an error term along
+		// the normal. That term is fine for the non-penetration axis, but not for the friction axes, see below.
+		RVec3 friction_point1 = RVec3::sZero(), friction_point2 = RVec3::sZero();
 		for (uint32 i = 0; i < mNumContactPoints; ++i)
-			friction_point += inWorldSpaceContacts[i];
-		friction_point /= Real(mNumContactPoints);
+		{
+			friction_point1 += inWorldSpaceContacts1[i];
+			friction_point2 += inWorldSpaceContacts2[i];
+		}
+		friction_point1 /= Real(mNumContactPoints);
+		friction_point2 /= Real(mNumContactPoints);
+
+		// Midpoint is only used for logging and for measuring the contact spread in the normal plane below,
+		// both of which are invariant to how far apart friction_point1 and friction_point2 are along the normal
+		RVec3 friction_point = 0.5_r * (friction_point1 + friction_point2);
 
 		JPH_DET_LOG("CalculateFrictionConstraintProperties: point: " << friction_point
 			<< " friction: " << inSettings.mCombinedFriction
@@ -156,13 +168,14 @@ void ContactConstraintManager::ContactConstraint<Type1, Type2>::CalculateFrictio
 		// Calculate distance of contact points to friction center in the normal plane
 		for (uint32 i = 0; i < mNumContactPoints; ++i)
 		{
-			Vec3 delta = Vec3(inWorldSpaceContacts[i] - friction_point);
+			Vec3 delta = Vec3(0.5_r * (inWorldSpaceContacts1[i] + inWorldSpaceContacts2[i]) - friction_point);
 			mContactPoints[i].mDistanceToFrictionCenter = (delta - delta.Dot(inWorldSpaceNormal) * inWorldSpaceNormal).Length();
 		}
 
-		// Calculate relative friction points
-		Vec3 r1 = Vec3(friction_point - inBody1.GetCenterOfMassPosition());
-		Vec3 r2 = Vec3(friction_point - inBody2.GetCenterOfMassPosition());
+		// Calculate relative friction points, one per body, so that the friction lever arm is not
+		// perturbed by the separation of a speculative contact along the normal
+		Vec3 r1 = Vec3(friction_point1 - inBody1.GetCenterOfMassPosition());
+		Vec3 r2 = Vec3(friction_point2 - inBody2.GetCenterOfMassPosition());
 
 		// Get surface velocity relative to tangents
 		Vec3 ws_surface_velocity = inSettings.mRelativeLinearSurfaceVelocity + inSettings.mRelativeAngularSurfaceVelocity.Cross(r1);
@@ -955,7 +968,8 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 			}
 
 			// Setup non-penetration constraints
-			RVec3 ws_contacts[MaxContactPoints];
+			RVec3 ws_contacts1[MaxContactPoints];
+			RVec3 ws_contacts2[MaxContactPoints];
 			for (uint32 i = 0; i < constraint->mNumContactPoints; ++i)
 			{
 				const CachedContactPoint &ccp = output_cm->mContactPoints[i];
@@ -964,8 +978,10 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 				RVec3 p1_ws = transform_body1 * Vec3::sLoadFloat3Unsafe(ccp.mPosition1);
 				RVec3 p2_ws = transform_body2 * Vec3::sLoadFloat3Unsafe(ccp.mPosition2);
 
-				// Remember where to apply friction
-				ws_contacts[i] = 0.5_r * (p1_ws + p2_ws);
+				// Remember where to apply friction, one contact point per body so that the friction
+				// lever arm is not perturbed by the normal-direction separation of a speculative contact
+				ws_contacts1[i] = p1_ws;
+				ws_contacts2[i] = p2_ws;
 
 				wcp.mNonPenetrationConstraint.SetTotalLambda(ccp.mNonPenetrationLambda);
 				wcp.CalculateNonPenetrationConstraintProperties(delta_time, gravity, inBody1, inBody2, constraint->mInvMass1, constraint->mInvMass2, inv_i1, inv_i2, p1_ws, p2_ws, world_space_normal, settings, mPhysicsSettings.mMinVelocityForRestitution);
@@ -979,7 +995,7 @@ void ContactConstraintManager::TemplatedGetContactsFromCache(ContactAllocator &i
 			constraint->mFrictionConstraint1.SetTotalLambda(output_cm->mFrictionLambda[0]);
 			constraint->mFrictionConstraint2.SetTotalLambda(output_cm->mFrictionLambda[1]);
 			constraint->mAngularFrictionConstraint.SetTotalLambda(output_cm->mAngularFrictionLambda);
-			constraint->CalculateFrictionConstraintProperties(inBody1, inBody2, constraint->mInvMass1, constraint->mInvMass2, inv_i1, inv_i2, ws_contacts, world_space_normal, t1, t2, settings);
+			constraint->CalculateFrictionConstraintProperties(inBody1, inBody2, constraint->mInvMass1, constraint->mInvMass2, inv_i1, inv_i2, ws_contacts1, ws_contacts2, world_space_normal, t1, t2, settings);
 
 		#ifdef JPH_DEBUG_RENDERER
 			// Draw the manifold
@@ -1241,7 +1257,8 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			inv_i2 = Mat44::sZero();
 		}
 
-		RVec3 ws_contacts[MaxContactPoints];
+		RVec3 ws_contacts1[MaxContactPoints];
+		RVec3 ws_contacts2[MaxContactPoints];
 		for (int i = 0; i < num_contact_points; ++i)
 		{
 			// Convert to world space and set positions
@@ -1249,8 +1266,10 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			RVec3 p1_ws = inManifold.mBaseOffset + inManifold.mRelativeContactPointsOn1[i];
 			RVec3 p2_ws = inManifold.mBaseOffset + inManifold.mRelativeContactPointsOn2[i];
 
-			// Remember where to apply friction
-			ws_contacts[i] = 0.5_r * (p1_ws + p2_ws);
+			// Remember where to apply friction, one contact point per body so that the friction
+			// lever arm is not perturbed by the normal-direction separation of a speculative contact
+			ws_contacts1[i] = p1_ws;
+			ws_contacts2[i] = p2_ws;
 
 			// Convert to local space to the body
 			Vec3 p1_ls = Vec3(inverse_transform_body1 * p1_ws);
@@ -1294,7 +1313,7 @@ void ContactConstraintManager::TemplatedAddContactConstraint(ContactAllocator &i
 			constraint->mFrictionConstraint2.SetTotalLambda(0.0f);
 			constraint->mAngularFrictionConstraint.SetTotalLambda(0.0f);
 		}
-		constraint->CalculateFrictionConstraintProperties(inBody1, inBody2, constraint->mInvMass1, constraint->mInvMass2, inv_i1, inv_i2, ws_contacts, inManifold.mWorldSpaceNormal, t1, t2, settings);
+		constraint->CalculateFrictionConstraintProperties(inBody1, inBody2, constraint->mInvMass1, constraint->mInvMass2, inv_i1, inv_i2, ws_contacts1, ws_contacts2, inManifold.mWorldSpaceNormal, t1, t2, settings);
 
 #ifdef JPH_DEBUG_RENDERER
 		// Draw the manifold

--- a/Jolt/Physics/Constraints/ContactConstraintManager.h
+++ b/Jolt/Physics/Constraints/ContactConstraintManager.h
@@ -483,7 +483,7 @@ private:
 	{
 	public:
 		/// Calculate constraint properties for the friction constraint
-		JPH_INLINE void			CalculateFrictionConstraintProperties(const Body &inBody1, const Body &inBody2, float inInvM1, float inInvM2, Mat44Arg inInvI1, Mat44Arg inInvI2, const RVec3 *inWorldSpaceContacts, Vec3Arg inWorldSpaceNormal, Vec3Arg inWorldSpaceTangent1, Vec3Arg inWorldSpaceTangent2, const ContactSettings &inSettings);
+		JPH_INLINE void			CalculateFrictionConstraintProperties(const Body &inBody1, const Body &inBody2, float inInvM1, float inInvM2, Mat44Arg inInvI1, Mat44Arg inInvI2, const RVec3 *inWorldSpaceContacts1, const RVec3 *inWorldSpaceContacts2, Vec3Arg inWorldSpaceNormal, Vec3Arg inWorldSpaceTangent1, Vec3Arg inWorldSpaceTangent2, const ContactSettings &inSettings);
 
 	#ifdef JPH_DEBUG_RENDERER
 		/// Draw the state of the contact constraint

--- a/UnitTests/Physics/PhysicsTests.cpp
+++ b/UnitTests/Physics/PhysicsTests.cpp
@@ -1810,6 +1810,55 @@ TEST_SUITE("PhysicsTests")
 		CHECK_APPROX_EQUAL(box.GetAngularVelocity(), angular_velocity, 5.0e-3f);
 	}
 
+	// This test checks friction vs speculative contact points. A ball bouncing on the floor will have speculative contact points.
+	// These speculative contact points should not be applied to a point outside the shape.
+	TEST_CASE("TestFrictionVsSpeculativeContactPoint")
+	{
+		PhysicsTestContext c;
+		BodyInterface &bi = c.GetBodyInterface();
+
+		// Create floor
+		Body &floor = c.CreateFloor();
+		floor.SetRestitution(0.8f);
+		floor.SetFriction(0.5f);
+
+		// Create a sphere rolling over the floor
+		const float radius = 0.1f;
+		const float v0 = 2.0f;
+		BodyCreationSettings bcs(new SphereShape(radius), RVec3(0, radius, 1), Quat::sIdentity(), EMotionType::Dynamic, Layers::MOVING);
+		bcs.mRestitution = 0.8f;
+		bcs.mFriction = 0.5f;
+		bcs.mLinearVelocity = Vec3(v0, 0, 0);
+		bcs.mLinearDamping = 0.0f;
+		bcs.mAngularDamping = 0.0f;
+		BodyID id1 = bi.CreateAndAddBody(bcs, EActivation::Activate);
+
+		// Create a sphere initially bouncing on the floor and eventually rolling over the floor
+		bcs.mPosition = RVec3(0, 1.35f, -1.0f);
+		BodyID id2 = bi.CreateAndAddBody(bcs, EActivation::Activate);
+
+		c.Simulate(5.0f);
+
+		// Assuming the sphere will eventually roll without slipping so that w1 = v1 / r
+		// and that the impulse at the friction point will lead to this through I * w1 = m * r * (v0 - v1)
+		// with I = 2 / 5 * m * r^2 (inertia of a solid sphere) this leads to
+		// 2 / 5 * m * r^2 * w1 = m * r * (v0 - v1)
+		// 2 / 5 * r * w1 = v0 - v1
+		// 2 / 5 * v1 = v0 - v1
+		// v1 = 5 / 7 * v0
+		float expected_v1 = (5.0f / 7.0f) * v0;
+		float expected_w1 = expected_v1 / radius;
+
+		// Test that both spheres have reached this velocity after some time
+		Vec3 v1, w1, v2, w2;
+		bi.GetLinearAndAngularVelocity(id1, v1, w1);
+		bi.GetLinearAndAngularVelocity(id2, v2, w2);
+		CHECK_APPROX_EQUAL(v1, Vec3(expected_v1, 0, 0), 1.0e-4f);
+		CHECK_APPROX_EQUAL(w1, Vec3(0, 0, -expected_w1), 1.0e-3f);
+		CHECK_APPROX_EQUAL(v2, Vec3(expected_v1, 0, 0), 1.0e-4f);
+		CHECK_APPROX_EQUAL(w2, Vec3(0, 0, -expected_w1), 1.0e-3f);
+	}
+
 	TEST_CASE("TestAllowedDOFs")
 	{
 		for (uint allowed_dofs = 1; allowed_dofs <= 0b111111; ++allowed_dofs)


### PR DESCRIPTION
Fixes #2121.

**Problem**

`ContactConstraint::CalculateFrictionConstraintProperties` derives the two friction lever arms `r1` / `r2` from `friction_point`, the average of the per-contact midpoints `0.5 * (p1 + p2)` that the callers store in `ws_contacts`. For a speculative contact the two shapes are still separated by `δ > 0` when the constraint is built, so on a curved body the effective friction lever arm is `R + δ/2` instead of `R`. Every sliding speculative impact then injects a spurious angular impulse `ΔL = |J_t|·δ/2` at the contact point (closed form and measurements in #2121: +1.51 % of the contact-point angular momentum on the first impact of a bouncing sphere, steady rolling speed +1.52 % off `5/7·v0`, independent of `μ`, restitution and solver iterations).

**Why only the friction axes**

Translating the application point along the contact normal leaves the non-penetration Jacobian unchanged (`(r + α·n) × n = r × n`), but changes the friction Jacobians (`(r + α·n) × t = r × t + α·(n × t)`). So the non-penetration constraint keeps using the shared midpoint and stays bit-exact; only the two friction `AxisConstraintPart`s get their lever arms from each body's own averaged contact points. Frictionless scenes are therefore unaffected.

**Change**

- The two callers keep both `p1_ws` and `p2_ws` per contact instead of only their midpoint.
- `CalculateFrictionConstraintProperties` averages the body-1 points and the body-2 points separately for `r1` / `r2`; the midpoint of the two averages is still used for the determinism log and for `mDistanceToFrictionCenter` (a normal-plane distance, invariant under the translation).
- Angular friction and the non-penetration constraints are untouched.
- `EstimateCollisionResponse.cpp` (the standalone response estimator) is updated in the same way so that it keeps matching the solver; `EstimateCollisionResponseTests` passes with both sides changed.

**Effect (measured on v5.3.0 with the equivalent 4-line change; this PR ports it to master's refactored friction setup)**

| Observable | Before | After |
|---|---|---|
| ΔL/L₀ at the first sliding impact (three drop heights) | +1.513 % | −0.00027 % |
| Steady rolling speed vs `5/7·v0` | +1.52 % | 0.0 % |
| Contact begin/end counts on the same scene | 10 / 9 | 10 / 9 |
| Byte-identical regression baselines (5 recorded scenes) | — | 4 of 5 unchanged; only the rolling scene (μ > 0, off-normal lever arm) changes |

Master builds with the change with no new warnings, and the unit tests pass on my machine (MinGW-w64 GCC 16, Windows, Release) except `ComputeTests::TestComputeDX12`, which fails on this machine without the change as well (no DX12 / dxc available).

Happy to adjust the approach (e.g. a per-body friction point only for speculative contacts, or a different placement of the averaging) if you prefer.
